### PR TITLE
Add token usage tracking per response

### DIFF
--- a/backend/app/ai/client.py
+++ b/backend/app/ai/client.py
@@ -271,7 +271,7 @@ def get_model_name(model_id: str) -> str:
         },
         "openai/": {
             "chat-model": "gpt-4.1-mini",
-            "chat-model-reasoning": "o1-mini",
+            "chat-model-reasoning": "gpt-5-mini",
             "title-model": "gpt-4.1-mini",
             "artifact-model": "gpt-4.1-mini",
         },

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -6,9 +6,11 @@ import { useCopyToClipboard } from "usehooks-ts";
 import { apiFetch } from "@/lib/api-client";
 import type { Vote } from "@/lib/db/schema";
 import type { ChatMessage } from "@/lib/types";
+import type { AppUsage } from "@/lib/usage";
 import { Action, Actions } from "./elements/actions";
 import { CopyIcon, FeedbackIcon, PencilEditIcon, ThumbDownIcon, ThumbUpIcon } from "./icons";
 import { MessageFeedback } from "./message-feedback";
+import { MessageTokenUsage } from "./message-token-usage";
 
 export function PureMessageActions({
   chatId,
@@ -36,6 +38,15 @@ export function PureMessageActions({
     .map((part) => part.text)
     .join("\n")
     .trim();
+
+  // Extract usage data from message parts
+  // The data-usage event is stored in parts with structure: { type: "data-usage", data: {...} }
+  const usagePart = message.parts?.find(
+    (part) => part.type === "data-usage"
+  );
+  const usageData: AppUsage | undefined = usagePart
+    ? (usagePart as { type: string; data?: AppUsage }).data
+    : undefined;
 
   const handleCopy = async () => {
     if (!textFromParts) {
@@ -197,6 +208,10 @@ export function PureMessageActions({
             )}
           </div>
         </Action>
+
+        {usageData && (
+          <MessageTokenUsage usage={usageData} />
+        )}
       </Actions>
       <MessageFeedback
         chatId={chatId}

--- a/components/message-token-usage.tsx
+++ b/components/message-token-usage.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import type { AppUsage } from "@/lib/usage";
+import { cn } from "@/lib/utils";
+
+export type MessageTokenUsageProps = ComponentProps<"button"> & {
+  /** Usage data for this message */
+  usage?: AppUsage;
+};
+
+function InfoRow({
+  label,
+  tokens,
+  costText,
+}: {
+  label: string;
+  tokens?: number;
+  costText?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-2 font-mono">
+        <span className="min-w-[4ch] text-right">
+          {tokens === undefined ? "—" : tokens.toLocaleString()}
+        </span>
+        {costText !== undefined &&
+          costText !== null &&
+          !Number.isNaN(Number.parseFloat(costText)) && (
+            <span className="text-muted-foreground">
+              ${Number.parseFloat(costText).toFixed(6)}
+            </span>
+          )}
+      </div>
+    </div>
+  );
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    return `${(tokens / 1_000).toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
+export function MessageTokenUsage({
+  className,
+  usage,
+  ...props
+}: MessageTokenUsageProps) {
+  if (!usage || !usage.totalTokens) {
+    return null;
+  }
+
+  const totalTokens = usage.totalTokens ?? 0;
+  const displayText = formatTokenCount(totalTokens);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "inline-flex select-none items-center gap-1 rounded-md text-xs",
+            "cursor-pointer bg-background text-muted-foreground",
+            "outline-none ring-offset-background transition-colors",
+            "hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            className
+          )}
+          type="button"
+          {...props}
+        >
+          <span className="font-mono">{displayText}</span>
+          <span className="text-[10px] opacity-60">tokens</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-fit p-3" side="top">
+        <div className="min-w-[240px] space-y-2">
+          <div className="flex items-start justify-between text-sm">
+            <span className="font-medium">Token Usage</span>
+            <span className="text-muted-foreground font-mono">
+              {totalTokens.toLocaleString()}
+            </span>
+          </div>
+          <div className="mt-1 space-y-1">
+            {usage?.cachedInputTokens && usage.cachedInputTokens > 0 && (
+              <InfoRow
+                costText={usage?.costUSD?.cacheReadUSD?.toString()}
+                label="Cache Hits"
+                tokens={usage?.cachedInputTokens}
+              />
+            )}
+            <InfoRow
+              costText={usage?.costUSD?.inputUSD?.toString()}
+              label="Input"
+              tokens={usage?.inputTokens}
+            />
+            <InfoRow
+              costText={usage?.costUSD?.outputUSD?.toString()}
+              label="Output"
+              tokens={usage?.outputTokens}
+            />
+            <InfoRow
+              costText={usage?.costUSD?.reasoningUSD?.toString()}
+              label="Reasoning"
+              tokens={
+                usage?.reasoningTokens && usage.reasoningTokens > 0
+                  ? usage.reasoningTokens
+                  : undefined
+              }
+            />
+            {usage?.costUSD?.totalUSD !== undefined && (
+              <>
+                <Separator className="mt-1" />
+                <div className="flex items-center justify-between pt-1 text-xs">
+                  <span className="text-muted-foreground">Total cost</span>
+                  <div className="flex items-center gap-2 font-mono">
+                    <span className="min-w-[4ch] text-right" />
+                    <span>
+                      {Number.isNaN(
+                        Number.parseFloat(usage.costUSD.totalUSD.toString())
+                      )
+                        ? "—"
+                        : `$${Number.parseFloat(usage.costUSD.totalUSD.toString()).toFixed(6)}`}
+                    </span>
+                  </div>
+                </div>
+              </>
+            )}
+            {usage?.modelId && (
+              <>
+                <Separator className="mt-1" />
+                <div className="flex items-center justify-between pt-1 text-xs">
+                  <span className="text-muted-foreground">Model</span>
+                  <span className="font-mono text-muted-foreground">
+                    {usage.modelId}
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
This feature allows per-response tracking of usage for transparency and observability.

<img width="852" height="287" alt="image" src="https://github.com/user-attachments/assets/19a941ea-af22-4fd9-9ea9-684252a5fe91" />
