### PR TITLE
feat(ui): Maintenance page with runtime toggle

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -26,3 +26,7 @@ NEXT_PUBLIC_APPLICATION_STATUS=alpha
 
 # Shows the part type in the thinking component stepper if true
 NEXT_PUBLIC_SHOW_REASONING_PART_TYPE=false
+
+
+# If set to `true` or `1` activates the maintenance page.
+MAINTENANCE_MODE=false

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -420,3 +420,76 @@ button.home-suggestion-chip:hover {
   --sidebar: hsl(240 5.9% 12%);
 }
 */
+
+/* Maintenance page: AI/data theme animations (disabled when user prefers reduced motion) */
+@keyframes maintenance-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes maintenance-pulse-soft {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@keyframes maintenance-shimmer {
+  0% {
+    background-position: 200% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
+}
+
+@keyframes maintenance-dot {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.8);
+    opacity: 0.5;
+  }
+  40% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+}
+
+.maintenance-float {
+  animation: maintenance-float 3s ease-in-out infinite;
+}
+
+.maintenance-pulse-soft {
+  animation: maintenance-pulse-soft 2s ease-in-out infinite;
+}
+
+.maintenance-dot {
+  animation: maintenance-dot 1.4s ease-in-out infinite both;
+}
+
+.maintenance-dot:nth-child(1) {
+  animation-delay: 0s;
+}
+.maintenance-dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+.maintenance-dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maintenance-float,
+  .maintenance-pulse-soft,
+  .maintenance-dot {
+    animation: none;
+  }
+}

--- a/frontend/app/maintenance/page.tsx
+++ b/frontend/app/maintenance/page.tsx
@@ -10,13 +10,14 @@
  * - NEXT_PUBLIC_MAINTENANCE_ESTIMATED_END: e.g. "2:00 PM UTC".
  * Contact link uses NEXT_PUBLIC_FEEDBACK_CONTACT_URL when set.
  */
-import { Construction } from "lucide-react";
+import { Bot, Database, Sparkles } from "lucide-react";
 import type { Metadata } from "next";
 import { appConfig } from "@/lib/config";
 
 export const metadata: Metadata = {
   title: `Maintenance | ${appConfig.metadata.title}`,
-  description: "Data360 Chat is currently under maintenance. Please check back later.",
+  description:
+    "Data360 Chat is currently under maintenance. Please check back later.",
   robots: "noindex, nofollow",
 };
 
@@ -40,24 +41,77 @@ export default function MaintenancePage() {
   const contact = appConfig.feedbackContact;
 
   return (
-    <main className="flex min-h-dvh w-full flex-col items-center justify-center bg-background px-4 py-12">
-      <div className="flex w-full max-w-lg flex-col items-center gap-8 text-center">
+    <main className="relative flex min-h-dvh w-full flex-col items-center justify-center overflow-hidden bg-background px-4 py-12">
+      {/* Subtle grid background (data vibe) */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.03] dark:opacity-[0.06]"
+        aria-hidden
+      >
         <div
-          className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full border-2 border-[var(--home-accent)] bg-[var(--home-accent)]/10 text-[var(--home-accent)]"
-          aria-hidden
-        >
-          <Construction
-            size={40}
-            strokeWidth={1.5}
+          className="h-full w-full"
+          style={{
+            backgroundImage: `
+              linear-gradient(to right, var(--foreground) 1px, transparent 1px),
+              linear-gradient(to bottom, var(--foreground) 1px, transparent 1px)
+            `,
+            backgroundSize: "32px 32px",
+          }}
+        />
+      </div>
+
+      <div className="relative flex w-full max-w-lg flex-col items-center gap-10 text-center">
+        {/* Animated hero: bot + data sparkles */}
+        <div className="flex flex-col items-center gap-6">
+          <div
+            className="maintenance-float relative flex h-24 w-24 shrink-0 items-center justify-center rounded-2xl border-2 border-[var(--home-accent)] bg-gradient-to-br from-[var(--home-accent)]/15 to-[var(--home-accent)]/5 text-[var(--home-accent)] shadow-lg"
             aria-hidden
-            className="shrink-0"
-          />
+          >
+            <Bot size={44} strokeWidth={1.5} aria-hidden className="shrink-0" />
+            <span
+              className="maintenance-pulse-soft absolute -right-1 -top-1 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--home-accent)]/20"
+              aria-hidden
+            >
+              <Sparkles
+                size={14}
+                className="text-[var(--home-accent)]"
+                aria-hidden
+              />
+            </span>
+            <span
+              className="maintenance-pulse-soft absolute -bottom-0.5 -left-1 flex h-5 w-5 items-center justify-center rounded bg-[var(--home-accent)]/10"
+              aria-hidden
+            >
+              <Database
+                size={12}
+                className="text-[var(--home-accent)]"
+                aria-hidden
+              />
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h1 className="font-semibold text-2xl tracking-tight text-foreground sm:text-3xl">
+              Recharging my data brain
+            </h1>
+            <p className="flex items-center justify-center gap-1 text-muted-foreground text-base">
+              <span className="sr-only">Loading</span>
+              <span
+                className="maintenance-dot h-2 w-2 rounded-full bg-[var(--home-accent)]"
+                aria-hidden
+              />
+              <span
+                className="maintenance-dot h-2 w-2 rounded-full bg-[var(--home-accent)]"
+                aria-hidden
+              />
+              <span
+                className="maintenance-dot h-2 w-2 rounded-full bg-[var(--home-accent)]"
+                aria-hidden
+              />
+            </p>
+          </div>
         </div>
 
         <div className="flex flex-col gap-3">
-          <h1 className="font-semibold text-2xl tracking-tight text-foreground sm:text-3xl">
-            Under maintenance
-          </h1>
           <p className="text-muted-foreground text-base leading-relaxed">
             {message}
           </p>
@@ -69,7 +123,8 @@ export default function MaintenancePage() {
         </div>
 
         <p className="text-muted-foreground text-sm">
-          Thank you for your patience.
+          Thank you for your patience. I’ll be back with better data answers
+          soon.
         </p>
 
         {contact ? (

--- a/frontend/app/maintenance/page.tsx
+++ b/frontend/app/maintenance/page.tsx
@@ -1,0 +1,86 @@
+/**
+ * Maintenance page shown when the app is under scheduled maintenance.
+ * Route: /maintenance
+ *
+ * Redirect (runtime, no rebuild): set MAINTENANCE_MODE=true in App Service (or server env).
+ * Middleware redirects all traffic to this page when MAINTENANCE_MODE is set.
+ *
+ * Optional env (build-time for custom copy):
+ * - NEXT_PUBLIC_MAINTENANCE_MESSAGE: custom message.
+ * - NEXT_PUBLIC_MAINTENANCE_ESTIMATED_END: e.g. "2:00 PM UTC".
+ * Contact link uses NEXT_PUBLIC_FEEDBACK_CONTACT_URL when set.
+ */
+import { Construction } from "lucide-react";
+import type { Metadata } from "next";
+import { appConfig } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: `Maintenance | ${appConfig.metadata.title}`,
+  description: "Data360 Chat is currently under maintenance. Please check back later.",
+  robots: "noindex, nofollow",
+};
+
+/** Optional maintenance message override via env. */
+function getMaintenanceMessage(): string {
+  const v = process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE;
+  if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  return "We're currently performing scheduled maintenance to improve your experience. Please check back shortly.";
+}
+
+/** Optional estimated end time (e.g. "2:00 PM UTC" or "in about 1 hour"). */
+function getEstimatedEnd(): string | null {
+  const v = process.env.NEXT_PUBLIC_MAINTENANCE_ESTIMATED_END;
+  if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  return null;
+}
+
+export default function MaintenancePage() {
+  const message = getMaintenanceMessage();
+  const estimatedEnd = getEstimatedEnd();
+  const contact = appConfig.feedbackContact;
+
+  return (
+    <main className="flex min-h-dvh w-full flex-col items-center justify-center bg-background px-4 py-12">
+      <div className="flex w-full max-w-lg flex-col items-center gap-8 text-center">
+        <div
+          className="flex h-20 w-20 shrink-0 items-center justify-center rounded-full border-2 border-[var(--home-accent)] bg-[var(--home-accent)]/10 text-[var(--home-accent)]"
+          aria-hidden
+        >
+          <Construction
+            size={40}
+            strokeWidth={1.5}
+            aria-hidden
+            className="shrink-0"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <h1 className="font-semibold text-2xl tracking-tight text-foreground sm:text-3xl">
+            Under maintenance
+          </h1>
+          <p className="text-muted-foreground text-base leading-relaxed">
+            {message}
+          </p>
+          {estimatedEnd ? (
+            <p className="text-muted-foreground text-sm">
+              Estimated completion: {estimatedEnd}
+            </p>
+          ) : null}
+        </div>
+
+        <p className="text-muted-foreground text-sm">
+          Thank you for your patience.
+        </p>
+
+        {contact ? (
+          <a
+            href={contact.url}
+            className="font-medium text-[var(--home-accent)] underline underline-offset-4 outline-none transition-colors hover:text-[var(--home-accent)]/80 focus-visible:ring-2 focus-visible:ring-[var(--home-accent)] focus-visible:ring-offset-2 rounded"
+          >
+            {contact.label}
+          </a>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/ui/sidebar.tsx
+++ b/frontend/components/ui/sidebar.tsx
@@ -659,10 +659,8 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  // Fixed width so server and client render the same (avoids hydration error #418).
+  const width = "70%";
 
   return (
     <div

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -17,7 +17,10 @@ function getRequestOrigin(request: NextRequest): string {
   if (referer) {
     try {
       const refUrl = new URL(referer);
-      if (refUrl.origin && (refUrl.protocol === "http:" || refUrl.protocol === "https:")) {
+      if (
+        refUrl.origin &&
+        (refUrl.protocol === "http:" || refUrl.protocol === "https:")
+      ) {
         return refUrl.origin;
       }
     } catch {
@@ -49,11 +52,22 @@ function isMaintenanceMode(): boolean {
   return v === "true" || v === "1";
 }
 
+/** Bypass maintenance redirect when this query param is present (e.g. ?nomaintenance=true). */
+function isMaintenanceBypass(request: NextRequest): boolean {
+  const v = request.nextUrl.searchParams.get("nomaintenance");
+  return v === "true" || v === "1";
+}
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  if (isMaintenanceMode()) {
-    if (pathname !== "/maintenance" && !pathname.startsWith("/_next") && !pathname.startsWith("/api") && !pathname.includes(".")) {
+  if (isMaintenanceMode() && !isMaintenanceBypass(request)) {
+    if (
+      pathname !== "/maintenance" &&
+      !pathname.startsWith("/_next") &&
+      !pathname.startsWith("/api") &&
+      !pathname.includes(".")
+    ) {
       return NextResponse.redirect(new URL("/maintenance", request.url));
     }
     if (pathname === "/maintenance") {
@@ -105,7 +119,7 @@ export function proxy(request: NextRequest) {
     const redirectTarget = `${baseOrigin}/`;
     const guestUrl = new URL(
       `/api/auth/guest?redirectUrl=${encodeURIComponent(redirectTarget)}`,
-      baseOrigin
+      baseOrigin,
     );
     return NextResponse.redirect(guestUrl);
   }

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -40,8 +40,26 @@ function getRequestOrigin(request: NextRequest): string {
   return `${proto}://${host}`;
 }
 
+/**
+ * When MAINTENANCE_MODE is "true" or "1" (set in App Service / runtime env),
+ * redirect to /maintenance except for that page and static/API assets.
+ */
+function isMaintenanceMode(): boolean {
+  const v = process.env.MAINTENANCE_MODE;
+  return v === "true" || v === "1";
+}
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  if (isMaintenanceMode()) {
+    if (pathname !== "/maintenance" && !pathname.startsWith("/_next") && !pathname.startsWith("/api") && !pathname.includes(".")) {
+      return NextResponse.redirect(new URL("/maintenance", request.url));
+    }
+    if (pathname === "/maintenance") {
+      return NextResponse.next();
+    }
+  }
 
   /*
    * Playwright starts the dev server and requires a 200 status to


### PR DESCRIPTION
## Description

Adds a dedicated maintenance experience: a friendly, animated page at `/maintenance` and a **runtime** toggle so we can show it without rebuilding or redeploying.

### What’s included

- **Maintenance page (`/maintenance`)**
  - Optional copy overrides via env: `NEXT_PUBLIC_MAINTENANCE_MESSAGE`, `NEXT_PUBLIC_MAINTENANCE_ESTIMATED_END`.
  - Contact link uses existing `NEXT_PUBLIC_FEEDBACK_CONTACT_URL` when set.
  - Metadata: title, description, `noindex, nofollow`.

- **Runtime maintenance mode**
  - **`MAINTENANCE_MODE`** (server env, no `NEXT_PUBLIC_`): when `true` or `1`, the proxy redirects all traffic to `/maintenance` except that page, `/_next`, `/api`, and static assets. Intended for App Service (or any server env): set the variable and restart (no rebuild).
  - **Bypass:** `?nomaintenance=true` (or `=1`) on any URL skips the redirect so admins can still use the app during maintenance.

- **Proxy changes (`proxy.ts`)**
  - Maintenance check and redirect run first; bypass and path exclusions documented in code.

- **Sidebar fix (included in this branch)**
  - `SidebarMenuSkeleton`: replaced random width with fixed `70%` to avoid server/client mismatch and fix hydration error.

### How to enable maintenance

1. Set **`MAINTENANCE_MODE=true`** in App Service (or server env).
2. Restart the app (no new build required).
3. To bypass: open the app with **`?nomaintenance=true`** (e.g. `https://data360.worldbank.org/chat/?nomaintenance=true`).

### Files changed (vs `origin/dev`)

| Path | Change |
|------|--------|
| `frontend/app/maintenance/page.tsx` | **New** – maintenance page (AI theme, animations, env-driven copy). |
| `frontend/app/globals.css` | **Added** – maintenance keyframes and classes; `prefers-reduced-motion` disables animations. |
| `frontend/proxy.ts` | **Added** – `MAINTENANCE_MODE` + redirect, `nomaintenance` bypass. |
| `frontend/components/ui/sidebar.tsx` | **Fixed** – skeleton width 70%. |

### Testing

- Without `MAINTENANCE_MODE`: visit `/maintenance` directly to see the page; rest of app unchanged.
- With `MAINTENANCE_MODE=true`: all routes redirect to `/maintenance` except `/maintenance`, `/_next`, `/api`, and paths with a dot; `?nomaintenance=true` bypasses redirect.
- Reduced motion: set OS “Reduce motion” and confirm animations are off on the maintenance page.
