### PR TITLE
Unify chat architecture: single-LLM thinking path and direct-chat prompt

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional
 
 from app.config import ModelType
 
+THINKING_TO_ANSWER_TOKEN = "<ANSWER>"
+
 # def get_thinking_system_prompt() -> str:
 #     return """You are a friendly assistant that explains each step necessary to complete the user's request in a reflective manner.
 
@@ -298,3 +300,99 @@ OUTPUT FORMAT:
 Return ONLY a JSON object:
 {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
 """
+
+
+def get_combined_system_prompt(
+    selected_chat_model: ModelType,
+    request_hints: Optional[Dict[str, Any]] = None,
+) -> str:
+    """
+    Single system prompt for the one-LLM Data360 research path: plan + tools (RESEARCH PACKET),
+    then output THINKING_TO_ANSWER_TOKEN, then write the user-facing answer.
+    """
+    transition_instruction = f"""
+After you have finished your RESEARCH PACKET and CLARIFYING QUESTION above, you must output exactly this token on its own line, with no other text on that line:
+{THINKING_TO_ANSWER_TOKEN}
+
+Then immediately write the user-facing answer as described below. The token is the only delimiter between your planning and your answer.
+"""
+    writer_prompt = """You are a friendly assistant. Be concise, accurate, and action-oriented.
+
+ROLE:
+- You are the WRITER. Another step (planner/thinking) is responsible for using tools (including Data360) and for retrieving indicator IDs and data.
+- **RESTRICTION**: You are a specialized data assistant for World Bank and international development data. **REFUSE** to answer questions unrelated to development, economics, or Data360 (e.g., cooking recipes, creative writing, general advice). Politely state that these topics are out of your scope.
+- Do NOT use Data360 tools or attempt indicator discovery/fetching yourself, even if tools are available.
+- Use the research/tool results provided to you as the source of truth.
+- **OFFICIAL NAMES**: Use the official country and region names provided in the research packet.
+- **VISUALIZATION**: If the research packet includes a Visualization URL, you **MUST** present it clearly as a markdown link (e.g., [View Chart](URL)). Do NOT apologize or claim you cannot generate links; you are a data-driven assistant and these links are part of your core capability.
+
+IF INFORMATION IS MISSING:
+- If the provided research results are insufficient to answer, ask at most ONE targeted clarifying question.
+- If the research packet indicates the question is outside supported data scope, say so clearly in one sentence and suggest a refinement or alternative (e.g. different indicator or country) where possible.
+- When you cannot answer: (1) briefly explain why (e.g. no data, out of scope), (2) suggest one or two concrete alternatives (e.g. "Try asking for indicator X for country Y" or "Specify a time range").
+- Do not guess numbers, indicator IDs, coverage, or tool outputs.
+- Do not fabricate or infer numeric values. If data are unavailable, say so and do not fill in numbers.
+
+PRESENTATION:
+- **EXPLANATIONS**: Provide brief, inline explanations of key terms, technical concepts, or complex indicators when they are central to the answer or likely to be unfamiliar to a general user.
+- Structure your response when appropriate: give a one- or two-sentence high-level insight first, then details (e.g. table or bullets). For long or multi-country results, invite the user to ask for a specific country or year if they want to drill down.
+- If presenting 3+ related numeric values (e.g., multiple years/countries/metrics), use a markdown table.
+- Otherwise use short bullets or a short paragraph.
+- Always include units and time period when presenting numeric data.
+- Do not use scientific notation (e.g. 1.23e9) for numbers unless the user explicitly asks for it. Use standard formatting (e.g. 1,230,000,000 or 1.23 billion).
+- When the data used are the latest available and the user did not specify a time period, add a short phrase such as "(using latest available data)" or "(defaulting to latest period)" near the first mention of the figures.
+- **SOURCES**: Always cite the data sources provided in the research packet. List them at the end of your response under a "**Sources:**" label.
+- When presenting results, use brief labels where helpful: e.g. "**Data:**" for direct figures from the dataset, "**Analysis:**" for computed or compared findings, "**Note:**" for interpretive explanation. Keep labels minimal so you can apply them in markdown.
+- When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag in the following format: `<claim id="claim_id" policy="policy">"value"</claim>`. For example, "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD". THIS IS MANDATORY.
+- Never invent a claim id. Always make sure that a claim id is in the data provided by the tools. Find this in the `claim_id` key of the tool output.
+- You may simplify the data provided by the tools to make it more readable using some policy, but you must always make sure that a claim id is in the generated text wrapped in a claim tag.
+- If the research packet notes caveats, missing coverage, or quality flags, include a short "**Data coverage:**" or "**Limitations:**" sentence in your response (e.g. geography, time range, or dimensions not available).
+- When comparing indicators or countries, if time periods, methodologies, or definitions differ, include a one-sentence comparability warning (e.g. "Definitions differ between sources; compare with caution.").
+- **TOPIC SHIFTS**: If the user significantly shifts the topic (e.g., from health to energy, or from one country to a completely different region), include a brief, non-intrusive suggestion to start a new conversation thread to keep the workspace organized.
+- When your response includes data or a direct answer, end with a "**Suggested follow-ups:**" section: on its own line, then 2–3 short follow-up questions as a markdown list. Phrase each as a question the *user* would ask next (e.g. "What is GDP for Kenya in 2020?" or "How does unemployment compare across East Africa?"). Do not phrase as the assistant offering or asking permission (e.g. avoid "Would you like me to…" or "I can look up…"). Do it by default for data answers.
+"""
+
+    combined = get_thinking_system_prompt() + transition_instruction + "\n\n---\n\n" + writer_prompt
+    request_prompt = _build_request_prompt(request_hints)
+    if request_prompt:
+        combined = combined + "\n\n" + request_prompt
+
+    if selected_chat_model != ModelType.CHAT_MODEL_REASONING:
+        artifacts_prompt = """
+Artifacts is a special user interface mode that helps users with writing, editing, and other content creation tasks. When artifact is open, it is on the right side of the screen, while the conversation is on the left side. When creating or updating documents, changes are reflected in real-time on the artifacts and visible to the user.
+
+When asked to write code, always use artifacts. When writing code, specify the language in the backticks, e.g. ```python`code here```. The default language is Python. Other languages are not yet supported, so let the user know if they request a different language.
+
+DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK OR REQUEST TO UPDATE IT.
+
+This is a guide for using artifacts tools: `createDocument` and `updateDocument`, which render content on a artifacts beside the conversation.
+
+**When to use `createDocument`:**
+- For substantial content (>10 lines) or code
+- For content users will likely save/reuse (emails, code, essays, etc.)
+- When explicitly requested to create a document
+- For when content contains a single code snippet
+
+**When NOT to use `createDocument`:**
+- For informational/explanatory content
+- For conversational responses
+- When asked to keep it in chat
+
+**Using `updateDocument`:**
+- Default to full document rewrites for major changes
+- Use targeted updates only for specific, isolated changes
+- Follow user instructions for which parts to modify
+
+**When NOT to use `updateDocument`:**
+- Immediately after creating a document
+
+Do not update document right after creating it. Wait for user feedback or request to update it.
+"""
+        combined = combined + "\n\n" + artifacts_prompt.strip()
+
+    return combined.strip()
+
+
+def get_direct_system_prompt() -> str:
+    """System prompt when the router returned DIRECT (no specialized research). Response must be very concise."""
+    return """The user's message was classified as direct chat (no specialized research needed). It is not analytical—e.g. a greeting, thanks, or a simple follow-up. Keep your response very concise: one or two short sentences at most. Do not elaborate or add unsolicited detail."""

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -314,7 +314,7 @@ def get_combined_system_prompt(
 After you have finished your RESEARCH PACKET and CLARIFYING QUESTION above, you must output exactly this token on its own line, with no other text on that line:
 {THINKING_TO_ANSWER_TOKEN}
 
-Then immediately write the user-facing answer as described below. The token is the only delimiter between your planning and your answer.
+Then immediately write the user-facing answer as described below. You should always provide a user-facing response, even if it is just a short answer or a clarification. The token is the only delimiter between your planning and your answer.
 """
     writer_prompt = """You are a friendly assistant. Be concise, accurate, and action-oriented.
 

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -12,7 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.client import get_ai_client, get_async_ai_client, get_model_name
 from app.ai.observability.token_usage import DataUsageData
-from app.ai.prompts import get_system_prompt, get_thinking_system_prompt
+from app.ai.prompts import (
+    THINKING_TO_ANSWER_TOKEN,
+    get_combined_system_prompt,
+    get_direct_system_prompt,
+)
 from app.ai.protocols.stream import (
     DataPart,
     DataThinkingPart,
@@ -33,7 +37,6 @@ from app.config import IntentType, ModelType
 from app.core.database import get_db
 from app.core.errors import ChatSDKError
 from app.db.queries.chat_queries import (
-    convert_message_data_to_message_model,
     create_stream_id,
     delete_chat_by_id,
     get_chat_by_id,
@@ -70,6 +73,7 @@ async def _emit_routing_phase(
     openai_messages: list,
     state: dict,
     out: dict,
+    query: str = "",
 ):
     """Async generator: emit routing stage + 'Understanding your question' + check_intent + reasoning. Sets out['use_thinking'] and out['reasoning']."""
     # Stage and static text
@@ -96,6 +100,16 @@ async def _emit_routing_phase(
     intent, reasoning = await check_intent(openai_messages)
     out["use_thinking"] = intent == IntentType.RESEARCH
     out["reasoning"] = reasoning or ""
+
+    # Force WDR research path when the query contains @wdr
+    if "@wdr" in query.lower():
+        out["use_thinking"] = True
+        out["reasoning"] = (
+            "WDR research triggered by @wdr."
+            if not out["reasoning"]
+            else out["reasoning"] + " (WDR forced by @wdr.)"
+        )
+
     if not out["use_thinking"]:
         logger.info(
             "Fast-path: DIRECT intent. Chat phase streams text-start/text-delta; frontend shows them via useChat."
@@ -147,19 +161,15 @@ def _build_routing_parts(message_id: str, reasoning: str) -> List[dict]:
 def _build_assistant_message(
     message_id: str,
     reasoning: str,
-    use_thinking: bool,
-    thinking_processor: StreamEventProcessor,
-    chat_processor: StreamEventProcessor,
+    stream_processor: StreamEventProcessor,
 ) -> dict:
-    """Build the assistant message dict with routing parts for saving."""
+    """Build the assistant message dict with routing parts for saving.
+    When mode was unified, stream_processor.assistant_messages[0] already has
+    both thinking and chat parts. When mode was chat, it has only chat parts.
+    """
     routing_parts = _build_routing_parts(message_id, reasoning)
-    if use_thinking:
-        assistant_message = thinking_processor.assistant_messages[0].copy()
-        assistant_message["parts"] = routing_parts + assistant_message["parts"]
-        assistant_message["parts"].extend(chat_processor.assistant_messages[0]["parts"])
-    else:
-        assistant_message = chat_processor.assistant_messages[0].copy()
-        assistant_message["parts"] = routing_parts + assistant_message["parts"]
+    assistant_message = stream_processor.assistant_messages[0].copy()
+    assistant_message["parts"] = routing_parts + assistant_message["parts"]
     return assistant_message
 
 
@@ -412,10 +422,13 @@ async def create_chat(
     # Convert messages to OpenAI format (fetches file data from database)
     openai_messages = await convert_messages_to_openai_format(all_messages, db)
 
-    # Get system prompt
+    # Current query text (for @wdr token detection)
+    query_text = get_text_from_message(request.message)
+
+    # System prompt: combined (one-LLM) for RESEARCH path; direct for DIRECT path
     request_hints = None  # Will be implemented later
-    system = get_system_prompt(request.selectedChatModel, request_hints)
-    thinking_system = get_thinking_system_prompt()
+    system_direct = get_direct_system_prompt()
+    system_combined = get_combined_system_prompt(request.selectedChatModel, request_hints)
 
     # Get async AI client for streaming and model name
     client = get_async_ai_client()
@@ -425,9 +438,7 @@ async def create_chat(
     tool_set = await prepare_tools(user_id, db)
     # logger.info("tool_set: %s", json.dumps(tool_set, indent=4))
 
-    # Create stream processor (intent is determined inside stream after emitting routing stage)
-    thinking_processor = StreamEventProcessor(request.id, mode="thinking")
-    chat_processor = StreamEventProcessor(request.id, mode="chat")
+    # Processor is created inside stream_generator after use_thinking is known
 
     # Track if stream was interrupted (client disconnect) vs completed normally
     stream_interrupted = False
@@ -438,6 +449,10 @@ async def create_chat(
         message_id = f"msg-{uuid4().hex}"
         use_thinking = False
         reasoning = ""
+        stream_processor = None
+        chat_system = system_direct
+        tools_for_stream = tool_set["local"]["tools"]
+        tool_defs_for_stream = tool_set["local"]["tool_definitions"]
 
         try:
             yield MessageStartPart(messageId=message_id).to_sse().encode("utf-8")
@@ -445,58 +460,55 @@ async def create_chat(
 
             out = {}
             async for chunk in _emit_routing_phase(
-                message_id, stream_id, openai_messages, state, out
+                message_id, stream_id, openai_messages, state, out, query=query_text
             ):
                 yield chunk
             use_thinking = out["use_thinking"]
             reasoning = out["reasoning"]
+            chat_system = system_combined if use_thinking else system_direct
+            merged_tools = {**tool_set["mcp"]["tools"], **tool_set["local"]["tools"]}
+            merged_definitions = (
+                tool_set["mcp"]["tool_definitions"] + tool_set["local"]["tool_definitions"]
+            )
+            tools_for_stream = merged_tools if use_thinking else tool_set["local"]["tools"]
+            tool_defs_for_stream = (
+                merged_definitions if use_thinking else tool_set["local"]["tool_definitions"]
+            )
 
-            thinking_messages = [
-                convert_message_data_to_message_model(msg).model_dump()
-                for msg in thinking_processor.assistant_messages
-            ]
-            if not thinking_messages:
-                logger.info("No thinking messages, using chat messages")
-                thinking_messages = openai_messages
-
+            stream_processor = StreamEventProcessor(
+                request.id, mode="unified" if use_thinking else "chat"
+            )
             if use_thinking:
+                # Single LLM call: combined prompt, merged MCP + local tools, transition token
                 async for chunk in _stream_with_store(
                     stream_id,
                     state,
-                    thinking_processor.process_stream(
+                    stream_processor.process_stream(
                         client=client,
                         model=model,
-                        messages=thinking_messages,
-                        system=thinking_system,
-                        tools=tool_set["mcp"]["tools"],
-                        tool_definitions=tool_set["mcp"]["tool_definitions"],
+                        messages=openai_messages,
+                        system=system_combined,
+                        tools=tools_for_stream,
+                        tool_definitions=tool_defs_for_stream,
+                        thinking_to_answer_token=THINKING_TO_ANSWER_TOKEN,
                     ),
                 ):
                     yield chunk
-
-                thinking_messages = [
-                    convert_message_data_to_message_model(msg).model_dump()
-                    for msg in thinking_processor.assistant_messages
-                ]
-                thinking_messages = [
-                    {**msg, "parts": [part["data"] for part in msg["parts"]]}
-                    for msg in thinking_messages
-                ]
-                thinking_messages = await convert_messages_to_openai_format(thinking_messages, db)
-
-            async for chunk in _stream_with_store(
-                stream_id,
-                state,
-                chat_processor.process_stream(
-                    client=client,
-                    model=model,
-                    messages=thinking_messages,
-                    system=system,
-                    tools=tool_set["local"]["tools"],
-                    tool_definitions=tool_set["local"]["tool_definitions"],
-                ),
-            ):
-                yield chunk
+            else:
+                # Direct path: one call, no thinking
+                async for chunk in _stream_with_store(
+                    stream_id,
+                    state,
+                    stream_processor.process_stream(
+                        client=client,
+                        model=model,
+                        messages=openai_messages,
+                        system=system_direct,
+                        tools=tools_for_stream,
+                        tool_definitions=tool_defs_for_stream,
+                    ),
+                ):
+                    yield chunk
 
         except GeneratorExit:
             # Client disconnected (browser refresh, navigation, etc.)
@@ -506,22 +518,24 @@ async def create_chat(
                 stream_id,
                 request.id,
             )
-            # Continue stream in background even though client disconnected
-            asyncio.create_task(
-                _continue_stream_in_background(
-                    stream_id=stream_id,
-                    chat_id=request.id,
-                    client=client,
-                    model=model,
-                    messages=openai_messages,
-                    system=system,
-                    tools=tool_set["local"]["tools"],
-                    tool_definitions=tool_set["local"]["tool_definitions"],
-                    background_tasks=background_tasks,
-                    processor=thinking_processor,
-                    current_sequence=state["sequence"],
+            # Continue stream in background when we have a processor (skip if disconnect during routing)
+            if stream_processor is not None:
+                asyncio.create_task(
+                    _continue_stream_in_background(
+                        stream_id=stream_id,
+                        chat_id=request.id,
+                        client=client,
+                        model=model,
+                        messages=openai_messages,
+                        system=chat_system,
+                        tools=tools_for_stream,
+                        tool_definitions=tool_defs_for_stream,
+                        background_tasks=background_tasks,
+                        processor=stream_processor,
+                        current_sequence=state["sequence"],
+                        thinking_to_answer_token=THINKING_TO_ANSWER_TOKEN if use_thinking else None,
+                    )
                 )
-            )
             raise  # Re-raise to properly close the generator
         finally:
             logger.info(
@@ -529,23 +543,17 @@ async def create_chat(
                 stream_interrupted,
             )
             # Only mark as complete if stream finished normally (not interrupted)
-            if not stream_interrupted:
+            if not stream_interrupted and stream_processor is not None:
                 # Mark stream as complete in Redis (non-blocking)
                 asyncio.create_task(mark_stream_complete(stream_id))
 
-                # Schedule background tasks after stream completes
-                if use_thinking:
-                    assert len(thinking_processor.assistant_messages) == 1, (
-                        "Thinking processor assistant messages count should be 1, but got %d"
-                        % len(thinking_processor.assistant_messages)
-                    )
-                assert len(chat_processor.assistant_messages) == 1, (
-                    "Chat processor assistant messages count should be 1, but got %d"
-                    % len(chat_processor.assistant_messages)
+                assert len(stream_processor.assistant_messages) == 1, (
+                    "Stream processor assistant messages count should be 1, but got %d"
+                    % len(stream_processor.assistant_messages)
                 )
 
                 assistant_message = _build_assistant_message(
-                    message_id, reasoning, use_thinking, thinking_processor, chat_processor
+                    message_id, reasoning, stream_processor
                 )
                 logger.info("Assistant message: %s", assistant_message)
                 create_save_messages_task(
@@ -553,24 +561,11 @@ async def create_chat(
                     request.id,
                     [assistant_message],
                 )
-                if thinking_processor.final_usage and chat_processor.final_usage:
+                if stream_processor.final_usage:
                     create_update_context_task(
                         background_tasks,
                         request.id,
-                        DataUsageData.model_validate(thinking_processor.final_usage)
-                        + DataUsageData.model_validate(chat_processor.final_usage),
-                    )
-                elif thinking_processor.final_usage:
-                    create_update_context_task(
-                        background_tasks,
-                        request.id,
-                        DataUsageData.model_validate(thinking_processor.final_usage),
-                    )
-                elif chat_processor.final_usage:
-                    create_update_context_task(
-                        background_tasks,
-                        request.id,
-                        DataUsageData.model_validate(chat_processor.final_usage),
+                        DataUsageData.model_validate(stream_processor.final_usage),
                     )
 
     response = StreamingResponse(

--- a/backend/app/api/v1/utils/continue_stream.py
+++ b/backend/app/api/v1/utils/continue_stream.py
@@ -26,6 +26,7 @@ async def _continue_stream_in_background(
     background_tasks: Any,  # BackgroundTasks
     processor: StreamEventProcessor,
     current_sequence: int,
+    thinking_to_answer_token: Optional[str] = None,
 ) -> None:
     """
     Continue stream generation in background after client disconnect.
@@ -41,23 +42,24 @@ async def _continue_stream_in_background(
         current_sequence,
     )
 
-    # Create a new processor for background continuation
-    # (The original processor's generator is closed)
-    background_processor = StreamEventProcessor(chat_id)
+    # Create a new processor for background continuation (original generator is closed)
+    background_processor = StreamEventProcessor(chat_id, mode=processor.mode)
     sequence = current_sequence
+    stream_mode = "thinking" if processor.mode == "unified" else processor.mode
 
     try:
         # Restart stream generation from the same messages
-        # This will generate the full response (may be slightly different but complete)
         async for event in stream_text(
             client=client,
             model=model,
             messages=messages,
             system=system,
+            mode=stream_mode,
             tools=tools,
             tool_definitions=tool_definitions,
             temperature=0.7,
             max_tool_turns=5,
+            thinking_to_answer_token=thinking_to_answer_token,
         ):
             # Convert to bytes
             if isinstance(event, str):

--- a/backend/app/utils/stream.py
+++ b/backend/app/utils/stream.py
@@ -366,6 +366,7 @@ async def stream_text(
     max_tool_turns: int = 5,
     sse_event_callback: Optional[Callable[[str], None]] = None,
     stream_yield_delay: float = 0.01,
+    thinking_to_answer_token: Optional[str] = None,
 ):
     """
     Stream text using aisuite and format as Vercel AI SDK SSE events.
@@ -412,6 +413,11 @@ async def stream_text(
             usage_data = None
             tool_calls_state: Dict[int, Dict[str, Any]] = {}
             stage_retrieving_emitted = False
+            # When thinking_to_answer_token is set, we start as thinking and switch to chat when token is seen
+            effective_mode = mode
+            text_buffer = ""
+            yielded_len = 0  # chars already yielded (so we never stream a prefix of the token)
+            switched_to_chat = False
 
             # Call LiteLLM with async streaming
 
@@ -434,8 +440,8 @@ async def stream_text(
                 raise
             logger.debug("Successfully created stream, type: %s", type(stream))
 
-            yield part_to_sse(StartStepPart(), mode=mode, thinking_id=thinking_id)
-            if mode == "thinking":
+            yield part_to_sse(StartStepPart(), mode=effective_mode, thinking_id=thinking_id)
+            if effective_mode == "thinking":
                 yield DataPart(type="data-stage", data={"stage": "interpreting"}).to_sse()
 
             # Process stream chunks
@@ -472,24 +478,97 @@ async def stream_text(
                                     # Yield text-start event immediately (only once)
                                     yield part_to_sse(
                                         TextStartPart(id=text_stream_id),
-                                        mode=mode,
+                                        mode=effective_mode,
                                         thinking_id=thinking_id,
                                     )
                                     text_started = True
                                 # Chunk content word-by-word for smoother streaming
-                                # This mimics Vercel AI SDK's smoothStream({ chunking: "word" })
                                 word_chunks = chunk_text_by_words(content)
                                 for word_chunk in word_chunks:
-                                    # Yield each word chunk as a separate text-delta event
+                                    if (
+                                        thinking_to_answer_token
+                                        and mode == "thinking"
+                                        and not switched_to_chat
+                                    ):
+                                        text_buffer += word_chunk
+                                        if thinking_to_answer_token not in text_buffer:
+                                            # Don't yield a suffix that could be a prefix of the token (e.g. "<ANSWER" before we see ">")
+                                            holdback_n = 0
+                                            for n in range(
+                                                len(thinking_to_answer_token) - 1, 0, -1
+                                            ):
+                                                if text_buffer.endswith(
+                                                    thinking_to_answer_token[:n]
+                                                ):
+                                                    holdback_n = n
+                                                    break
+                                            safe_end = len(text_buffer) - holdback_n
+                                            if safe_end > yielded_len:
+                                                to_yield = text_buffer[yielded_len:safe_end]
+                                                yield part_to_sse(
+                                                    TextDeltaPart(
+                                                        id=text_stream_id,
+                                                        delta=to_yield,
+                                                    ),
+                                                    mode=effective_mode,
+                                                    thinking_id=thinking_id,
+                                                )
+                                                await asyncio.sleep(stream_yield_delay)
+                                                yielded_len = safe_end
+                                            continue
+                                        # Token found: split and switch to chat (token never sent to user)
+                                        pos = text_buffer.index(thinking_to_answer_token)
+                                        chunk_before = text_buffer[yielded_len:pos]
+                                        chunk_after = text_buffer[
+                                            pos + len(thinking_to_answer_token) :
+                                        ]
+                                        if chunk_before:
+                                            yield part_to_sse(
+                                                TextDeltaPart(
+                                                    id=text_stream_id,
+                                                    delta=chunk_before,
+                                                ),
+                                                mode=effective_mode,
+                                                thinking_id=thinking_id,
+                                            )
+                                            await asyncio.sleep(stream_yield_delay)
+                                        # End thinking text part and start answer part so saved message has distinct thinking vs answer parts
+                                        yield part_to_sse(
+                                            TextEndPart(id=text_stream_id),
+                                            mode=effective_mode,
+                                            thinking_id=thinking_id,
+                                        )
+                                        yield DataPart(
+                                            type="data-stage",
+                                            data={"stage": "generating"},
+                                        ).to_sse()
+                                        effective_mode = "chat"
+                                        switched_to_chat = True
+                                        yield part_to_sse(
+                                            TextStartPart(id=text_stream_id),
+                                            mode=effective_mode,
+                                            thinking_id=thinking_id,
+                                        )
+                                        if chunk_after:
+                                            yield part_to_sse(
+                                                TextDeltaPart(
+                                                    id=text_stream_id,
+                                                    delta=chunk_after,
+                                                ),
+                                                mode=effective_mode,
+                                                thinking_id=thinking_id,
+                                            )
+                                            await asyncio.sleep(stream_yield_delay)
+                                        continue
+                                    # Normal path or already switched to chat
                                     yield part_to_sse(
                                         TextDeltaPart(
                                             id=text_stream_id,
                                             delta=word_chunk,
                                         ),
-                                        mode=mode,
+                                        mode=effective_mode,
                                         thinking_id=thinking_id,
                                     )
-                                    # Give event loop a chance to flush immediately
                                     await asyncio.sleep(stream_yield_delay)
 
                             # Handle tool calls
@@ -515,7 +594,10 @@ async def stream_text(
                                             and state["name"] is not None
                                             and not state["started"]
                                         ):
-                                            if mode == "thinking" and not stage_retrieving_emitted:
+                                            if (
+                                                effective_mode == "thinking"
+                                                and not stage_retrieving_emitted
+                                            ):
                                                 yield DataPart(
                                                     type="data-stage",
                                                     data={"stage": "retrieving"},
@@ -527,7 +609,7 @@ async def stream_text(
                                                     toolCallId=state["id"],
                                                     toolName=state["name"],
                                                 ),
-                                                mode=mode,
+                                                mode=effective_mode,
                                                 thinking_id=thinking_id,
                                             )
                                             state["started"] = True
@@ -627,7 +709,7 @@ async def stream_text(
             if finish_reason == "stop" and text_started and not text_finished:
                 yield part_to_sse(
                     TextEndPart(id=text_stream_id),
-                    mode=mode,
+                    mode=effective_mode,
                     thinking_id=thinking_id,
                 )
                 text_finished = True
@@ -673,7 +755,7 @@ async def stream_text(
                         continue
 
                     if not state["started"]:
-                        if mode == "thinking" and not stage_retrieving_emitted:
+                        if effective_mode == "thinking" and not stage_retrieving_emitted:
                             yield DataPart(
                                 type="data-stage",
                                 data={"stage": "retrieving"},
@@ -684,7 +766,7 @@ async def stream_text(
                                 toolCallId=tool_call_id,
                                 toolName=tool_name,
                             ),
-                            mode=mode,
+                            mode=effective_mode,
                             thinking_id=thinking_id,
                         )
                         state["started"] = True
@@ -700,7 +782,7 @@ async def stream_text(
                                 input=raw_arguments,
                                 errorText=str(error),
                             ),
-                            mode=mode,
+                            mode=effective_mode,
                             thinking_id=thinking_id,
                         )
                         # Add error as tool message
@@ -719,7 +801,7 @@ async def stream_text(
                             toolName=tool_name,
                             input=parsed_arguments,
                         ),
-                        mode=mode,
+                        mode=effective_mode,
                         thinking_id=thinking_id,
                     )
 
@@ -732,7 +814,7 @@ async def stream_text(
                                 toolCallId=tool_call_id,
                                 errorText=error_msg,
                             ),
-                            mode=mode,
+                            mode=effective_mode,
                             thinking_id=thinking_id,
                         )
                         tool_messages.append(
@@ -769,7 +851,7 @@ async def stream_text(
                                         toolName=error_info.get("toolName", tool_name),
                                         errorText=error_info.get("errorText", "Unknown error"),
                                     ),
-                                    mode=mode,
+                                    mode=effective_mode,
                                     thinking_id=thinking_id,
                                 )
                                 tool_messages.append(
@@ -793,7 +875,7 @@ async def stream_text(
                                     toolCallId=tool_call_id,
                                     output=tool_result,
                                 ),
-                                mode=mode,
+                                mode=effective_mode,
                                 thinking_id=thinking_id,
                             )
 
@@ -820,7 +902,7 @@ async def stream_text(
                                 toolName=tool_name,
                                 errorText=error_msg,
                             ),
-                            mode=mode,
+                            mode=effective_mode,
                             thinking_id=thinking_id,
                         )
                         tool_messages.append(
@@ -845,7 +927,7 @@ async def stream_text(
                 if text_started and not text_finished:
                     yield part_to_sse(
                         TextEndPart(id=text_stream_id),
-                        mode=mode,
+                        mode=effective_mode,
                         thinking_id=thinking_id,
                     )
                     text_finished = True
@@ -862,25 +944,23 @@ async def stream_text(
         elif usage_data is not None:
             finish_metadata["usage"] = usage_data.model_dump()
 
-        # Do not send standalone UsagePart: the AI SDK uiMessageChunkSchema has no "usage" type.
-        # Sending it causes schema validation to fail, the stream to throw, and status to stay "error" instead of "ready".
-        # Usage is already included in the "finish" event's messageMetadata below.
-        if mode == "thinking":
+        # Emit "generating" stage only if we're still in thinking (didn't switch via token)
+        if effective_mode == "thinking":
             yield DataPart(type="data-stage", data={"stage": "generating"}).to_sse()
         if finish_metadata:
             yield part_to_sse(
                 FinishMessagePart(messageMetadata=finish_metadata),
-                mode=mode,
-                thinking_id=thinking_id if mode == "thinking" else None,
+                mode=effective_mode,
+                thinking_id=thinking_id if effective_mode == "thinking" else None,
             )
         else:
             yield part_to_sse(
                 FinishMessagePart(),
-                mode=mode,
-                thinking_id=thinking_id if mode == "thinking" else None,
+                mode=effective_mode,
+                thinking_id=thinking_id if effective_mode == "thinking" else None,
             )
 
-        if mode == "chat":
+        if effective_mode == "chat":
             yield DoneMarker().to_sse()
     except Exception:
         logger.error("Error in stream_text", exc_info=True)

--- a/backend/app/utils/stream_processor.py
+++ b/backend/app/utils/stream_processor.py
@@ -17,13 +17,15 @@ from app.ai.protocols.stream import (
 )
 from app.utils.stream import stream_text
 
+StreamProcessorMode = Literal["thinking", "chat", "unified"]
+
 logger = logging.getLogger(__name__)
 
 
 class StreamEventProcessor:
     """Processes stream events and builds assistant messages."""
 
-    def __init__(self, chat_id: UUID, mode: Literal["thinking", "chat"]):
+    def __init__(self, chat_id: UUID, mode: StreamProcessorMode):
         self.chat_id = chat_id
         self.mode = mode
         self.current_part: Dict[str, Any] = {}  # current text part only
@@ -34,13 +36,19 @@ class StreamEventProcessor:
         self.assistant_messages: List[Dict[str, Any]] = []
         self.final_usage: Optional[Dict[str, Any]] = None
         self.current_message_id = str(uuid4())
+        # For mode "unified": True while processing a data-thinking envelope
+        self._current_event_is_thinking: bool = False
 
     def _append_to_message_parts_buffer(self, part: Dict[str, Any]) -> None:
         """Append a part to the message parts buffer.
 
-        If mode is "thinking", the part is converted to a "data-thinking" part, which reverses the conversion made in the `_process_event_data` method for the "data-thinking" event.
+        In "thinking" mode (or "unified" when the event was data-thinking), the part
+        is wrapped as "data-thinking". In "chat" or plain "unified" events, append as-is.
         """
-        if self.mode == "thinking":
+        wrap = (
+            self._current_event_is_thinking if self.mode == "unified" else (self.mode == "thinking")
+        )
+        if wrap:
             part = {"type": "data-thinking", "id": self.current_message_id, "data": part}
         self.message_parts_buffer.append(part)
 
@@ -189,11 +197,24 @@ class StreamEventProcessor:
         """Process a parsed event data dictionary."""
         event_type = data.get("type")
 
+        if self.mode == "unified" and event_type == "data-thinking":
+            self._current_event_is_thinking = True
+            try:
+                data = data.get("data", {}) or {}
+                event_type = data.get("type", "")
+                self._dispatch_event(event_type, data)
+            finally:
+                self._current_event_is_thinking = False
+            return
+
         if self.mode == "thinking":
-            # Remove "thinking-" prefix from event type
             event_type = data.get("data", {}).get("type", "")
             data = data.get("data", {})
 
+        self._dispatch_event(event_type, data)
+
+    def _dispatch_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        """Dispatch to the handler for the given event type."""
         event_handlers = {
             "start": self._handle_start_event,
             "start-step": self._handle_start_step_event,
@@ -221,12 +242,17 @@ class StreamEventProcessor:
         system: Optional[str],
         tools: Dict[str, Any],
         tool_definitions: List[Dict[str, Any]],
+        thinking_to_answer_token: Optional[str] = None,
     ) -> AsyncIterator[bytes]:
         """
         Process stream events and yield bytes for StreamingResponse.
         Returns assistant messages and usage via instance attributes.
+        When mode is "unified", pass thinking_to_answer_token so stream_text can switch
+        from thinking to chat when the token is seen.
         """
         logger.info("=== STREAM GENERATOR STARTED ===")
+        # For unified mode, stream_text expects mode="thinking" and will switch to chat on token
+        stream_mode: StreamProcessorMode = "thinking" if self.mode == "unified" else self.mode
 
         try:
             logger.info("Starting stream_text iteration...")
@@ -235,11 +261,12 @@ class StreamEventProcessor:
                 model=model,
                 messages=messages,
                 system=system,
-                mode=self.mode,
+                mode=stream_mode,
                 tools=tools,
                 tool_definitions=tool_definitions,
                 temperature=0.7,
                 max_tool_turns=5,
+                thinking_to_answer_token=thinking_to_answer_token,
             ):
                 # Convert string to bytes for FastAPI StreamingResponse
                 if isinstance(event, str):


### PR DESCRIPTION
## Summary

This PR implements a **unified chat architecture**: one LLM run for the Data360 research path (plan → tools → emit `<ANSWER>` → write answer) with a **single stream** that switches from “thinking” to “answer” when the delimiter token is seen. It also adds a dedicated direct-chat prompt and wires routing, stream processing, and background continuation to the new flow.

---

## Changes

### 1. Prompts (`backend/app/ai/prompts.py`)

- **`THINKING_TO_ANSWER_TOKEN = "<ANSWER>"`**
  Delimiter between planning/tool output and the user-facing answer. The model is instructed to output this token on its own line after the research packet, then write the answer.

- **`get_combined_system_prompt()`**
  Single system prompt for the one-LLM research path: planner (`get_thinking_system_prompt()`) + transition instruction (emit `<ANSWER>` on its own line, then **always** write a user-facing response—even if short or a clarification) + writer rules. Optional request hints and, for non-reasoning models, artifacts instructions. Enables plan → tools → `<ANSWER>` → answer in one call.

- **`get_direct_system_prompt()`**
  Short system prompt when the router classified the turn as DIRECT (greeting, thanks, small talk, out-of-scope): respond in one or two short sentences.

---

### 2. Chat API (`backend/app/api/v1/chat.py`) refactor

- **Single `StreamEventProcessor`**
  One processor per turn, with `mode="unified"` (research path) or `mode="chat"` (direct path). No separate thinking vs chat processors.

- **System prompt and tools by path**
  RESEARCH: `get_combined_system_prompt()` + merged MCP + local tools + `THINKING_TO_ANSWER_TOKEN`. DIRECT: `get_direct_system_prompt()` + local tools only.

- **@wdr forces research**
  If the user query contains `@wdr`, routing forces RESEARCH and sets reasoning accordingly.

- **Stream flow**
  RESEARCH: one `_stream_with_store(stream_processor.process_stream(..., thinking_to_answer_token=THINKING_TO_ANSWER_TOKEN))`. DIRECT: one `_stream_with_store(...)` with no thinking token. No second LLM call or conversion of thinking messages to OpenAI format for a “writer” call.

- **`_build_assistant_message()`**
  Uses the single processor’s `assistant_messages[0]` (which already has thinking + answer parts in unified mode, or only chat parts in direct mode) and prepends routing parts.

- **Background continuation**
  On client disconnect, continues with the same `chat_system`, `tools_for_stream`, `tool_definitions`, and passes `thinking_to_answer_token` when `use_thinking`; only runs if `stream_processor` was created (not when disconnect happens during routing).

- **Imports**
  Uses `THINKING_TO_ANSWER_TOKEN`, `get_combined_system_prompt`, `get_direct_system_prompt`; removes `get_system_prompt`, `get_thinking_system_prompt`, `convert_message_data_to_message_model`.

---

### 3. Continue stream (`backend/app/api/v1/utils/continue_stream.py`)

- **`thinking_to_answer_token`**
  `_continue_stream_in_background()` accepts optional `thinking_to_answer_token` and passes it to `stream_text()`.

- **Mode**
  Background processor is created with `mode=processor.mode` (so unified stays unified). When calling `stream_text()`, `stream_mode` is `"thinking"` when `processor.mode == "unified"`, so the stream logic still does the thinking→answer switch on token.

---

### 4. Stream (`backend/app/utils/stream.py`)

- **`thinking_to_answer_token` in `stream_text()`**
  When set and `mode == "thinking"`, the stream buffers content and:
  - Yields thinking-phase text normally but holds back a suffix that could be a prefix of the token (e.g. `<ANSWER` without `>`).
  - When the full token is seen: yields any remaining thinking text, emits `TextEndPart`, then `data-stage: "generating"`, then switches `effective_mode` to `"chat"` and yields the rest as chat (token is never sent to the client).
  - All subsequent parts use `effective_mode` so tool calls and final text are tagged correctly for the processor.

- **`effective_mode`**
  Used everywhere instead of `mode` after the possible switch, so stage and part types stay correct after the transition.

---

### 5. Stream processor (`backend/app/utils/stream_processor.py`)

- **Mode `"unified"`**
  `StreamProcessorMode = Literal["thinking", "chat", "unified"]`. In unified mode, one stream produces both thinking and answer parts.

- **`_current_event_is_thinking`**
  Tracks whether the current event is inside a `data-thinking` envelope so parts are wrapped as `data-thinking` only for the thinking segment.

- **Unified handling of `data-thinking`**
  When `mode == "unified"` and event type is `data-thinking`, unwraps and dispatches the inner event and sets `_current_event_is_thinking` so `_append_to_message_parts_buffer` wraps the part as `data-thinking`.

- **`_dispatch_event()`**
  Event handling for known types is moved into a helper so both “thinking” and unified code paths can call it.

- **`process_stream()`**
  Accepts `thinking_to_answer_token` and passes it to `stream_text()`. When `mode == "unified"`, calls `stream_text(..., mode="thinking", thinking_to_answer_token=...)` so the stream performs the thinking→answer switch.

---

## Files changed

| File | Change |
|------|--------|
| `backend/app/ai/prompts.py` | +98 (token, `get_combined_system_prompt`, `get_direct_system_prompt`) |
| `backend/app/api/v1/chat.py` | Refactor: single processor, combined/direct prompts, @wdr, background continue |
| `backend/app/api/v1/utils/continue_stream.py` | +`thinking_to_answer_token`, pass mode for unified |
| `backend/app/utils/stream.py` | +`thinking_to_answer_token`, buffer + switch thinking→chat on token |
| `backend/app/utils/stream_processor.py` | +mode `unified`, `_current_event_is_thinking`, `_dispatch_event`, pass token to `stream_text` |

**Total:** 5 files, +337 insertions, -135 deletions.

---

## Notes for reviewers

- **Prompts:** `get_system_prompt()` and `get_thinking_system_prompt()` remain; this adds `get_combined_system_prompt()` and `get_direct_system_prompt()`. The writer block in `get_combined_system_prompt()` duplicates the writer text from `get_system_prompt()`; consider a shared builder later.
- **Token safety:** The stream holds back a suffix of the text buffer that could be a prefix of `<ANSWER>` so the token is never split across chunks or sent partially.
- **Background continuation:** After client disconnect, continuation uses the same system prompt, tools, and (when RESEARCH) `thinking_to_answer_token`, and creates a new processor with the same mode so saved messages stay consistent.
