### PR TITLE
Patch/chat fixes 01 PCN, Chat Routing, Fix hallucinations of indicators

### DIFF
--- a/backend/app/ai/mcp_tools/_client.py
+++ b/backend/app/ai/mcp_tools/_client.py
@@ -10,7 +10,7 @@ from app.config import get_mcp_settings
 
 @cache
 def get_mcp_client(
-    transport: Literal["sse", "http"] = "sse",
+    transport: Literal["sse", "http"] = "http",
 ) -> Client[SSETransport | StreamableHttpTransport]:
     """Get a cached MCP client instance.
     TODO: Deprecate SSE transport.

--- a/backend/app/ai/mcp_tools/_client.py
+++ b/backend/app/ai/mcp_tools/_client.py
@@ -10,7 +10,7 @@ from app.config import get_mcp_settings
 
 @cache
 def get_mcp_client(
-    transport: Literal["sse", "http"] = "http",
+    transport: Literal["sse", "http"] = "sse",
 ) -> Client[SSETransport | StreamableHttpTransport]:
     """Get a cached MCP client instance.
     TODO: Deprecate SSE transport.

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -113,7 +113,7 @@ Data360 policy (STRICT):
 - **STRICT DATA INTEGRITY**:
   - If a requested country (`REF_AREA`) or year (`TIME_PERIOD`) is missing from the tool output, you MUST state "Data not available" for that specific entity.
   - **NEVER** guess, approximate, or reuse data from a different row (different `REF_AREA` or `TIME_PERIOD`).
-  - **NEVER** invent a claim ID or modify a value. The value in the `<claim>` tag MUST match the `OBS_VALUE` from the tool output. 
+  - **NEVER** invent a claim ID or modify a value. The value in the `<claim>` tag MUST match the `OBS_VALUE` from the tool output.
   - **NUMERIC VALUES**: Even if the tool returns a numeric value as a string (e.g., "1234.5"), you MUST report it in the `<claim>` tag **WITHOUT** quotes (e.g., <claim id="...">1234.5</claim>). DO NOT include the JSON quotes.
   - **VERIFICATION**: Cross-check that the `claim_id` you use actually belongs to the row for the correct `REF_AREA`.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -113,9 +113,9 @@ Data360 policy (STRICT):
 - **STRICT DATA INTEGRITY**:
   - If a requested country (`REF_AREA`) or year (`TIME_PERIOD`) is missing from the tool output, you MUST state "Data not available" for that specific entity.
   - **NEVER** guess, approximate, or reuse data from a different row (different `REF_AREA` or `TIME_PERIOD`).
-  - **NEVER** invent a claim ID or modify a value. The value in the `<claim>` tag MUST match the `OBS_VALUE` from the tool output.
+  - **NEVER** invent a claim ID. You MAY format the value (e.g. "1.2 million" for 1,203,000) if the PCN policy allows it, but the underlying data must remain accurate.
   - **NUMERIC VALUES**: Even if the tool returns a numeric value as a string (e.g., "1234.5"), you MUST report it in the `<claim>` tag **WITHOUT** quotes (e.g., <claim id="...">1234.5</claim>). DO NOT include the JSON quotes.
-  - **VERIFICATION**: Cross-check that the `claim_id` you use actually belongs to the row for the correct `REF_AREA`.
+  - **VERIFICATION**: Cross-check that the `claim_id` you use actually belongs to the row for the correct `REF_AREA` and/or `TIME_PERIOD`.
 
 General:
 - You MAY ask at most ONE clarifying question, only if required to complete tool calls correctly.
@@ -264,3 +264,26 @@ Do not update document right after creating it. Wait for user feedback or reques
         return base
 
     return (base + "\n\n" + artifacts_prompt).strip()
+
+
+def get_routing_system_prompt() -> str:
+    return """You are a high-speed intent router for a World Bank data assistant.
+Your job is to determine if the user's latest message requires specialized Data360 research or is just general conversation.
+
+CATEGORIES:
+1. RESEARCH: Choose this if the user asks for:
+   - Specific data, statistics, or indicators (GDP, population, spending, etc.)
+   - Comparisons between countries or regions.
+   - Charts, visualizations, or "last X years" of data.
+   - Anything requiring the World Bank / Data360 database.
+
+2. DIRECT: Choose this if the user is:
+   - Greeting you (Hello, Hi, Hey).
+   - Asking "How are you?" or other small talk.
+   - Asking a general follow-up that DOES NOT need new data (e.g. "Explain that last point," "What do you mean by X?").
+   - Complimenting or thanking you.
+
+OUTPUT FORMAT:
+Return ONLY a JSON object:
+{"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
+"""

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -89,22 +89,33 @@ def get_thinking_system_prompt() -> str:
 
 Your job:
 - Plan the steps necessary to complete the user's request. Explain what you are planning to do before doing any tools calls.
-- Use available tools for Data360, where necessary, to gather the minimum necessary facts. Do not user tools that are not related to Data360 here.
+- Use available tools for Data360, where necessary, to gather the minimum necessary facts. Do not use tools that are not related to Data360 here.
 - Produce a concise research packet that the chat agent will turn into the final response.
 - Do NOT write the final user-facing answer.
 
 Data360 policy (STRICT):
 - If the user's query is ambiguous (e.g. country name, indicator name, or time period unclear), use CLARIFYING QUESTION to ask one short, focused question before fetching data. Do not assume—clarify first.
 - If a country or region is specified, make sure to clarify if there's any ambiguity in the country or region name.
-- If the user asks for indicator data or statistics:
+- If the user asks for indicator data, statistics, OR visualization/charts:
   1) Search/identify relevant indicators FIRST.
   2) Choose the best indicator(s) and record their IDs + titles.
-  3) ONLY THEN fetch data for those indicator IDs.
-- Never fetch data if you have not selected indicator IDs.
-- If no suitable indicator is found, do not fetch data. Ask ONE targeted clarifying question.
+  3) ONLY THEN fetch data or generate visualization for those indicator IDs.
+- **CRITICAL**: When using `data360_get_data` or `data360_get_viz_spec`, use the **EXACT** `indicator_id` string returned by the search tool.
+- **VISUALIZATION JUDGMENT**: Before calling `data360_get_viz_spec`, assess the data coverage for the requested entities (e.g., from `data360_get_data` or search results).
+  - If any entity has sparse data (e.g. <3 data points) or significant gaps (e.g. one country has 10 years and another has only 1-2 years), you **MUST NOT** call the visualization tool.
+  - Instead, use CLARIFYING QUESTION to explain the gap: "Data for [Country X] is only available for [Years]. Do you still want to generate a comparison chart?"
+- Never fetch data or generate visualization if you have not selected indicator IDs.
+- If no suitable indicator is found, do not fetch data or generate visualization. Ask ONE targeted clarifying question.
 - When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag in the following format: `<claim id="claim_id" policy="policy">"value"</claim>`. For example, "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD". THIS IS MANDATORY.
 - Never invent a claim id. Always make sure that a claim id is in the data provided by the tools. Find this in the `claim_id` key of the tool output.
 - You may simplify the data provided by the tools to make it more readable using some policy, but you must always make sure that a claim id is in the generated text wrapped in a claim tag.
+
+- **STRICT DATA INTEGRITY**:
+  - If a requested country (`REF_AREA`) or year (`TIME_PERIOD`) is missing from the tool output, you MUST state "Data not available" for that specific entity.
+  - **NEVER** guess, approximate, or reuse data from a different row (different `REF_AREA` or `TIME_PERIOD`).
+  - **NEVER** invent a claim ID or modify a value. The value in the `<claim>` tag MUST match the `OBS_VALUE` from the tool output. 
+  - **NUMERIC VALUES**: Even if the tool returns a numeric value as a string (e.g., "1234.5"), you MUST report it in the `<claim>` tag **WITHOUT** quotes (e.g., <claim id="...">1234.5</claim>). DO NOT include the JSON quotes.
+  - **VERIFICATION**: Cross-check that the `claim_id` you use actually belongs to the row for the correct `REF_AREA`.
 
 General:
 - You MAY ask at most ONE clarifying question, only if required to complete tool calls correctly.
@@ -125,6 +136,8 @@ Output format (MUST follow exactly):
   - Any caveats, missing coverage, or quality flags.
   - If coverage is limited (e.g. missing countries, years, or breakdowns), list them in one bullet so the writer can surface them.
   - If comparing series that differ in time coverage, methodology, or definitions, note this in the research packet so the writer can add a comparability warning.
+- Visualization (if any):
+  - If you called `data360_get_viz_spec`, provide the EXACT URL from the tool output here.
 - Recommended response plan (for chat agent):
   - <1-3 bullets on how to present findings>
   - When presenting data, suggest the writer end with 2–3 suggested follow-up questions phrased as questions the user would ask (e.g. "What is X for country Y?"), not as the assistant offering (e.g. not "Would you like me to…").
@@ -166,6 +179,7 @@ ROLE:
 - You are the WRITER. Another step (planner/thinking) is responsible for using tools (including Data360) and for retrieving indicator IDs and data.
 - Do NOT use Data360 tools or attempt indicator discovery/fetching yourself, even if tools are available.
 - Use the research/tool results provided to you as the source of truth.
+- **VISUALIZATION**: If the research packet includes a Visualization URL, you **MUST** present it clearly as a markdown link (e.g., [View Chart](URL)). Do NOT apologize or claim you cannot generate links; you are a data-driven assistant and these links are part of your core capability.
 
 IF INFORMATION IS MISSING:
 - If the provided research results are insufficient to answer, ask at most ONE targeted clarifying question.

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -1,0 +1,65 @@
+import logging
+import json
+from typing import Any, Dict, List, Literal
+from app.ai.client import get_async_ai_client
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+async def check_intent(messages: List[Dict[str, Any]]) -> Literal["RESEARCH", "DIRECT"]:
+    """
+    Analyzes the user's latest message and conversation context to determine
+    if it requires the Research Planner (Data360 tools) or can be handled
+    via Direct Chat (Fast-Path).
+    """
+    
+    # We use gpt-4o-mini for fast routing
+    client = get_async_ai_client()
+    
+    system_prompt = """You are a high-speed intent router for a World Bank data assistant.
+Your job is to determine if the user's latest message requires specialized Data360 research or is just general conversation.
+
+CATEGORIES:
+1. RESEARCH: Choose this if the user asks for:
+   - Specific data, statistics, or indicators (GDP, population, spending, etc.)
+   - Comparisons between countries or regions.
+   - Charts, visualizations, or "last X years" of data.
+   - Anything requiring the World Bank / Data360 database.
+
+2. DIRECT: Choose this if the user is:
+   - Greeting you (Hello, Hi, Hey).
+   - Asking "How are you?" or other small talk.
+   - Asking a general follow-up that DOES NOT need new data (e.g. "Explain that last point," "What do you mean by X?").
+   - Complimenting or thanking you.
+
+OUTPUT FORMAT:
+Return ONLY a JSON object: 
+{"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
+"""
+
+    try:
+        # We only need the last few messages for intent
+        recent_history = messages[-3:] if len(messages) > 3 else messages
+        
+        response = await client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                *recent_history
+            ],
+            response_format={"type": "json_object"},
+            temperature=0,
+            max_tokens=50,
+            stream=False
+        )
+        
+        result = json.loads(response.choices[0].message.content)
+        intent = result.get("intent", "RESEARCH")
+        reasoning = result.get("reasoning", "")
+        
+        logger.info("Intent Routing: %s (Reason: %s)", intent, reasoning)
+        return intent
+
+    except Exception as e:
+        logger.error("Error in intent routing: %s. Defaulting to RESEARCH.", str(e))
+        return "RESEARCH"

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -1,10 +1,11 @@
-import logging
 import json
+import logging
 from typing import Any, Dict, List, Literal
+
 from app.ai.client import get_async_ai_client
-from app.config import settings
 
 logger = logging.getLogger(__name__)
+
 
 async def check_intent(messages: List[Dict[str, Any]]) -> Literal["RESEARCH", "DIRECT"]:
     """
@@ -12,10 +13,10 @@ async def check_intent(messages: List[Dict[str, Any]]) -> Literal["RESEARCH", "D
     if it requires the Research Planner (Data360 tools) or can be handled
     via Direct Chat (Fast-Path).
     """
-    
+
     # We use gpt-4o-mini for fast routing
     client = get_async_ai_client()
-    
+
     system_prompt = """You are a high-speed intent router for a World Bank data assistant.
 Your job is to determine if the user's latest message requires specialized Data360 research or is just general conversation.
 
@@ -33,30 +34,27 @@ CATEGORIES:
    - Complimenting or thanking you.
 
 OUTPUT FORMAT:
-Return ONLY a JSON object: 
+Return ONLY a JSON object:
 {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
 """
 
     try:
         # We only need the last few messages for intent
         recent_history = messages[-3:] if len(messages) > 3 else messages
-        
+
         response = await client.chat.completions.create(
             model="gpt-4o-mini",
-            messages=[
-                {"role": "system", "content": system_prompt},
-                *recent_history
-            ],
+            messages=[{"role": "system", "content": system_prompt}, *recent_history],
             response_format={"type": "json_object"},
             temperature=0,
             max_tokens=50,
-            stream=False
+            stream=False,
         )
-        
+
         result = json.loads(response.choices[0].message.content)
         intent = result.get("intent", "RESEARCH")
         reasoning = result.get("reasoning", "")
-        
+
         logger.info("Intent Routing: %s (Reason: %s)", intent, reasoning)
         return intent
 

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -3,11 +3,14 @@ import logging
 from typing import Any, Dict, List, Literal
 
 from app.ai.client import get_async_ai_client
+from app.ai.prompts import get_routing_system_prompt
+
+from app.config import IntentType, settings
 
 logger = logging.getLogger(__name__)
 
 
-async def check_intent(messages: List[Dict[str, Any]]) -> Literal["RESEARCH", "DIRECT"]:
+async def check_intent(messages: List[Dict[str, Any]]) -> IntentType:
     """
     Analyzes the user's latest message and conversation context to determine
     if it requires the Research Planner (Data360 tools) or can be handled
@@ -17,33 +20,18 @@ async def check_intent(messages: List[Dict[str, Any]]) -> Literal["RESEARCH", "D
     # We use gpt-4o-mini for fast routing
     client = get_async_ai_client()
 
-    system_prompt = """You are a high-speed intent router for a World Bank data assistant.
-Your job is to determine if the user's latest message requires specialized Data360 research or is just general conversation.
-
-CATEGORIES:
-1. RESEARCH: Choose this if the user asks for:
-   - Specific data, statistics, or indicators (GDP, population, spending, etc.)
-   - Comparisons between countries or regions.
-   - Charts, visualizations, or "last X years" of data.
-   - Anything requiring the World Bank / Data360 database.
-
-2. DIRECT: Choose this if the user is:
-   - Greeting you (Hello, Hi, Hey).
-   - Asking "How are you?" or other small talk.
-   - Asking a general follow-up that DOES NOT need new data (e.g. "Explain that last point," "What do you mean by X?").
-   - Complimenting or thanking you.
-
-OUTPUT FORMAT:
-Return ONLY a JSON object:
-{"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
-"""
+    system_prompt = get_routing_system_prompt()
 
     try:
         # We only need the last few messages for intent
-        recent_history = messages[-3:] if len(messages) > 3 else messages
+        limit = settings.ROUTING_HISTORY_LIMIT
+        if len(messages) > limit:
+            recent_history = messages[-limit:]
+        else:
+            recent_history = messages
 
         response = await client.chat.completions.create(
-            model="gpt-4o-mini",
+            model=settings.ROUTING_MODEL,
             messages=[{"role": "system", "content": system_prompt}, *recent_history],
             response_format={"type": "json_object"},
             temperature=0,
@@ -52,7 +40,7 @@ Return ONLY a JSON object:
         )
 
         result = json.loads(response.choices[0].message.content)
-        intent = result.get("intent", "RESEARCH")
+        intent = IntentType(result.get("intent", IntentType.RESEARCH))
         reasoning = result.get("reasoning", "")
 
         logger.info("Intent Routing: %s (Reason: %s)", intent, reasoning)
@@ -60,4 +48,4 @@ Return ONLY a JSON object:
 
     except Exception as e:
         logger.error("Error in intent routing: %s. Defaulting to RESEARCH.", str(e))
-        return "RESEARCH"
+        return IntentType.RESEARCH

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -99,6 +99,22 @@ async def get_current_user(
                         logger.debug("Could not check password_changed_at: %s", e)
                         pass
 
+
+            # Verify user actually exists in the database (crucial for dev envs where DB is reset)
+            try:
+                user_uuid = UUID(user_id)
+                user = await get_user_by_id(db, user_uuid)
+                if not user:
+                    logger.warning(
+                        "Token valid but user not found in DB (DB reset?): user_id=%s", user_id
+                    )
+                    payload = None  # Invalidate token
+            except Exception as e:
+                logger.error("Error verifying user existence: %s", e)
+                # Fail safe? Or continue?
+                # safer to invalidate if we can't check
+                pass
+
             if payload is not None:
                 return {"id": user_id, "type": payload.get("type", "regular")}
         # Token expired or invalid - fall through to guest session check

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -99,7 +99,6 @@ async def get_current_user(
                         logger.debug("Could not check password_changed_at: %s", e)
                         pass
 
-
             # Verify user actually exists in the database (crucial for dev envs where DB is reset)
             try:
                 user_uuid = UUID(user_id)

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -14,6 +14,7 @@ from app.ai.client import get_ai_client, get_async_ai_client, get_model_name
 from app.ai.observability.token_usage import DataUsageData
 from app.ai.prompts import get_system_prompt, get_thinking_system_prompt
 from app.ai.protocols.stream import MessageStartPart
+from app.ai.routing import check_intent
 from app.api.deps import get_current_user, get_optional_user
 from app.api.v1.utils.background_tasks import (
     create_save_messages_task,
@@ -215,7 +216,8 @@ async def create_chat(
             }
             for msg in messages_from_db
         ]
-        logger.info("messages_from_db: %s", json.dumps(messages_from_db, indent=4))
+        logger.info("Fetched %d messages from DB for chat_id: %s", len(messages_from_db), request.id)
+        logger.debug("messages_from_db: %s", json.dumps(messages_from_db, indent=4))
 
     else:
         # Create new chat - generate title from user message
@@ -303,8 +305,13 @@ async def create_chat(
     tool_set = await prepare_tools(user_id, db)
     # logger.info("tool_set: %s", json.dumps(tool_set, indent=4))
 
-    # use_thinking = False
-    use_thinking = True
+    # Determine intent (Fast-Path vs Research Path)
+    intent = await check_intent(openai_messages)
+    use_thinking = (intent == "RESEARCH")
+    
+    if not use_thinking:
+        logger.info("Fast-path: Skipping Research Planner for DIRECT intent.")
+    
     # Create stream processor
     thinking_processor = StreamEventProcessor(request.id, mode="thinking")
     chat_processor = StreamEventProcessor(request.id, mode="chat")

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -16,6 +16,7 @@ from app.ai.prompts import get_system_prompt, get_thinking_system_prompt
 from app.ai.protocols.stream import MessageStartPart
 from app.ai.routing import check_intent
 from app.api.deps import get_current_user, get_optional_user
+from app.config import IntentType, ModelType
 from app.api.v1.utils.background_tasks import (
     create_save_messages_task,
     create_update_context_task,
@@ -309,7 +310,7 @@ async def create_chat(
 
     # Determine intent (Fast-Path vs Research Path)
     intent = await check_intent(openai_messages)
-    use_thinking = intent == "RESEARCH"
+    use_thinking = intent == IntentType.RESEARCH
 
     if not use_thinking:
         logger.info("Fast-path: Skipping Research Planner for DIRECT intent.")

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -216,7 +216,9 @@ async def create_chat(
             }
             for msg in messages_from_db
         ]
-        logger.info("Fetched %d messages from DB for chat_id: %s", len(messages_from_db), request.id)
+        logger.info(
+            "Fetched %d messages from DB for chat_id: %s", len(messages_from_db), request.id
+        )
         logger.debug("messages_from_db: %s", json.dumps(messages_from_db, indent=4))
 
     else:
@@ -307,11 +309,11 @@ async def create_chat(
 
     # Determine intent (Fast-Path vs Research Path)
     intent = await check_intent(openai_messages)
-    use_thinking = (intent == "RESEARCH")
-    
+    use_thinking = intent == "RESEARCH"
+
     if not use_thinking:
         logger.info("Fast-path: Skipping Research Planner for DIRECT intent.")
-    
+
     # Create stream processor
     thinking_processor = StreamEventProcessor(request.id, mode="thinking")
     chat_processor = StreamEventProcessor(request.id, mode="chat")

--- a/backend/app/api/v1/utils/tool_setup.py
+++ b/backend/app/api/v1/utils/tool_setup.py
@@ -51,10 +51,7 @@ async def create_tool_wrappers(user_id: UUID, db: AsyncSession) -> Dict[str, Dic
         )
 
     return {
-        "getWeather": {
-            "function": get_weather_wrapper,
-            "type": "tool",
-        },
+
         "createDocument": {
             "function": create_document_wrapper,
             "type": "tool",
@@ -76,7 +73,6 @@ async def prepare_tools(
     tool_set = {
         "local": {
             "tool_definitions": [
-                GET_WEATHER_TOOL_DEFINITION,
                 CREATE_DOCUMENT_TOOL_DEFINITION,
                 UPDATE_DOCUMENT_TOOL_DEFINITION,
             ],
@@ -97,7 +93,8 @@ async def prepare_tools(
                 "type": "mcp",
             }
             tool_set["mcp"]["tool_definitions"].append(tool)
-        logger.info("Successfully loaded %d MCP tools", len(mcp_tools))
+        tool_names = [t["function"]["name"] for t in mcp_tools]
+        logger.info("Successfully loaded %d MCP tools: %s", len(mcp_tools), tool_names)
     except Exception as e:
         logger.warning(
             "Failed to load MCP tools (continuing without them): %s",

--- a/backend/app/api/v1/utils/tool_setup.py
+++ b/backend/app/api/v1/utils/tool_setup.py
@@ -11,7 +11,6 @@ from app.ai.tools import (
     CREATE_DOCUMENT_TOOL_DEFINITION,
     UPDATE_DOCUMENT_TOOL_DEFINITION,
     create_document_tool,
-    get_weather,
     update_document_tool,
 )
 
@@ -23,11 +22,6 @@ async def create_tool_wrappers(user_id: UUID, db: AsyncSession) -> Dict[str, Dic
     Create async tool wrappers for OpenAI tools.
     These wrappers handle the _sse_writer parameter and pass user_id/db_session.
     """
-
-    async def get_weather_wrapper(**kwargs):
-        # Remove _sse_writer if present (weather doesn't need it)
-        kwargs.pop("_sse_writer", None)
-        return await get_weather(**kwargs)
 
     async def create_document_wrapper(**kwargs):
         sse_writer = kwargs.pop("_sse_writer", None)

--- a/backend/app/api/v1/utils/tool_setup.py
+++ b/backend/app/api/v1/utils/tool_setup.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.ai.mcp_tools.data360_mcp import get_mcp_tools
 from app.ai.tools import (
     CREATE_DOCUMENT_TOOL_DEFINITION,
-    GET_WEATHER_TOOL_DEFINITION,
     UPDATE_DOCUMENT_TOOL_DEFINITION,
     create_document_tool,
     get_weather,
@@ -51,7 +50,6 @@ async def create_tool_wrappers(user_id: UUID, db: AsyncSession) -> Dict[str, Dic
         )
 
     return {
-
         "createDocument": {
             "function": create_document_wrapper,
             "type": "tool",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,13 @@ class ModelType(str, Enum):
     ARTIFACT_MODEL = "artifact-model"
 
 
+class IntentType(str, Enum):
+    """Enum for chat intent types."""
+
+    RESEARCH = "RESEARCH"
+    DIRECT = "DIRECT"
+
+
 class ModelSettings(BaseSettings):
     MODEL_PROVIDER: str = "azure/"
     CHAT_MODEL: str = "gpt-4o-mini"
@@ -85,6 +92,10 @@ class Settings(BaseSettings):
 
     # AI Model Configuration - can be overridden via environment variables
     models: ModelSettings = ModelSettings()
+
+    # Routing Configuration
+    ROUTING_MODEL: str = "gpt-4o-mini"
+    ROUTING_HISTORY_LIMIT: int = 3
 
     # App
     ENVIRONMENT: str = "development"

--- a/backend/app/utils/message_converter.py
+++ b/backend/app/utils/message_converter.py
@@ -40,58 +40,74 @@ async def convert_messages_to_openai_format(
                     is_image = media_type.startswith("image/")
                     is_pdf = media_type == "application/pdf"
                     file_id = extract_file_id_from_url(file_url)
-                    
+
                     if file_id:
                         base64_data = await get_file_base64(file_id, db)
                         if base64_data:
                             if is_pdf:
-                                content.append({"type": "file", "file": {"filename": file_name, "file_data": base64_data}})
+                                content.append(
+                                    {
+                                        "type": "file",
+                                        "file": {"filename": file_name, "file_data": base64_data},
+                                    }
+                                )
                             elif is_image:
-                                content.append({"type": "image_url", "image_url": {"url": base64_data}})
+                                content.append(
+                                    {"type": "image_url", "image_url": {"url": base64_data}}
+                                )
                             else:
-                                content.append({"type": "file", "file": {"filename": file_name, "file_data": base64_data}})
+                                content.append(
+                                    {
+                                        "type": "file",
+                                        "file": {"filename": file_name, "file_data": base64_data},
+                                    }
+                                )
                         else:
                             parsed = urlparse(file_url)
                             if not (parsed.scheme and parsed.netloc):
                                 file_url = urljoin(settings.NEXTJS_URL.rstrip("/"), file_url)
                             if is_image:
-                                content.append({"type": "image_url", "image_url": {"url": file_url}})
+                                content.append(
+                                    {"type": "image_url", "image_url": {"url": file_url}}
+                                )
                     else:
                         parsed = urlparse(file_url)
                         if not (parsed.scheme and parsed.netloc):
                             file_url = urljoin(settings.NEXTJS_URL.rstrip("/"), file_url)
                         if is_image:
                             content.append({"type": "image_url", "image_url": {"url": file_url}})
-            
+
             if content:
                 openai_messages.append({"role": "user", "content": content})
 
         elif role == "assistant":
             # Assistant messages can be complex, containing thinking text, tool calls, and final responses.
             # We expand them into: [Assistant(tool_calls), Tool(result), Assistant(text), ...]
-            
+
             pending_tool_calls = []
             pending_tool_results = []
             current_text_content = []
 
             for part in parts:
                 part_type = part.get("type")
-                
+
                 if part_type == "text":
                     # If we have tool calls pending, we MUST flush them before text
                     if pending_tool_calls:
-                        openai_messages.append({
-                            "role": "assistant",
-                            "content": current_text_content if current_text_content else None,
-                            "tool_calls": pending_tool_calls
-                        })
+                        openai_messages.append(
+                            {
+                                "role": "assistant",
+                                "content": current_text_content if current_text_content else None,
+                                "tool_calls": pending_tool_calls,
+                            }
+                        )
                         pending_tool_calls = []
                         current_text_content = []
                         # Flush tool results immediately after assistant call
                         for res in pending_tool_results:
                             openai_messages.append(res)
                         pending_tool_results = []
-                    
+
                     text = part.get("text", "")
                     if text:
                         current_text_content.append({"type": "text", "text": text})
@@ -103,24 +119,28 @@ async def convert_messages_to_openai_format(
                         tool_call_id = data["toolCallId"]
                         tool_name = data.get("type", "").replace("tool-", "")
                         tool_input = data.get("input", {})
-                        
-                        pending_tool_calls.append({
-                            "id": tool_call_id,
-                            "type": "function",
-                            "function": {
-                                "name": tool_name,
-                                "arguments": json.dumps(tool_input)
+
+                        pending_tool_calls.append(
+                            {
+                                "id": tool_call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": tool_name,
+                                    "arguments": json.dumps(tool_input),
+                                },
                             }
-                        })
-                        
+                        )
+
                         # Add any available output as a pending tool result
                         if "output" in data:
-                            pending_tool_results.append({
-                                "role": "tool",
-                                "tool_call_id": tool_call_id,
-                                "content": json.dumps(data["output"])
-                            })
-                    
+                            pending_tool_results.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": tool_call_id,
+                                    "content": json.dumps(data["output"]),
+                                }
+                            )
+
                     # Also extract thinking text if present
                     elif data.get("type") == "text":
                         text = data.get("text", "")
@@ -129,23 +149,22 @@ async def convert_messages_to_openai_format(
 
             # Final flush of tool calls if any
             if pending_tool_calls:
-                openai_messages.append({
-                    "role": "assistant",
-                    "content": current_text_content if current_text_content else None,
-                    "tool_calls": pending_tool_calls
-                })
+                openai_messages.append(
+                    {
+                        "role": "assistant",
+                        "content": current_text_content if current_text_content else None,
+                        "tool_calls": pending_tool_calls,
+                    }
+                )
                 # Flush tool results
                 for res in pending_tool_results:
                     openai_messages.append(res)
                 # Reset
                 current_text_content = []
-            
+
             # Final assistant text part
             if current_text_content:
-                openai_messages.append({
-                    "role": "assistant",
-                    "content": current_text_content
-                })
+                openai_messages.append({"role": "assistant", "content": current_text_content})
 
         elif role == "tool":
             # Although the DB merges them into assistant messages, we should still handle
@@ -158,17 +177,21 @@ async def convert_messages_to_openai_format(
                         tool_content += part.get("text", "")
                     elif part.get("type") == "tool-result":
                         tool_content = json.dumps(part.get("result", {}))
-            
-            openai_messages.append({
-                "role": "tool",
-                "tool_call_id": tool_call_id,
-                "content": tool_content
-            })
+
+            openai_messages.append(
+                {"role": "tool", "tool_call_id": tool_call_id, "content": tool_content}
+            )
 
     logger.info("Converted %d messages to OpenAI format", len(openai_messages))
     # Log a simplified version for debugging
     for i, m in enumerate(openai_messages):
         content_preview = str(m.get("content"))[:200] + "..." if m.get("content") else "No content"
-        logger.debug("Msg %d: role=%s, content=%s, tool_calls=%s", i, m['role'], content_preview, "Yes" if m.get("tool_calls") else "No")
-    
+        logger.debug(
+            "Msg %d: role=%s, content=%s, tool_calls=%s",
+            i,
+            m["role"],
+            content_preview,
+            "Yes" if m.get("tool_calls") else "No",
+        )
+
     return openai_messages

--- a/backend/app/utils/message_converter.py
+++ b/backend/app/utils/message_converter.py
@@ -1,5 +1,4 @@
-"""Convert messages from database format to OpenAI format."""
-
+import json
 import logging
 from typing import Any, Dict, List
 from urllib.parse import urljoin, urlparse
@@ -17,8 +16,8 @@ async def convert_messages_to_openai_format(
 ) -> List[Dict[str, Any]]:
     """
     Convert messages from database format to OpenAI format.
-    Handles both text and file parts.
-    For files stored in our database, uses base64-encoded data instead of URLs.
+    Handles both text and file parts, and expands multi-part assistant messages
+    (which may contain tool calls and results) into sequential OpenAI turns.
     """
     openai_messages = []
 
@@ -26,106 +25,150 @@ async def convert_messages_to_openai_format(
         role = msg["role"]
         parts = msg.get("parts", [])
 
-        # Build content array for OpenAI format
-        content = []
-        for part in parts:
-            if part.get("type") == "text":
-                content.append({"type": "text", "text": part.get("text", "")})
-            elif part.get("type") == "file":
-                file_url = part.get("url", "")
-                file_name = part.get("name", "file")
-                media_type = part.get("mediaType") or part.get(
-                    "contentType", "application/octet-stream"
-                )
-
-                # Determine if this is an image or PDF based on media type
-                is_image = media_type.startswith("image/")
-                is_pdf = media_type == "application/pdf"
-
-                # Try to extract file ID from URL (our database files)
-                file_id = extract_file_id_from_url(file_url)
-                if file_id:
-                    # File is in our database - use base64 encoding
-                    base64_data = await get_file_base64(file_id, db)
-                    if base64_data:
-                        if is_pdf:
-                            # Use file format for PDFs
-                            content.append(
-                                {
-                                    "type": "file",
-                                    "file": {
-                                        "filename": file_name,
-                                        "file_data": base64_data,
-                                    },
-                                }
-                            )
-                        elif is_image:
-                            # Use image_url format for images (JPEG, PNG, etc.)
-                            content.append(
-                                {
-                                    "type": "image_url",
-                                    "image_url": {"url": base64_data},
-                                }
-                            )
+        if role == "user":
+            content = []
+            for part in parts:
+                if part.get("type") == "text":
+                    content.append({"type": "text", "text": part.get("text", "")})
+                elif part.get("type") == "file":
+                    # Handle files (same as before)
+                    file_url = part.get("url", "")
+                    file_name = part.get("name", "file")
+                    media_type = part.get("mediaType") or part.get(
+                        "contentType", "application/octet-stream"
+                    )
+                    is_image = media_type.startswith("image/")
+                    is_pdf = media_type == "application/pdf"
+                    file_id = extract_file_id_from_url(file_url)
+                    
+                    if file_id:
+                        base64_data = await get_file_base64(file_id, db)
+                        if base64_data:
+                            if is_pdf:
+                                content.append({"type": "file", "file": {"filename": file_name, "file_data": base64_data}})
+                            elif is_image:
+                                content.append({"type": "image_url", "image_url": {"url": base64_data}})
+                            else:
+                                content.append({"type": "file", "file": {"filename": file_name, "file_data": base64_data}})
                         else:
-                            # Unknown type - default to file format
-                            logger.warning("Unknown media type %s, using file format", media_type)
-                            content.append(
-                                {
-                                    "type": "file",
-                                    "file": {
-                                        "filename": file_name,
-                                        "file_data": base64_data,
-                                    },
-                                }
-                            )
+                            parsed = urlparse(file_url)
+                            if not (parsed.scheme and parsed.netloc):
+                                file_url = urljoin(settings.NEXTJS_URL.rstrip("/"), file_url)
+                            if is_image:
+                                content.append({"type": "image_url", "image_url": {"url": file_url}})
                     else:
-                        # Fallback to URL if file not found in database
-                        logger.warning("File not found, falling back to URL: %s", file_url)
-                        # Convert relative URL to absolute URL as fallback
                         parsed = urlparse(file_url)
                         if not (parsed.scheme and parsed.netloc):
-                            base_url = settings.NEXTJS_URL.rstrip("/")
-                            file_url = urljoin(base_url, file_url)
-                        # Use appropriate format based on media type
+                            file_url = urljoin(settings.NEXTJS_URL.rstrip("/"), file_url)
                         if is_image:
-                            content.append(
-                                {
-                                    "type": "image_url",
-                                    "image_url": {"url": file_url},
-                                }
-                            )
-                        else:
-                            # For non-images, we can't use URL format with OpenAI
-                            # This shouldn't happen if file is in our database
-                            logger.error("Cannot use URL format for non-image file: %s", media_type)
-                else:
-                    # External URL - use appropriate format based on media type
-                    parsed = urlparse(file_url)
-                    if not (parsed.scheme and parsed.netloc):
-                        base_url = settings.NEXTJS_URL.rstrip("/")
-                        file_url = urljoin(base_url, file_url)
-                    if is_image:
-                        content.append(
-                            {
-                                "type": "image_url",
-                                "image_url": {"url": file_url},
+                            content.append({"type": "image_url", "image_url": {"url": file_url}})
+            
+            if content:
+                openai_messages.append({"role": "user", "content": content})
+
+        elif role == "assistant":
+            # Assistant messages can be complex, containing thinking text, tool calls, and final responses.
+            # We expand them into: [Assistant(tool_calls), Tool(result), Assistant(text), ...]
+            
+            pending_tool_calls = []
+            pending_tool_results = []
+            current_text_content = []
+
+            for part in parts:
+                part_type = part.get("type")
+                
+                if part_type == "text":
+                    # If we have tool calls pending, we MUST flush them before text
+                    if pending_tool_calls:
+                        openai_messages.append({
+                            "role": "assistant",
+                            "content": current_text_content if current_text_content else None,
+                            "tool_calls": pending_tool_calls
+                        })
+                        pending_tool_calls = []
+                        current_text_content = []
+                        # Flush tool results immediately after assistant call
+                        for res in pending_tool_results:
+                            openai_messages.append(res)
+                        pending_tool_results = []
+                    
+                    text = part.get("text", "")
+                    if text:
+                        current_text_content.append({"type": "text", "text": text})
+
+                elif part_type == "data-thinking":
+                    data = part.get("data", {})
+                    # Check for tool call in data-thinking part
+                    if "toolCallId" in data:
+                        tool_call_id = data["toolCallId"]
+                        tool_name = data.get("type", "").replace("tool-", "")
+                        tool_input = data.get("input", {})
+                        
+                        pending_tool_calls.append({
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": json.dumps(tool_input)
                             }
-                        )
-                    else:
-                        # For external non-image files, we can't use URL format
-                        logger.warning(
-                            "External non-image file URL not supported: %s (%s)",
-                            file_url,
-                            media_type,
-                        )
+                        })
+                        
+                        # Add any available output as a pending tool result
+                        if "output" in data:
+                            pending_tool_results.append({
+                                "role": "tool",
+                                "tool_call_id": tool_call_id,
+                                "content": json.dumps(data["output"])
+                            })
+                    
+                    # Also extract thinking text if present
+                    elif data.get("type") == "text":
+                        text = data.get("text", "")
+                        if text:
+                            current_text_content.append({"type": "text", "text": text})
 
-        if content:
-            openai_messages.append(
-                {
-                    "role": role,
-                    "content": content,
-                }
-            )
+            # Final flush of tool calls if any
+            if pending_tool_calls:
+                openai_messages.append({
+                    "role": "assistant",
+                    "content": current_text_content if current_text_content else None,
+                    "tool_calls": pending_tool_calls
+                })
+                # Flush tool results
+                for res in pending_tool_results:
+                    openai_messages.append(res)
+                # Reset
+                current_text_content = []
+            
+            # Final assistant text part
+            if current_text_content:
+                openai_messages.append({
+                    "role": "assistant",
+                    "content": current_text_content
+                })
 
+        elif role == "tool":
+            # Although the DB merges them into assistant messages, we should still handle
+            # explicit tool messages if they ever appear.
+            tool_call_id = msg.get("tool_call_id")
+            tool_content = msg.get("content", "")
+            if not tool_content:
+                for part in parts:
+                    if part.get("type") == "text":
+                        tool_content += part.get("text", "")
+                    elif part.get("type") == "tool-result":
+                        tool_content = json.dumps(part.get("result", {}))
+            
+            openai_messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": tool_content
+            })
+
+    logger.info("Converted %d messages to OpenAI format", len(openai_messages))
+    # Log a simplified version for debugging
+    for i, m in enumerate(openai_messages):
+        content_preview = str(m.get("content"))[:200] + "..." if m.get("content") else "No content"
+        logger.debug("Msg %d: role=%s, content=%s, tool_calls=%s", i, m['role'], content_preview, "Yes" if m.get("tool_calls") else "No")
+    
     return openai_messages

--- a/backend/app/utils/stream.py
+++ b/backend/app/utils/stream.py
@@ -148,8 +148,17 @@ async def execute_tool_with_streaming(
             event = tool_sse_events.popleft()
             yield ("event", event)
 
+        # Log tool input
+        logger.info(">>> Tool Call [%s]: %s", tool_name, json.dumps(parsed_arguments))
+
         # Get tool result
         tool_result = await tool_task
+        
+        # Log tool output (truncated for readability)
+        res_str = json.dumps(tool_result)
+        truncated_res = (res_str[:2000] + '...') if len(res_str) > 2000 else res_str
+        logger.info("<<< Tool Output [%s]: %s", tool_name, truncated_res)
+
         yield ("result", tool_result)
 
     except asyncio.CancelledError:
@@ -173,12 +182,14 @@ async def execute_tool_with_streaming(
 
     except Exception as error:
         tbck = traceback.format_exc()
+        error_text = str(error) + "\n" + tbck
+        logger.error("!!! Tool Error [%s]: %s", tool_name, error_text)
         # Tool execution failed
         tool_error = {
             "type": "tool-error",
             "toolCallId": tool_call_id,
             "toolName": tool_name,
-            "errorText": str(error) + "\n" + tbck,
+            "errorText": error_text,
         }
         yield ("error", tool_error)
         raise

--- a/backend/app/utils/stream.py
+++ b/backend/app/utils/stream.py
@@ -149,7 +149,7 @@ async def execute_tool_with_streaming(
             yield ("event", event)
 
         # Log tool input
-        logger.info(">>> Tool Call [%s]: %s", tool_name, json.dumps(parsed_arguments))
+        logger.debug(">>> Tool Call [%s]: %s", tool_name, json.dumps(parsed_arguments))
 
         # Get tool result
         tool_result = await tool_task
@@ -157,7 +157,7 @@ async def execute_tool_with_streaming(
         # Log tool output (truncated for readability)
         res_str = json.dumps(tool_result)
         truncated_res = (res_str[:2000] + "...") if len(res_str) > 2000 else res_str
-        logger.info("<<< Tool Output [%s]: %s", tool_name, truncated_res)
+        logger.debug("<<< Tool Output [%s]: %s", tool_name, truncated_res)
 
         yield ("result", tool_result)
 
@@ -395,14 +395,14 @@ async def stream_text(
             # Insert system message at the beginning
             conversation_messages.insert(0, {"role": "system", "content": system})
 
-        logger.info("Conversation messages: %s", conversation_messages)
+        logger.debug("Conversation messages: %s", conversation_messages)
 
         # Track cumulative usage across all turns
         total_usage_data = None
 
         # Multi-turn tool calling loop
         for turn in range(max_tool_turns):
-            logger.info("=== Tool turn %d/%d ===", turn + 1, max_tool_turns)
+            logger.debug("=== Tool turn %d/%d ===", turn + 1, max_tool_turns)
 
             thinking_id = f"msg-{turn}" if mode == "thinking" else ""
             text_stream_id = "text-1"
@@ -425,21 +425,21 @@ async def stream_text(
             )
 
             # TODO: Clean up this logging and exception handling for debugging purposes
-            logger.info("About to call client.chat.completions.create with mode=%s", mode)
+            logger.debug("About to call client.chat.completions.create with mode=%s", mode)
             try:
                 stream = await client.chat.completions.create(**chat_input)
-                logger.info("Successfully created stream, type: %s", type(stream))
+                logger.debug("Successfully created stream, type: %s", type(stream))
             except Exception as e:
                 logger.error("Exception during stream creation: %s", e, exc_info=True)
                 raise
-            logger.info("Successfully created stream, type: %s", type(stream))
+            logger.debug("Successfully created stream, type: %s", type(stream))
 
             yield part_to_sse(StartStepPart(), mode=mode, thinking_id=thinking_id)
             if mode == "thinking":
                 yield DataPart(type="data-stage", data={"stage": "interpreting"}).to_sse()
 
             # Process stream chunks
-            logger.info("Starting to iterate over stream chunks...")
+            logger.debug("Starting to iterate over stream chunks...")
             chunk_count = 0
             try:
                 # Iterate over stream chunks using async iteration
@@ -449,7 +449,7 @@ async def stream_text(
                     await asyncio.sleep(stream_yield_delay)
                     chunk_count += 1
                     if chunk_count == 1:
-                        logger.info("First chunk received in turn %d", turn + 1)
+                        logger.debug("First chunk received in turn %d", turn + 1)
                     text_stream_id = chunk.id
 
                     # Check if chunk has choices (OpenAI-like format)
@@ -634,7 +634,7 @@ async def stream_text(
 
             # Handle tool calls completion
             if finish_reason == "tool_calls" and tools:
-                logger.info("Tool calls detected, executing tools...")
+                logger.debug("Tool calls detected, executing tools...")
 
                 # First, add the assistant message with tool calls to conversation
                 assistant_tool_calls = []
@@ -834,7 +834,7 @@ async def stream_text(
 
                 # Add tool results to conversation for next turn
                 if tool_messages:
-                    logger.info(
+                    logger.debug(
                         "Adding %d tool result(s) to conversation for next turn", len(tool_messages)
                     )
                     conversation_messages.extend(tool_messages)

--- a/backend/app/utils/stream.py
+++ b/backend/app/utils/stream.py
@@ -153,10 +153,10 @@ async def execute_tool_with_streaming(
 
         # Get tool result
         tool_result = await tool_task
-        
+
         # Log tool output (truncated for readability)
         res_str = json.dumps(tool_result)
-        truncated_res = (res_str[:2000] + '...') if len(res_str) > 2000 else res_str
+        truncated_res = (res_str[:2000] + "...") if len(res_str) > 2000 else res_str
         logger.info("<<< Tool Output [%s]: %s", tool_name, truncated_res)
 
         yield ("result", tool_result)

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -10,8 +10,8 @@ import type { NextRequest, NextResponse } from "next/server";
 import { NextResponse as NextResponseValue } from "next/server";
 
 const API_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
   process.env.SERVER_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
   "http://localhost:8001";
 
 /**


### PR DESCRIPTION
For your local testing also, not super optimized prompts but a better overall experience.

- Intent Routing (Fast-Path): New gpt-4o-mini classifier to bypass the research planner for direct chat/greetings.
- Improved Context: Refactored message conversion to preserve "Researcher Thinking" blocks across turns.
- Data Integrity: Enforced exact indicator IDs and strict claim formatting (no quotes) for PCN compatibility.

Please see chat conversation with smoother reponses from the chatbot.
[simulation_chats.html](https://github.com/user-attachments/files/25077979/simulation_chats.html)
Improvements:
1. as chat progresses, the chatbot will forget to use multi-country get_data
2. outputs one table at a time.