### PR TITLE
feat: Feedback review dashboard for designated reviewers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -82,3 +82,6 @@ LOG_FILE=logs/chatbot.log
 # AZURE_AD_CLIENT_ID=<client-id>
 # # AZURE_AD_VALID_AUDIENCES=
 # AZURE_AD_SKIP_SIGNATURE_VERIFY=true  # Must be set to false in prod
+
+#
+# FEEDBACK_REVIEWER_EMAILS=<comma-separated list of allowed reviewers>

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -331,3 +331,56 @@ async def get_optional_user(
             e.detail,
         )
         return None
+
+
+async def require_feedback_reviewer(
+    current_user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Require authenticated user whose email is in FEEDBACK_REVIEWER_EMAILS.
+    Use for feedback review/list endpoints. Raises 403 if not allowed.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    allowed_raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
+    allowed = [e.strip().lower() for e in allowed_raw.split(",") if e.strip()]
+    if not allowed:
+        logger.warning("require_feedback_reviewer: FEEDBACK_REVIEWER_EMAILS is empty")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Feedback review is not configured or access is disabled",
+        )
+    user_id_str = current_user.get("id")
+    if not user_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User ID not found",
+        )
+    try:
+        user_uuid = UUID(user_id_str)
+    except (ValueError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid user ID",
+        )
+    user = await get_user_by_id(db, user_uuid)
+    if not user or not getattr(user, "email", None):
+        logger.warning(
+            "require_feedback_reviewer: user not found or no email, user_id=%s", user_id_str
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to view feedback",
+        )
+    if user.email.strip().lower() not in allowed:
+        logger.info(
+            "require_feedback_reviewer: email not in allowlist, user_id=%s",
+            user_id_str,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to view feedback",
+        )
+    return current_user

--- a/backend/app/api/v1/feedback.py
+++ b/backend/app/api/v1/feedback.py
@@ -1,18 +1,44 @@
-"""App-level feedback (rating + free text)."""
+"""App-level feedback (rating + free text) and response-level votes/feedback review."""
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import nulls_last
 
-from app.api.deps import get_optional_user
+from app.api.deps import get_optional_user, require_feedback_reviewer
 from app.core.database import get_db
+from app.core.errors import ChatSDKError
+from app.db.queries.chat_queries import get_chat_by_id, get_messages_by_chat_id
 from app.models.app_feedback import AppFeedback
+from app.models.chat import Chat
+from app.models.message import Message
+from app.models.vote import Vote
 
 logger = logging.getLogger(__name__)
+
+MESSAGE_PREVIEW_MAX_LEN = 280
+
+
+def _message_preview_from_parts(parts: Any) -> str:
+    """Extract first text content from message parts (JSON list of {type, text?}) and truncate."""
+    if not parts or not isinstance(parts, list):
+        return ""
+    text_parts = []
+    for p in parts:
+        if isinstance(p, dict) and p.get("type") == "text":
+            t = p.get("text")
+            if isinstance(t, str) and t.strip():
+                text_parts.append(t.strip())
+    combined = " ".join(text_parts)
+    if len(combined) <= MESSAGE_PREVIEW_MAX_LEN:
+        return combined
+    return combined[: MESSAGE_PREVIEW_MAX_LEN - 3].rstrip() + "..."
+
 
 router = APIRouter()
 
@@ -58,3 +84,202 @@ async def submit_app_feedback(
         user_id,
     )
     return {"ok": True}
+
+
+class FeedbackReviewItem(BaseModel):
+    """Single feedback row for review list."""
+
+    id: UUID
+    rating: int
+    feedback: Optional[str]
+    user_id: Optional[UUID]
+    created_at: str  # ISO format
+
+
+class FeedbackReviewResponse(BaseModel):
+    """Paginated list of feedback for reviewers."""
+
+    items: list[FeedbackReviewItem]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.get("/review", response_model=FeedbackReviewResponse)
+async def list_feedback_for_review(
+    _reviewer: dict = Depends(require_feedback_reviewer),
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    rating_min: Optional[int] = Query(None, ge=1, le=5),
+    rating_max: Optional[int] = Query(None, ge=1, le=5),
+):
+    """
+    List app feedback (paginated). Only allowed for users in FEEDBACK_REVIEWER_EMAILS.
+    """
+    # Count total
+    count_q = select(func.count()).select_from(AppFeedback)
+    if rating_min is not None:
+        count_q = count_q.where(AppFeedback.rating >= rating_min)
+    if rating_max is not None:
+        count_q = count_q.where(AppFeedback.rating <= rating_max)
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    # Fetch page
+    q = select(AppFeedback).order_by(desc(AppFeedback.created_at)).limit(limit).offset(offset)
+    if rating_min is not None:
+        q = q.where(AppFeedback.rating >= rating_min)
+    if rating_max is not None:
+        q = q.where(AppFeedback.rating <= rating_max)
+    result = await db.execute(q)
+    rows = result.scalars().all()
+
+    items = [
+        FeedbackReviewItem(
+            id=row.id,
+            rating=row.rating,
+            feedback=row.feedback,
+            user_id=row.user_id,
+            created_at=row.created_at.isoformat() if row.created_at else "",
+        )
+        for row in rows
+    ]
+    return FeedbackReviewResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+# --- Response-level (vote/comment) review ---
+
+
+class VoteReviewItem(BaseModel):
+    """Single response vote/feedback row for reviewers."""
+
+    chat_id: UUID
+    message_id: UUID
+    chat_title: str
+    message_preview: str
+    is_upvoted: Optional[bool]
+    feedback: Optional[str]
+    updated_at: str
+    feedback_updated_at: Optional[str]
+
+
+class VoteReviewResponse(BaseModel):
+    """Paginated list of response votes/feedback for reviewers."""
+
+    items: list[VoteReviewItem]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.get("/review/votes", response_model=VoteReviewResponse)
+async def list_votes_for_review(
+    _reviewer: dict = Depends(require_feedback_reviewer),
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    has_feedback: Optional[bool] = Query(None, description="Only entries with comment text"),
+):
+    """
+    List response-level votes and comments (paginated). Only for users in FEEDBACK_REVIEWER_EMAILS.
+    Includes chat title and message preview for context.
+    """
+    # Votes that have either a vote (up/down) or feedback text
+    base_filter = or_(Vote.feedback.isnot(None), Vote.isUpvoted.isnot(None))
+    if has_feedback is True:
+        base_filter = Vote.feedback.isnot(None)
+    elif has_feedback is False:
+        base_filter = Vote.feedback.is_(None) & Vote.isUpvoted.isnot(None)
+
+    count_q = select(func.count()).select_from(Vote).where(base_filter)
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    # Join Vote -> Message, Vote -> Chat; order by most recent (feedbackUpdatedAt or updatedAt)
+    q = (
+        select(Vote, Chat.title, Message.parts)
+        .join(Chat, Vote.chatId == Chat.id)
+        .join(Message, (Vote.messageId == Message.id) & (Vote.chatId == Message.chatId))
+        .where(base_filter)
+        .order_by(
+            nulls_last(desc(Vote.feedbackUpdatedAt)),
+            desc(Vote.updatedAt),
+        )
+        .limit(limit)
+        .offset(offset)
+    )
+    result = await db.execute(q)
+    rows = result.all()
+
+    items = []
+    for vote, chat_title, parts in rows:
+        updated_at = vote.feedbackUpdatedAt or vote.updatedAt or vote.createdAt
+        items.append(
+            VoteReviewItem(
+                chat_id=vote.chatId,
+                message_id=vote.messageId,
+                chat_title=chat_title or "",
+                message_preview=_message_preview_from_parts(parts),
+                is_upvoted=vote.isUpvoted,
+                feedback=vote.feedback,
+                updated_at=updated_at.isoformat() if updated_at else "",
+                feedback_updated_at=(
+                    vote.feedbackUpdatedAt.isoformat() if vote.feedbackUpdatedAt else None
+                ),
+            )
+        )
+    return VoteReviewResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+# --- Chat preview for reviewers (side panel) ---
+
+# ruff: noqa: N815
+
+
+class ChatPreviewMessage(BaseModel):
+    """Message in chat preview (same shape as frontend expects)."""
+
+    id: str
+    chatId: str
+    role: str
+    parts: list[Any]
+    attachments: list[Any]
+    createdAt: str
+
+
+class ChatPreviewResponse(BaseModel):
+    """Chat title and messages for the review side panel."""
+
+    title: str
+    messages: list[ChatPreviewMessage]
+
+
+@router.get("/review/preview", response_model=ChatPreviewResponse)
+async def get_chat_preview_for_review(
+    chat_id: UUID = Query(..., description="Chat to preview"),
+    _reviewer: dict = Depends(require_feedback_reviewer),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Get chat title and all messages for a chat. For reviewers only.
+    Used by the feedback review page to show the conversation in a side panel.
+    """
+    chat = await get_chat_by_id(db, chat_id)
+    if not chat:
+        raise ChatSDKError("not_found:chat", status_code=status.HTTP_404_NOT_FOUND)
+    messages = await get_messages_by_chat_id(db, chat_id)
+    return ChatPreviewResponse(
+        title=chat.title or "Untitled chat",
+        messages=[
+            ChatPreviewMessage(
+                id=str(m.id),
+                chatId=str(m.chatId),
+                role=m.role,
+                parts=m.parts or [],
+                attachments=m.attachments or [],
+                createdAt=m.createdAt.isoformat() if m.createdAt else "",
+            )
+            for m in messages
+        ],
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -137,6 +137,10 @@ class Settings(BaseSettings):
     # Password Security
     ENABLE_HIBP_CHECK: bool = False  # Enable Have I Been Pwned password checking
 
+    # Feedback review: only these users (by email) can list feedback. Comma-separated, case-insensitive.
+    # Empty = no one can access review; set in production to e.g. "admin@example.com,reviewer@example.com"
+    FEEDBACK_REVIEWER_EMAILS: str = ""
+
     @field_validator("CORS_ORIGINS", mode="before")
     @classmethod
     def parse_cors_origins(cls, v: Union[str, List[str]]) -> List[str]:

--- a/backend/app/core/auth/azure.py
+++ b/backend/app/core/auth/azure.py
@@ -236,9 +236,19 @@ def validate_azure_access_token(token: str) -> Optional[dict[str, Any]]:
             return None
         except jwt.InvalidTokenError as e:
             last_error = e
+            logger.debug(
+                "Azure AD token validation failed for JWKS endpoint %s: %s",
+                label,
+                e,
+            )
             continue
         except Exception as e:
             last_error = e
+            logger.warning(
+                "Azure AD token validation raised unexpected error for JWKS endpoint %s: %s",
+                label,
+                e,
+            )
             continue
 
     _log_token_claims_for_debug(token)

--- a/frontend/app/review/feedback/page.tsx
+++ b/frontend/app/review/feedback/page.tsx
@@ -1,0 +1,910 @@
+"use client";
+
+/**
+ * Feedback review page. Only users listed in FEEDBACK_REVIEWER_EMAILS can access.
+ * Route: /review/feedback
+ */
+
+import {
+  AlertCircle,
+  ArrowLeft,
+  Lock,
+  MessageCircle,
+  MessageSquare,
+  Star,
+  ThumbsDown,
+  ThumbsUp,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { PreviewMessage } from "@/components/message";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { apiFetch, getApiUrl } from "@/lib/api-client";
+import type { Vote } from "@/lib/db/schema";
+import type { ChatMessage } from "@/lib/types";
+
+type FeedbackItem = {
+  id: string;
+  rating: number;
+  feedback: string | null;
+  user_id: string | null;
+  created_at: string;
+};
+
+type ReviewResponse = {
+  items: FeedbackItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+type VoteReviewItem = {
+  chat_id: string;
+  message_id: string;
+  chat_title: string;
+  message_preview: string;
+  is_upvoted: boolean | null;
+  feedback: string | null;
+  updated_at: string;
+  feedback_updated_at: string | null;
+};
+
+type VoteReviewResponse = {
+  items: VoteReviewItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+type TabKind = "app" | "response";
+
+type ChatPreviewMessage = {
+  id: string;
+  chatId: string;
+  role: string;
+  parts: Array<{ type?: string; text?: string }>;
+  attachments: unknown[];
+  createdAt: string;
+};
+
+type ChatPreviewResponse = {
+  title: string;
+  messages: ChatPreviewMessage[];
+};
+
+const PAGE_SIZE = 25;
+
+function Stars({ rating }: { rating: number }) {
+  return (
+    <span
+      className="flex items-center gap-0.5"
+      role="img"
+      aria-label={`${rating} out of 5 stars`}
+    >
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Star
+          key={i}
+          className={`h-4 w-4 ${
+            i <= rating
+              ? "fill-amber-400 text-amber-400"
+              : "fill-transparent text-muted-foreground/40"
+          }`}
+          aria-hidden
+        />
+      ))}
+    </span>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export default function FeedbackReviewPage() {
+  const [tab, setTab] = useState<TabKind>("app");
+  const [data, setData] = useState<ReviewResponse | null>(null);
+  const [status, setStatus] = useState<
+    "loading" | "ok" | "forbidden" | "unauthorized" | "error"
+  >("loading");
+  const [offset, setOffset] = useState(0);
+  const [ratingFilter, setRatingFilter] = useState<number | "all">("all");
+  const ratingFilterId = useId();
+  const tabAppId = useId();
+  const tabResponseId = useId();
+  const panelAppId = useId();
+  const panelResponseId = useId();
+
+  const [voteData, setVoteData] = useState<VoteReviewResponse | null>(null);
+  const [voteLoading, setVoteLoading] = useState(false);
+  const [voteOffset, setVoteOffset] = useState(0);
+  const [voteHasFeedback, setVoteHasFeedback] = useState<
+    "all" | "comments_only" | "votes_only"
+  >("all");
+  const voteFilterId = useId();
+
+  const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
+  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
+    null,
+  );
+  const [selectedFeedback, setSelectedFeedback] =
+    useState<VoteReviewItem | null>(null);
+  const [previewData, setPreviewData] = useState<ChatPreviewResponse | null>(
+    null,
+  );
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const previewScrollRef = useRef<HTMLDivElement>(null);
+
+  const PREVIEW_PANEL_MIN = 280;
+  const PREVIEW_PANEL_MAX = 640;
+  const PREVIEW_PANEL_DEFAULT = 448; // 28rem
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(
+    PREVIEW_PANEL_DEFAULT,
+  );
+  const [isResizingPreview, setIsResizingPreview] = useState(false);
+  const resizeStartXRef = useRef(0);
+  const resizeStartWidthRef = useRef(PREVIEW_PANEL_DEFAULT);
+
+  const handlePreviewResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsResizingPreview(true);
+      resizeStartXRef.current = e.clientX;
+      resizeStartWidthRef.current = previewPanelWidth;
+    },
+    [previewPanelWidth],
+  );
+
+  useEffect(() => {
+    if (!isResizingPreview) return;
+    const onMove = (e: MouseEvent) => {
+      const delta = resizeStartXRef.current - e.clientX; // drag left = panel wider
+      const next = Math.min(
+        PREVIEW_PANEL_MAX,
+        Math.max(PREVIEW_PANEL_MIN, resizeStartWidthRef.current + delta),
+      );
+      setPreviewPanelWidth(next);
+    };
+    const onUp = () => setIsResizingPreview(false);
+    const prevCursor = document.body.style.cursor;
+    const prevUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevUserSelect;
+    };
+  }, [isResizingPreview]);
+
+  const fetchReview = useCallback(async () => {
+    setStatus("loading");
+    const params = new URLSearchParams();
+    params.set("limit", String(PAGE_SIZE));
+    params.set("offset", String(offset));
+    if (ratingFilter !== "all") {
+      params.set("rating_min", String(ratingFilter));
+      params.set("rating_max", String(ratingFilter));
+    }
+    const url = getApiUrl(`/api/feedback/review?${params.toString()}`);
+    const res = await apiFetch(url);
+    if (res.status === 401) {
+      setStatus("unauthorized");
+      return;
+    }
+    if (res.status === 403) {
+      setStatus("forbidden");
+      return;
+    }
+    if (!res.ok) {
+      setStatus("error");
+      return;
+    }
+    const json = (await res.json()) as ReviewResponse;
+    setData(json);
+    setStatus("ok");
+  }, [offset, ratingFilter]);
+
+  const fetchVotes = useCallback(async () => {
+    setVoteLoading(true);
+    const params = new URLSearchParams();
+    params.set("limit", String(PAGE_SIZE));
+    params.set("offset", String(voteOffset));
+    if (voteHasFeedback === "comments_only") params.set("has_feedback", "true");
+    if (voteHasFeedback === "votes_only") params.set("has_feedback", "false");
+    const url = getApiUrl(`/api/feedback/review/votes?${params.toString()}`);
+    const res = await apiFetch(url);
+    setVoteLoading(false);
+    if (!res.ok) return;
+    const json = (await res.json()) as VoteReviewResponse;
+    setVoteData(json);
+  }, [voteOffset, voteHasFeedback]);
+
+  useEffect(() => {
+    fetchReview();
+  }, [fetchReview]);
+
+  useEffect(() => {
+    if (status === "ok" && tab === "response") {
+      fetchVotes();
+    }
+  }, [status, tab, fetchVotes]);
+
+  const fetchPreview = useCallback(async (chatId: string) => {
+    setPreviewLoading(true);
+    setPreviewData(null);
+    const url = getApiUrl(
+      `/api/feedback/review/preview?chat_id=${encodeURIComponent(chatId)}`,
+    );
+    const res = await apiFetch(url);
+    setPreviewLoading(false);
+    if (!res.ok) return;
+    const json = (await res.json()) as ChatPreviewResponse;
+    setPreviewData(json);
+  }, []);
+
+  useEffect(() => {
+    if (selectedChatId) {
+      fetchPreview(selectedChatId);
+    } else {
+      setPreviewData(null);
+    }
+  }, [selectedChatId, fetchPreview]);
+
+  useEffect(() => {
+    if (
+      !previewData?.messages.length ||
+      !selectedMessageId ||
+      !previewScrollRef.current
+    )
+      return;
+    const el = document.getElementById(`preview-msg-${selectedMessageId}`);
+    el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [previewData, selectedMessageId]);
+
+  const openPreview = useCallback(
+    (chatId: string, messageId: string, feedbackItem?: VoteReviewItem) => {
+      setSelectedChatId(chatId);
+      setSelectedMessageId(messageId);
+      setSelectedFeedback(feedbackItem ?? null);
+    },
+    [],
+  );
+
+  const closePreview = useCallback(() => {
+    setSelectedChatId(null);
+    setSelectedMessageId(null);
+    setSelectedFeedback(null);
+    setPreviewData(null);
+  }, []);
+
+  const totalPages = data ? Math.ceil(data.total / data.limit) : 0;
+  const currentPage = data ? Math.floor(offset / data.limit) + 1 : 0;
+
+  const showPreviewPanel =
+    status === "ok" && tab === "response" && selectedChatId !== null;
+
+  return (
+    <main className="min-h-dvh bg-background">
+      <div
+        className={`w-full gap-0 px-4 py-8 ${showPreviewPanel ? "lg:grid" : ""}`}
+        style={
+          showPreviewPanel
+            ? { gridTemplateColumns: `minmax(0,1fr) ${previewPanelWidth}px` }
+            : undefined
+        }
+      >
+        <div
+          className={
+            status === "ok"
+              ? `mx-auto flex min-h-0 max-h-[calc(100dvh-var(--header-height,0)-2rem)] max-w-4xl flex-col overflow-hidden ${showPreviewPanel ? "min-w-0 lg:col-start-1 lg:row-start-1" : ""}`
+              : "mx-auto max-w-4xl"
+          }
+        >
+          <div className="mb-6 flex shrink-0 items-center gap-4">
+            <Button
+              variant="ghost"
+              size="icon"
+              asChild
+              aria-label="Back to chat"
+            >
+              <Link href="/">
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+            </Button>
+            <div className="flex-1">
+              <h1 className="font-semibold text-2xl tracking-tight text-foreground">
+                Feedback review
+              </h1>
+              <p className="text-muted-foreground text-sm">
+                User ratings and comments. Only authorized reviewers can view
+                this page.
+              </p>
+            </div>
+          </div>
+
+          <div
+            className={
+              status === "ok"
+                ? "min-h-0 flex-1 overflow-y-auto pb-4"
+                : undefined
+            }
+          >
+            {status === "loading" && (
+              <Card>
+                <CardContent className="flex items-center justify-center py-16">
+                  <p className="text-muted-foreground text-sm">
+                    Loading feedback…
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+
+            {status === "unauthorized" && (
+              <Card className="border-amber-200 dark:border-amber-900/50">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 font-semibold text-lg">
+                    <AlertCircle
+                      className="h-5 w-5 text-amber-600"
+                      aria-hidden
+                    />
+                    Sign in required
+                  </CardTitle>
+                  <CardDescription>
+                    You need to be signed in to view feedback. Please log in and
+                    try again.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button asChild>
+                    <Link href="/login">Go to login</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            {status === "forbidden" && (
+              <Card className="border-muted">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 font-semibold text-lg">
+                    <Lock
+                      className="h-5 w-5 text-muted-foreground"
+                      aria-hidden
+                    />
+                    Access denied
+                  </CardTitle>
+                  <CardDescription>
+                    You don’t have permission to view feedback. Access is
+                    limited to designated reviewers.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button variant="outline" asChild>
+                    <Link href="/">Back to chat</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            {status === "error" && (
+              <Card className="border-destructive/50">
+                <CardHeader>
+                  <CardTitle className="font-semibold text-lg text-destructive">
+                    Something went wrong
+                  </CardTitle>
+                  <CardDescription>
+                    We couldn’t load feedback. Please try again later.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button variant="outline" onClick={() => fetchReview()}>
+                    Retry
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            {status === "ok" && data && (
+              <>
+                <div
+                  className="mb-4 flex flex-wrap items-center gap-2 border-b border-border pb-3"
+                  role="tablist"
+                  aria-label="Feedback type"
+                >
+                  <Button
+                    type="button"
+                    variant={tab === "app" ? "secondary" : "ghost"}
+                    size="sm"
+                    onClick={() => setTab("app")}
+                    role="tab"
+                    aria-selected={tab === "app"}
+                    aria-controls={panelAppId}
+                    id={tabAppId}
+                  >
+                    <Star className="mr-1.5 h-4 w-4" aria-hidden />
+                    App feedback
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={tab === "response" ? "secondary" : "ghost"}
+                    size="sm"
+                    onClick={() => setTab("response")}
+                    role="tab"
+                    aria-selected={tab === "response"}
+                    aria-controls={panelResponseId}
+                    id={tabResponseId}
+                  >
+                    <MessageCircle className="mr-1.5 h-4 w-4" aria-hidden />
+                    Response feedback
+                  </Button>
+                </div>
+
+                {tab === "app" && (
+                  <div
+                    id={panelAppId}
+                    role="tabpanel"
+                    aria-labelledby={tabAppId}
+                    className="space-y-4"
+                  >
+                    <div className="flex flex-wrap items-center gap-3">
+                      <label
+                        htmlFor={ratingFilterId}
+                        className="text-muted-foreground text-sm"
+                      >
+                        Filter by rating:
+                      </label>
+                      <select
+                        id={ratingFilterId}
+                        className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        value={ratingFilter}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          setRatingFilter(
+                            v === "all" ? "all" : Number.parseInt(v, 10),
+                          );
+                          setOffset(0);
+                        }}
+                        aria-label="Filter by star rating"
+                      >
+                        <option value="all">All ratings</option>
+                        {[5, 4, 3, 2, 1].map((r) => (
+                          <option key={r} value={r}>
+                            {r} star{r !== 1 ? "s" : ""}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="text-muted-foreground text-sm">
+                        {data.total} total · page {currentPage} of{" "}
+                        {totalPages || 1}
+                      </span>
+                    </div>
+
+                    <ul className="space-y-4">
+                      {data.items.length === 0 ? (
+                        <Card>
+                          <CardContent className="py-12 text-center">
+                            <MessageSquare
+                              className="mx-auto mb-2 h-10 w-10 text-muted-foreground/60"
+                              aria-hidden
+                            />
+                            <p className="text-muted-foreground text-sm">
+                              No feedback yet.
+                            </p>
+                          </CardContent>
+                        </Card>
+                      ) : (
+                        data.items.map((item) => (
+                          <li key={item.id}>
+                            <Card className="overflow-hidden">
+                              <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0 pb-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <Stars rating={item.rating} />
+                                  <span className="text-muted-foreground text-xs">
+                                    {formatDate(item.created_at)}
+                                  </span>
+                                  <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-muted-foreground text-xs">
+                                    {item.user_id
+                                      ? "Logged-in user"
+                                      : "Anonymous"}
+                                  </span>
+                                </div>
+                              </CardHeader>
+                              {item.feedback?.trim() ? (
+                                <CardContent className="pt-0">
+                                  <p className="whitespace-pre-wrap text-foreground text-sm">
+                                    {item.feedback}
+                                  </p>
+                                </CardContent>
+                              ) : null}
+                            </Card>
+                          </li>
+                        ))
+                      )}
+                    </ul>
+
+                    {data.items.length > 0 && totalPages > 1 && (
+                      <nav
+                        className="mt-6 flex items-center justify-between"
+                        aria-label="App feedback pagination"
+                      >
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={offset === 0}
+                          onClick={() =>
+                            setOffset((o) => Math.max(0, o - PAGE_SIZE))
+                          }
+                        >
+                          Previous
+                        </Button>
+                        <span className="text-muted-foreground text-sm">
+                          Page {currentPage} of {totalPages}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={offset + data.items.length >= data.total}
+                          onClick={() => setOffset((o) => o + PAGE_SIZE)}
+                        >
+                          Next
+                        </Button>
+                      </nav>
+                    )}
+                  </div>
+                )}
+
+                {tab === "response" && (
+                  <div
+                    id={panelResponseId}
+                    role="tabpanel"
+                    aria-labelledby={tabResponseId}
+                    className="space-y-4"
+                  >
+                    <div className="flex flex-wrap items-center gap-3">
+                      <label
+                        htmlFor={voteFilterId}
+                        className="text-muted-foreground text-sm"
+                      >
+                        Filter:
+                      </label>
+                      <select
+                        id={voteFilterId}
+                        className="rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        value={voteHasFeedback}
+                        onChange={(e) => {
+                          const v = e.target.value as typeof voteHasFeedback;
+                          setVoteHasFeedback(v);
+                          setVoteOffset(0);
+                        }}
+                        aria-label="Filter response feedback"
+                      >
+                        <option value="all">All (votes and comments)</option>
+                        <option value="comments_only">
+                          With comment text only
+                        </option>
+                        <option value="votes_only">
+                          Vote only (no comment)
+                        </option>
+                      </select>
+                      {voteData ? (
+                        <span className="text-muted-foreground text-sm">
+                          {voteData.total} total · page{" "}
+                          {Math.floor(voteOffset / PAGE_SIZE) + 1} of{" "}
+                          {Math.ceil(voteData.total / voteData.limit) || 1}
+                        </span>
+                      ) : null}
+                    </div>
+
+                    {voteLoading ? (
+                      <Card>
+                        <CardContent className="flex items-center justify-center py-16">
+                          <p className="text-muted-foreground text-sm">
+                            Loading response feedback…
+                          </p>
+                        </CardContent>
+                      </Card>
+                    ) : voteData?.items.length === 0 ? (
+                      <Card>
+                        <CardContent className="py-12 text-center">
+                          <MessageCircle
+                            className="mx-auto mb-2 h-10 w-10 text-muted-foreground/60"
+                            aria-hidden
+                          />
+                          <p className="text-muted-foreground text-sm">
+                            No response feedback yet.
+                          </p>
+                        </CardContent>
+                      </Card>
+                    ) : (
+                      <ul className="space-y-4">
+                        {voteData?.items.map((item) => (
+                          <li key={`${item.chat_id}-${item.message_id}`}>
+                            <Card className="overflow-hidden">
+                              <CardHeader className="space-y-0 pb-2">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  {item.is_upvoted === true ? (
+                                    <span
+                                      className="flex items-center gap-1 rounded bg-green-500/15 px-1.5 py-0.5 text-green-700 text-xs dark:text-green-400"
+                                      role="img"
+                                      aria-label="Upvoted"
+                                    >
+                                      <ThumbsUp
+                                        className="h-3.5 w-3.5"
+                                        aria-hidden
+                                      />
+                                      Helpful
+                                    </span>
+                                  ) : item.is_upvoted === false ? (
+                                    <span
+                                      className="flex items-center gap-1 rounded bg-red-500/15 px-1.5 py-0.5 text-red-700 text-xs dark:text-red-400"
+                                      role="img"
+                                      aria-label="Downvoted"
+                                    >
+                                      <ThumbsDown
+                                        className="h-3.5 w-3.5"
+                                        aria-hidden
+                                      />
+                                      Not helpful
+                                    </span>
+                                  ) : null}
+                                  <span className="text-muted-foreground text-xs">
+                                    {formatDate(
+                                      item.feedback_updated_at ??
+                                        item.updated_at,
+                                    )}
+                                  </span>
+                                </div>
+                                <CardTitle className="font-medium text-base">
+                                  <Link
+                                    href={`/chat/${item.chat_id}`}
+                                    className="text-primary underline-offset-4 hover:underline"
+                                  >
+                                    {item.chat_title || "Untitled chat"}
+                                  </Link>
+                                </CardTitle>
+                                {item.message_preview ? (
+                                  <CardDescription className="line-clamp-2 pt-1 font-normal text-foreground/80">
+                                    {item.message_preview}
+                                  </CardDescription>
+                                ) : null}
+                              </CardHeader>
+                              {item.feedback?.trim() ? (
+                                <CardContent className="pt-0">
+                                  <p className="whitespace-pre-wrap rounded bg-muted/50 p-3 text-foreground text-sm">
+                                    {item.feedback}
+                                  </p>
+                                </CardContent>
+                              ) : null}
+                              <CardContent className="pt-0">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    openPreview(
+                                      item.chat_id,
+                                      item.message_id,
+                                      item,
+                                    )
+                                  }
+                                >
+                                  View conversation
+                                </Button>
+                              </CardContent>
+                            </Card>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {voteData &&
+                      voteData.items.length > 0 &&
+                      voteData.total > PAGE_SIZE && (
+                        <nav
+                          className="mt-6 flex items-center justify-between"
+                          aria-label="Response feedback pagination"
+                        >
+                          <Button
+                            type="button"
+                            variant="outline"
+                            disabled={voteOffset === 0}
+                            onClick={() =>
+                              setVoteOffset((o) => Math.max(0, o - PAGE_SIZE))
+                            }
+                          >
+                            Previous
+                          </Button>
+                          <span className="text-muted-foreground text-sm">
+                            Page {Math.floor(voteOffset / PAGE_SIZE) + 1} of{" "}
+                            {Math.ceil(voteData.total / voteData.limit)}
+                          </span>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            disabled={
+                              voteOffset + voteData.items.length >=
+                              voteData.total
+                            }
+                            onClick={() => setVoteOffset((o) => o + PAGE_SIZE)}
+                          >
+                            Next
+                          </Button>
+                        </nav>
+                      )}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        {showPreviewPanel && (
+          <aside
+            ref={previewScrollRef}
+            className="relative sticky top-4 flex h-[calc(100dvh-var(--header-height,0)-3rem)] min-h-[20rem] flex-col overflow-hidden border-border bg-muted/30 lg:col-start-2 lg:row-start-1 lg:min-h-[24rem] lg:min-w-0 lg:border-l"
+            style={{ width: previewPanelWidth }}
+            aria-label="Chat preview"
+          >
+            <button
+              type="button"
+              aria-label="Resize chat preview panel"
+              className="absolute left-0 top-0 z-10 hidden h-full w-1.5 cursor-col-resize border-0 bg-transparent hover:bg-primary/20 lg:block"
+              style={{ transform: "translateX(-50%)" }}
+              onMouseDown={handlePreviewResizeStart}
+            />
+            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border bg-background px-4 py-3">
+              <h2 className="truncate font-semibold text-sm text-foreground">
+                {previewLoading
+                  ? "Loading…"
+                  : (previewData?.title ?? "Chat preview")}
+              </h2>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={closePreview}
+                aria-label="Close chat preview"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            {selectedFeedback ? (
+              <div className="shrink-0 border-b border-border bg-muted/50 px-4 py-2">
+                <p className="text-muted-foreground text-xs">
+                  Selected feedback
+                </p>
+                <div className="mt-1 flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ${
+                      selectedFeedback.is_upvoted === true
+                        ? "bg-green-500/15 text-green-700 dark:text-green-400"
+                        : selectedFeedback.is_upvoted === false
+                          ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+                          : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {selectedFeedback.is_upvoted === true ? (
+                      <ThumbsUp className="size-3" aria-hidden />
+                    ) : selectedFeedback.is_upvoted === false ? (
+                      <ThumbsDown className="size-3" aria-hidden />
+                    ) : null}
+                    {selectedFeedback.is_upvoted === true
+                      ? "Helpful"
+                      : selectedFeedback.is_upvoted === false
+                        ? "Not helpful"
+                        : "No vote"}
+                  </span>
+                  {selectedFeedback.feedback?.trim() ? (
+                    <span className="line-clamp-2 text-foreground text-xs">
+                      “{selectedFeedback.feedback.trim()}”
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+            <div className="min-h-0 flex-1 overflow-y-auto p-3">
+              {previewLoading ? (
+                <p className="py-8 text-center text-muted-foreground text-sm">
+                  Loading conversation…
+                </p>
+              ) : previewData?.messages.length ? (
+                <ul className="space-y-3">
+                  {previewData.messages.map((msg) => {
+                    const isTarget = msg.id === selectedMessageId;
+                    const message: ChatMessage = {
+                      id: msg.id,
+                      role: msg.role as "user" | "assistant" | "system",
+                      parts: msg.parts as ChatMessage["parts"],
+                    };
+                    const voteForMessage: Vote | undefined =
+                      isTarget && selectedFeedback && selectedChatId
+                        ? {
+                            chatId: selectedChatId,
+                            messageId: msg.id,
+                            isUpvoted: selectedFeedback.is_upvoted ?? false,
+                            feedback: selectedFeedback.feedback,
+                            createdAt: new Date(),
+                            updatedAt: new Date(),
+                            voteCreatedAt: null,
+                            voteUpdatedAt: null,
+                            feedbackCreatedAt: null,
+                            feedbackUpdatedAt: null,
+                          }
+                        : undefined;
+                    const noopSync = () => {};
+                    const noopAsync = async () => {};
+                    return (
+                      <li
+                        key={msg.id}
+                        id={`preview-msg-${msg.id}`}
+                        className={
+                          isTarget
+                            ? "rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background"
+                            : undefined
+                        }
+                      >
+                        <PreviewMessage
+                          chatId={selectedChatId ?? ""}
+                          message={message}
+                          vote={voteForMessage}
+                          isLoading={false}
+                          setMessages={noopSync}
+                          regenerate={noopAsync}
+                          isReadonly
+                          requiresScrollPadding={false}
+                        />
+                        {isTarget ? (
+                          <p className="mt-1 px-1 text-primary text-xs">
+                            ↑ Feedback on this message
+                          </p>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : previewData ? (
+                <p className="py-8 text-center text-muted-foreground text-sm">
+                  No messages in this chat.
+                </p>
+              ) : selectedChatId && !previewLoading ? (
+                <p className="py-8 text-center text-muted-foreground text-sm">
+                  Could not load conversation.
+                </p>
+              ) : null}
+            </div>
+            {previewData && selectedChatId ? (
+              <div className="shrink-0 border-t border-border bg-background px-4 py-2">
+                <Button variant="outline" size="sm" className="w-full" asChild>
+                  <Link
+                    href={`/chat/${selectedChatId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open full chat
+                  </Link>
+                </Button>
+              </div>
+            ) : null}
+          </aside>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/review/layout.tsx
+++ b/frontend/app/review/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { PcnProviderClient } from "@/components/data360/pcn-provider-client";
+import { appConfig } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: `Review | ${appConfig.metadata.title}`,
+  description: "Review and moderate user feedback. Access is restricted to designated reviewers.",
+  robots: "noindex, nofollow",
+};
+
+export default function ReviewLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return <PcnProviderClient>{children}</PcnProviderClient>;
+}

--- a/frontend/components/message-feedback.tsx
+++ b/frontend/components/message-feedback.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { useSWRConfig } from "swr";
 import { apiFetch } from "@/lib/api-client";
@@ -139,7 +139,7 @@ export function MessageFeedback({
 
       toast.success("Thank you! Your feedback has been submitted.");
       onOpenChange(false);
-    } catch (error) {
+    } catch {
       toast.error("Failed to submit feedback. Please try again.");
     } finally {
       setIsSubmitting(false);
@@ -156,55 +156,59 @@ export function MessageFeedback({
   const characterCount = feedback.length;
   const isNearLimit = characterCount > MAX_FEEDBACK_LENGTH * 0.9;
   const hasFeedback = feedback.trim().length > 0;
+  const feedbackTextareaId = useId();
 
   return (
     <Sheet onOpenChange={onOpenChange} open={open}>
       <SheetContent
-        className="left-1/2 top-1/2 max-h-[85vh] w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border sm:max-h-[80vh] data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        className="left-1/2 top-1/2 flex max-h-[85vh] w-[calc(100vw-2rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border p-4 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:max-h-[80vh] sm:p-6"
         side="bottom"
       >
-        <div className="mx-auto flex w-full max-w-xl flex-1 flex-col overflow-hidden">
-          <SheetHeader className="pb-4 text-left">
-            <SheetTitle className="text-xl">Feedback on AI Response</SheetTitle>
-            <SheetDescription className="text-base">
+        <div className="mx-auto flex min-h-0 w-full max-w-xl flex-1 flex-col overflow-hidden">
+          <SheetHeader className="shrink-0 pb-4 text-left">
+            <SheetTitle className="text-lg sm:text-xl">Feedback on AI Response</SheetTitle>
+            <SheetDescription className="text-sm sm:text-base">
               Help us improve by sharing your thoughts about this AI response.
               What did you find helpful? What could be better? Your feedback
               helps us enhance future responses.
             </SheetDescription>
           </SheetHeader>
 
-          <div className="flex flex-1 flex-col gap-3 overflow-hidden">
-            <div className="flex flex-col gap-2">
-              <Label
-                className="text-sm font-medium text-foreground"
-                htmlFor="feedback-textarea"
-              >
-                Your Feedback
-              </Label>
-              <div className="relative flex-1">
-                <Textarea
-                  autoFocus
-                  className="min-h-[180px] resize-none text-base leading-relaxed sm:min-h-[200px]"
-                  id="feedback-textarea"
-                  onChange={handleFeedbackChange}
-                  placeholder="For example:&#10;&#10;• What did you find helpful about this response?&#10;• What could be improved or clarified?&#10;• Any specific suggestions for better responses?"
-                  value={feedback}
-                />
-                <div
-                  className={`mt-2 flex items-center justify-end text-xs ${
-                    isNearLimit ? "text-destructive" : "text-muted-foreground"
-                  }`}
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-2">
+                <Label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor={feedbackTextareaId}
                 >
-                  <span>
-                    {characterCount} / {MAX_FEEDBACK_LENGTH}
-                  </span>
+                  Your Feedback
+                </Label>
+                <div className="relative">
+                  <Textarea
+                    autoFocus
+                    className="min-h-[120px] resize-none text-base leading-relaxed sm:min-h-[180px]"
+                    id={feedbackTextareaId}
+                    onChange={handleFeedbackChange}
+                    placeholder="For example:&#10;&#10;• What did you find helpful about this response?&#10;• What could be improved or clarified?&#10;• Any specific suggestions for better responses?"
+                    value={feedback}
+                  />
+                  <div
+                    className={`mt-2 flex items-center justify-end text-xs ${
+                      isNearLimit ? "text-destructive" : "text-muted-foreground"
+                    }`}
+                  >
+                    <span>
+                      {characterCount} / {MAX_FEEDBACK_LENGTH}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
 
-          <SheetFooter className="gap-2 border-t pt-4 sm:gap-3">
+          <SheetFooter className="mt-4 shrink-0 flex-wrap gap-2 border-t pt-4 sm:gap-3">
             <Button
+              className="w-full sm:w-auto"
               disabled={isSubmitting}
               onClick={() => onOpenChange(false)}
               type="button"
@@ -213,6 +217,7 @@ export function MessageFeedback({
               Cancel
             </Button>
             <Button
+              className="w-full sm:w-auto"
               disabled={isSubmitting || !hasFeedback}
               onClick={handleSubmit}
               type="button"


### PR DESCRIPTION
## Summary

Adds a reviewer-only feedback dashboard at `/review/feedback` so designated users can view and triage app-level and response-level feedback. Includes chat preview in a resizable side panel, scrollable lists, and responsive fixes for the in-chat feedback modal.

**Base branch:** `origin/feat/implement-msal-auth`

---

## Backend

- **Config:** `FEEDBACK_REVIEWER_EMAILS` (comma-separated, case-insensitive) in `backend/app/config.py` to restrict review access.
- **Auth:** `require_feedback_reviewer` in `backend/app/api/deps.py`; returns 403 when the current user is not in the list.
- **APIs (reviewers only):**
  - `GET /api/feedback/review` — Paginated app feedback (rating, feedback text, user_id, created_at) with optional `rating_min` / `rating_max`.
  - `GET /api/feedback/review/votes` — Paginated response-level votes/feedback (chat_id, message_id, chat_title, message_preview, is_upvoted, feedback, dates) with optional `has_feedback` filter.
  - `GET /api/feedback/review/preview?chat_id=<uuid>` — Chat title and messages for the side-panel preview.

---

## Frontend – Review page (`/review/feedback`)

- **Tabs:** “App feedback” (star ratings + optional text) and “Response feedback” (votes/comments with “View conversation”).
- **Chat preview panel (when a response feedback item is selected):**
  - Right-hand panel (or below on small screens) with chat title, **selected feedback hint** (Helpful / Not helpful / No vote + optional comment snippet), and conversation thread.
  - Messages rendered with shared **PreviewMessage** (markdown, tools, etc.); the message that received feedback is highlighted with “↑ Feedback on this message.”
  - **Resizable width** (drag handle on left edge; min 280px, max 640px).
  - **Scrollable** content; height uses `calc(100dvh - var(--header-height,0) - 3rem)` so the external header and grid padding are accounted for and the bottom is not truncated.
- **Left column:** Scrollable feedback list (with and without preview open); bottom padding; pagination (25 per page) for both tabs.
- **Review layout:** Wrapped in `PcnProviderClient` so `<claim>` content in preview messages works (ClaimsProvider required).

---

## Frontend – Feedback submission modal

- **Responsive behavior** so the “Feedback on AI Response” panel works on small screens:
  - Panel width `calc(100vw - 2rem)` with `max-w-2xl`; responsive padding `p-4 sm:p-6`.
  - Scrollable form area when space is limited (e.g. short viewport or keyboard open).
  - Smaller textarea min-height on mobile; title/description font sizes scale down.
  - Full-width stacked Cancel / Submit buttons on small screens.
- **A11y / lint:** Label/textarea linked via `useId()`; unused `catch` variable removed.

---

## Testing

- As a user **not** in `FEEDBACK_REVIEWER_EMAILS`: access to `/review/feedback` returns 403; review API calls return 403.
- As a user **in** the list: can open the page, switch tabs, paginate, open chat preview, resize the panel, scroll the list and the preview, and see the feedback hint and correct message highlight.
- Feedback modal: verify on a narrow viewport that the panel doesn’t overflow, content scrolls, and buttons remain usable.