### PR TITLE
fix: Token usage from lastContext, async MSAL, routing/prompts, and caching

### DIFF
--- a/backend/app/ai/observability/token_usage.py
+++ b/backend/app/ai/observability/token_usage.py
@@ -1,11 +1,14 @@
 # ruff: noqa: N815
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Optional
 
 from litellm import get_model_info
 from pydantic import BaseModel, ConfigDict, NonNegativeFloat, NonNegativeInt
+
+logger = logging.getLogger(__name__)
 
 
 class CostUSD(BaseModel):
@@ -164,15 +167,37 @@ class Prices:
     cache_read_per_token: float  # may fallback to input_per_token
 
 
+def _int_or_zero(val: Any) -> int:
+    """Coerce to int; use 0 for None or invalid."""
+    if val is None:
+        return 0
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return 0
+
+
 def extract_usage(resp: Any) -> Usage:
+    """
+    Extract token usage from a completion response (full chunk or usage object).
+    Supports both OpenAI-style (prompt_tokens, completion_tokens) and Azure-style
+    (input_tokens, output_tokens) field names for compatibility with LiteLLM + Azure.
+    """
     usage = at(resp, "usage", default={})
+    if usage is None:
+        usage = {}
 
-    prompt = int(at(usage, "prompt_tokens", default=0))
-    completion = int(at(usage, "completion_tokens", default=0))
-    total = int(at(usage, "total_tokens", default=prompt + completion))
+    # Prefer OpenAI names; fall back to Azure/OpenAI Responses API names
+    prompt = _int_or_zero(
+        at(usage, "prompt_tokens", default=None) or at(usage, "input_tokens", default=0)
+    )
+    completion = _int_or_zero(
+        at(usage, "completion_tokens", default=None) or at(usage, "output_tokens", default=0)
+    )
+    total = _int_or_zero(at(usage, "total_tokens", default=prompt + completion))
 
-    cached = int(at(usage, "prompt_tokens_details", "cached_tokens", default=0))
-    reasoning = int(at(usage, "completion_tokens_details", "reasoning_tokens", default=0))
+    cached = _int_or_zero(at(usage, "prompt_tokens_details", "cached_tokens", default=0))
+    reasoning = _int_or_zero(at(usage, "completion_tokens_details", "reasoning_tokens", default=0))
 
     return Usage(
         prompt_tokens=prompt,
@@ -213,6 +238,52 @@ def normalize_model_id(model: str, resp: Any) -> str:
     return str(at(resp, "model", default=model) or model)
 
 
+def _safe_get_model_info(model_id: str, provider_prefix: str = "azure/") -> Dict[str, Any]:
+    """
+    Get LiteLLM model info; try with and without provider prefix (Azure deployment names
+    often don't include the prefix). Never raises; returns {} on failure.
+    """
+    candidates = [model_id]
+    if provider_prefix and "/" not in model_id:
+        candidates.append(f"{provider_prefix}{model_id}")
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            info = get_model_info(model=candidate)
+            if info:
+                return info
+        except Exception as e:
+            logger.debug("get_model_info(%r) failed: %s", candidate, e)
+    return {}
+
+
+def build_data_usage_event_from_usage_only(
+    *,
+    model: str,
+    completion_response: Any,
+) -> DataUsageEvent:
+    """
+    Build a minimal DataUsageEvent from token counts only (no cost/context).
+    Use when build_data_usage_event fails (e.g. get_model_info unavailable for Azure).
+    """
+    u = extract_usage(completion_response)
+    model_id = normalize_model_id(model, completion_response)
+    return DataUsageEvent(
+        type="data-usage",
+        data=DataUsageData(
+            inputTokens=u.prompt_tokens,
+            outputTokens=u.completion_tokens,
+            totalTokens=u.total_tokens,
+            reasoningTokens=u.reasoning_tokens,
+            cachedInputTokens=u.cached_tokens,
+            context=ContextLimits(),
+            costUSD=CostUSD(),
+            modelId=model_id,
+        ),
+    )
+
+
 # --- main API ----------------------------------------------------------------
 
 
@@ -221,11 +292,15 @@ def build_data_usage_event(
     model: str,
     completion_response: Any,
     model_info: Optional[Dict[str, Any]] = None,
+    provider_prefix: str = "azure/",
 ) -> DataUsageEvent:
     u = extract_usage(completion_response)
     model_id = normalize_model_id(model, completion_response)
 
-    mi = model_info or get_model_info(model=model_id)
+    if model_info is not None:
+        mi = model_info
+    else:
+        mi = _safe_get_model_info(model_id, provider_prefix=provider_prefix)
     ctx = extract_context(mi)
     p = extract_prices(mi)
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -314,31 +314,15 @@ DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK.
 # ---------------------------------------------------------------------------
 def get_routing_system_prompt() -> str:
     """Intent router: classifies user message as RESEARCH or DIRECT based on Data360 tool capability."""
-    return """You are a high-speed intent router for the Data360 Chat assistant.
-Route to RESEARCH only when the user's request can be answered using the Data360 tools. Otherwise route to DIRECT.
+    return """You are an intent router for the Data360 Chat assistant. Route to RESEARCH only when the request can be answered using Data360 tools; otherwise route to DIRECT. Responses and your brief explanation use the user's language and push back politely on stereotypes, bias, or unfounded generalizations.
 
-WHAT DATA360 TOOLS CAN DO (route RESEARCH):
-- Search for indicators by topic (e.g. unemployment, poverty, GDP per capita, population, health, education)
-- Get indicator metadata (definition, methodology, unit, periodicity) — e.g. "What does GDP mean?" can be answered by search + metadata
-- Retrieve time-series or tabular data for an indicator (by country, year range, or breakdowns like sex/age/urban-rural)
-- Check data availability (which countries, years, or dimensions exist for an indicator)
-- Generate charts/visualizations from indicator data (line, bar, area, etc.)
-- Resolve country or dimension names to codes (e.g. "Kenya" → KEN) when needed for a data request
+RESEARCH: Data or information from tools — e.g. search indicators, metadata (definitions, methodology, sources, limitations), time-series or tabular data, availability, charts, or country/dimension lookups. Includes "What does X mean?", "Is there data for X?", Data360/WDI, other World Bank data, or development/economic data requests. Let the search figure out whether the data exists; do not pre-judge availability.
 
-WHAT DATA360 TOOLS CANNOT DO (route DIRECT):
-- Greetings, small talk, thanks, or compliments (Hello, Hi, How are you?, Thank you)
-- Questions unrelated to development/economic data (weather, sports, general knowledge) — Writer will politely refuse
-- Policy or narrative advice that does not require fetching specific indicator data from the database
+DIRECT: Greetings, thanks, small talk, or questions not answerable from tools (weather, sports, general knowledge, or policy advice without indicator lookup). Respond with polite refusal when off-topic.
 
-ROUTING RULES:
-1. RESEARCH: User asks for data, statistics, indicators, definitions of indicators (e.g. "What does GDP mean?" — search + metadata can answer), country/time comparisons, charts, or "is there data for X?" — anything that can be answered by searching indicators, fetching data/metadata, or building a visualization.
-2. DIRECT: User is greeting/thanking, making small talk, or asking something unrelated to development/economic data (no Data360 lookup needed).
+Again, if the user asks for anything related to development data or an explanation that can be answer from metadata, or follows up on a previous question, route to RESEARCH.
 
-If the user asks both for data and for an explanation, choose RESEARCH (tools can fetch data and metadata; Writer can add explanation).
-
-OUTPUT FORMAT:
-Return ONLY a JSON object:
-{"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
+Return ONLY this JSON: {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
 """
 
 
@@ -500,6 +484,10 @@ def get_direct_system_prompt() -> str:
     """System prompt for DIRECT intent (no specialized research needed)."""
     return """The user's message was classified as direct chat (no specialized research needed).
 It is not analytical — e.g., a greeting, thanks, or a simple follow-up.
+
+**Language:** Use the user's query language for your response unless they specify otherwise.
+
+**Pushback:** If the user's request involves stereotypes, bias, or unfounded generalizations, politely push back and decline to respond in that way.
 
 **CRITICAL**: You are in DIRECT chat mode. Answer immediately and concisely.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -313,27 +313,28 @@ DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK.
 # Routing prompt  (MVP §4 coverage)
 # ---------------------------------------------------------------------------
 def get_routing_system_prompt() -> str:
-    """Intent router: classifies user message as RESEARCH or DIRECT."""
+    """Intent router: classifies user message as RESEARCH or DIRECT based on Data360 tool capability."""
     return """You are a high-speed intent router for the Data360 Chat assistant.
-Determine if the user's latest message requires Data360 research or is general conversation.
+Route to RESEARCH only when the user's request can be answered using the Data360 tools. Otherwise route to DIRECT.
 
-CATEGORIES:
+WHAT DATA360 TOOLS CAN DO (route RESEARCH):
+- Search for indicators by topic (e.g. unemployment, poverty, GDP per capita, population, health, education)
+- Get indicator metadata (definition, methodology, unit, periodicity) — e.g. "What does GDP mean?" can be answered by search + metadata
+- Retrieve time-series or tabular data for an indicator (by country, year range, or breakdowns like sex/age/urban-rural)
+- Check data availability (which countries, years, or dimensions exist for an indicator)
+- Generate charts/visualizations from indicator data (line, bar, area, etc.)
+- Resolve country or dimension names to codes (e.g. "Kenya" → KEN) when needed for a data request
 
-1. RESEARCH — choose when the user asks for:
-   - Specific data, statistics, or indicators (GDP, population, spending, etc.)
-   - Country or regional comparisons
-   - Charts, visualizations, or time-series data
-   - **Follow-up questions about data or visualization** (e.g., "Can we create a chart with that data?", "Is there data for country X?")
-   - Anything requiring the World Bank / Data360 database or data assessment
+WHAT DATA360 TOOLS CANNOT DO (route DIRECT):
+- Greetings, small talk, thanks, or compliments (Hello, Hi, How are you?, Thank you)
+- Questions unrelated to development/economic data (weather, sports, general knowledge) — Writer will politely refuse
+- Policy or narrative advice that does not require fetching specific indicator data from the database
 
-2. DIRECT — choose when the user is:
-   - Greeting (Hello, Hi, Hey)
-   - Making small talk ("How are you?")
-   - Asking a PURELY explanatory follow-up that does NOT need data assessment (e.g., "What does GDP mean?", "Explain that term")
-   - Thanking or complimenting the assistant
-   - Asking something unrelated to development/economics (route to DIRECT so the Writer can politely refuse)
+ROUTING RULES:
+1. RESEARCH: User asks for data, statistics, indicators, definitions of indicators (e.g. "What does GDP mean?" — search + metadata can answer), country/time comparisons, charts, or "is there data for X?" — anything that can be answered by searching indicators, fetching data/metadata, or building a visualization.
+2. DIRECT: User is greeting/thanking, making small talk, or asking something unrelated to development/economic data (no Data360 lookup needed).
 
-**IMPORTANT**: If the user asks about charts, visualizations, or data availability (even as a follow-up), route to RESEARCH.
+If the user asks both for data and for an explanation, choose RESEARCH (tools can fetch data and metadata; Writer can add explanation).
 
 OUTPUT FORMAT:
 Return ONLY a JSON object:

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -32,7 +32,7 @@ from app.config import ModelType
 from app.utils.helpers import get_date_string
 
 # Delimiter between planner output and writer output in combined mode.
-THINKING_TO_ANSWER_TOKEN = "<ANSWER>"
+THINKING_TO_ANSWER_TOKEN = "^ANSWER^"
 
 
 # ---------------------------------------------------------------------------
@@ -327,155 +327,155 @@ Return ONLY this JSON: {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief exp
 """
 
 
-# ---------------------------------------------------------------------------
-# Combined prompt (single-LLM: planner + writer in one call)
-# ---------------------------------------------------------------------------
-def get_combined_system_prompt(
-    selected_chat_model: ModelType,
-    request_hints: Optional[Dict[str, Any]] = None,
-) -> str:
-    """Single system prompt for the one-LLM path: planner → token → writer."""
+# # ---------------------------------------------------------------------------
+# # Combined prompt (single-LLM: planner + writer in one call)
+# # ---------------------------------------------------------------------------
+# def get_combined_system_prompt(
+#     selected_chat_model: ModelType,
+#     request_hints: Optional[Dict[str, Any]] = None,
+# ) -> str:
+#     """Single system prompt for the one-LLM path: planner → token → writer."""
 
-    transition_instruction = f"""
-═══════════════════════════════════════════════════════════════════
-                   ⚠️  CRITICAL: OUTPUT FORMAT  ⚠️
-═══════════════════════════════════════════════════════════════════
+#     transition_instruction = f"""
+# ═══════════════════════════════════════════════════════════════════
+#                    ⚠️  CRITICAL: OUTPUT FORMAT  ⚠️
+# ═══════════════════════════════════════════════════════════════════
 
-After completing your RESEARCH PACKET and CLARIFYING QUESTION, you MUST **ALWAYS**:
+# After completing your RESEARCH PACKET and CLARIFYING QUESTION, you MUST **ALWAYS**:
 
-1. Output EXACTLY this token on its own line (no other text on that line):
+# 1. Output EXACTLY this token on its own line (no other text on that line):
 
-   {THINKING_TO_ANSWER_TOKEN}
+#    {THINKING_TO_ANSWER_TOKEN}
 
-2. Then IMMEDIATELY write the user-facing answer (as described in the Writer section below).
+# 2. Then IMMEDIATELY write the user-facing answer (as described in the Writer section below).
 
-**NEVER** write the user-facing answer BEFORE outputting the token above.
-**NEVER** skip the token — it is **ALWAYS REQUIRED** to switch from research to answer mode.
-You **MUST** emit this token in **EVERY** RESEARCH response — no exceptions.
+# **NEVER** write the user-facing answer BEFORE outputting the token above.
+# **NEVER** skip the token — it is **ALWAYS REQUIRED** to switch from research to answer mode.
+# You **MUST** emit this token in **EVERY** RESEARCH response — no exceptions.
 
-Example format:
-```
-### RESEARCH PACKET:
-- User intent: Get GDP for Philippines 2023
-- Data retrieved: No data available for 2023
-...
+# Example format:
+# ```
+# ### RESEARCH PACKET:
+# - User intent: Get GDP for Philippines 2023
+# - Data retrieved: No data available for 2023
+# ...
 
-### CLARIFYING QUESTION: <blank>
+# ### CLARIFYING QUESTION: <blank>
 
-{THINKING_TO_ANSWER_TOKEN}
+# {THINKING_TO_ANSWER_TOKEN}
 
-**Data:**
-There is currently no published value available for the Philippines for 2023...
-```
+# **Data:**
+# There is currently no published value available for the Philippines for 2023...
+# ```
 
-The token {THINKING_TO_ANSWER_TOKEN} is the ONLY delimiter between your research and your answer.
-You MUST **ALWAYS** provide a user-facing response after the token, even if brief.
+# The token {THINKING_TO_ANSWER_TOKEN} is the ONLY delimiter between your research and your answer.
+# You MUST **ALWAYS** provide a user-facing response after the token, even if brief.
 
-═══════════════════════════════════════════════════════════════════
-"""
+# ═══════════════════════════════════════════════════════════════════
+# """
 
-    writer_prompt = f"""You are the Data360 Chat assistant — a friendly, concise, and accurate data assistant for World Bank and international development data.
+#     writer_prompt = f"""You are the Data360 Chat assistant — a friendly, concise, and accurate data assistant for World Bank and international development data. Today is {get_date_string()}.
 
-ROLE:
-You are the WRITER. The Planner phase above has already done research and called all necessary tools.
-Your job starts AFTER the {THINKING_TO_ANSWER_TOKEN} token.
-You are specialized in development, economics, and Data360 data. REFUSE unrelated questions politely.
+# ROLE:
+# You are the WRITER. The Planner phase above has already done research and called all necessary tools.
+# Your job starts AFTER the {THINKING_TO_ANSWER_TOKEN} token.
+# You are specialized in development, economics, and Data360 data. REFUSE unrelated questions politely.
 
-**CRITICAL:** AFTER the {THINKING_TO_ANSWER_TOKEN} token (i.e., in THIS writer phase), NEVER call any `data360_*` tools — they were already used in the planner phase above.
-Use the research results from the planner's RESEARCH PACKET as your source of truth.
-Use official country, region, and indicator names from the research packet.
-If the research packet includes a Visualization URL, present it as a markdown link.
-If the research packet includes an API URL, present it under "**Direct API Access:**".
+# **CRITICAL:** AFTER the {THINKING_TO_ANSWER_TOKEN} token (i.e., in THIS writer phase), NEVER call any `data360_*` tools — they were already used in the planner phase above.
+# Use the research results from the planner's RESEARCH PACKET as your source of truth.
+# Use official country, region, and indicator names from the research packet.
+# If the research packet includes a Visualization URL, present it as a markdown link.
+# If the research packet includes an API URL, present it under "**Direct API Access:**".
 
-WHEN INFORMATION IS MISSING:
-- If results are insufficient, ask at most ONE targeted clarifying question.
-- If out of scope, say so and suggest a refinement.
-- When you cannot answer: (1) explain why, (2) suggest alternatives.
-- NEVER guess numbers, indicator IDs, or coverage.
+# WHEN INFORMATION IS MISSING:
+# - If results are insufficient, ask at most ONE targeted clarifying question.
+# - If out of scope, say so and suggest a refinement.
+# - When you cannot answer: (1) explain why, (2) suggest alternatives.
+# - NEVER guess numbers, indicator IDs, or coverage.
 
-PRESENTATION:
-- Use labels: "**Data:**", "**Analysis:**", "**Note:**" as appropriate.
-- Explain technical terms or indicators that may be unfamiliar.
-- Lead with a summary sentence, then provide tables or bullets.
-- For multi-entity results, invite the user to drill down.
-- Use markdown tables for 3+ related numeric values. Otherwise use bullets or paragraphs.
-- **NUMBER FORMATTING (CRITICAL):**
-  - For large numbers (money, GDP, population >1 million), **ALWAYS** use comma separators OR abbreviated forms
-  - Examples of CORRECT formatting:
-    * "860,692,200,000" (with commas) OR "861 billion" (abbreviated)
-    * "1,234,567" OR "1.2 million"
-    * "$45,500,000" OR "$45.5 million"
-  - **NEVER** show raw unformatted numbers like: 860692200000, 1234567, 45500000
-  - For percentages and small numbers (<1000), raw format is acceptable: "5.2%", "127"
-- **Number formatting:** For large numbers (money, GDP, population), use comma separators (e.g., "860,692,200,000") or abbreviated forms (e.g., "861 billion"). NEVER show raw unformatted numbers like 860692200000.
-- Always include units and time period with numeric data.
-- NEVER use scientific notation unless explicitly requested.
-- Indicate "(using latest available data)" when no time period was specified.
-- Cite sources under a "**Sources:**" label at the end.
-  - Format citations clearly: **Database name** — Indicator name — methodology note
-  - Example: "**World Bank — Health, Nutrition and Population Statistics** — Unemployment, total (% of total labor force) — modeled ILO estimate"
-  - Use bullets for multiple sources
+# PRESENTATION:
+# - Use labels: "**Data:**", "**Analysis:**", "**Note:**" as appropriate.
+# - Explain technical terms or indicators that may be unfamiliar.
+# - Lead with a summary sentence, then provide tables or bullets.
+# - For multi-entity results, invite the user to drill down.
+# - Use markdown tables for 3+ related numeric values. Otherwise use bullets or paragraphs.
+# - **NUMBER FORMATTING (CRITICAL):**
+#   - For large numbers (money, GDP, population >1 million), **ALWAYS** use comma separators OR abbreviated forms
+#   - Examples of CORRECT formatting:
+#     * "860,692,200,000" (with commas) OR "861 billion" (abbreviated)
+#     * "1,234,567" OR "1.2 million"
+#     * "$45,500,000" OR "$45.5 million"
+#   - **NEVER** show raw unformatted numbers like: 860692200000, 1234567, 45500000
+#   - For percentages and small numbers (<1000), raw format is acceptable: "5.2%", "127"
+# - **Number formatting:** For large numbers (money, GDP, population), use comma separators (e.g., "860,692,200,000") or abbreviated forms (e.g., "861 billion"). NEVER show raw unformatted numbers like 860692200000.
+# - Always include units and time period with numeric data.
+# - NEVER use scientific notation unless explicitly requested.
+# - Indicate "(using latest available data)" when no time period was specified.
+# - Cite sources under a "**Sources:**" label at the end.
+#   - Format citations clearly: **Database name** — Indicator name — methodology note
+#   - Example: "**World Bank — Health, Nutrition and Population Statistics** — Unemployment, total (% of total labor force) — modeled ILO estimate"
+#   - Use bullets for multiple sources
 
-CLAIM TAGGING:
-When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag: `<claim id="claim_id" policy="policy">value</claim>`.
-Example: "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD".
+# CLAIM TAGGING:
+# When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag: `<claim id="claim_id" policy="policy">value</claim>`.
+# Example: "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD".
 
-You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
-NEVER invent a claim_id. Use the `claim_id` from the tool output only.
+# You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
+# NEVER invent a claim_id. Use the `claim_id` from the tool output only.
 
-DATA CAVEATS:
-- Include "**Limitations:**" if the research packet notes caveats.
-- Warn when comparing data with differing methodologies or time ranges.
+# DATA CAVEATS:
+# - Include "**Limitations:**" if the research packet notes caveats.
+# - Warn when comparing data with differing methodologies or time ranges.
 
-CONVERSATION FLOW:
-- If the topic shifts dramatically, suggest starting a new conversation.
+# CONVERSATION FLOW:
+# - If the topic shifts dramatically, suggest starting a new conversation.
 
-FOLLOW-UP QUESTIONS:
-End data answers with "**Suggested follow-ups:**" — 2-3 user-phrased questions. NEVER phrase as assistant offerings.
+# FOLLOW-UP QUESTIONS:
+# End data answers with "**Suggested follow-ups:**" — 2-3 user-phrased questions. NEVER phrase as assistant offerings.
 
-DOCUMENT TOOLS:
-You have access to `createDocument` and `updateDocument` for writing code or long-form content.
+# DOCUMENT TOOLS:
+# You have access to `createDocument` and `updateDocument` for writing code or long-form content.
 
-─── ADVANCED DATA ACCESS ──────────────────────────────────────────
-If the research packet includes an API URL (from `data360_get_data_api_url`):
-- Present it under "**Direct API Access:**" so the user can query data directly.
-- If feasible, generate a short Python `requests` example.
-If the API URL was not generated, do not fabricate one.
-"""
+# ─── ADVANCED DATA ACCESS ──────────────────────────────────────────
+# If the research packet includes an API URL (from `data360_get_data_api_url`):
+# - Present it under "**Direct API Access:**" so the user can query data directly.
+# - If feasible, generate a short Python `requests` example.
+# If the API URL was not generated, do not fabricate one.
+# """
 
-    combined = get_thinking_system_prompt() + transition_instruction + "\n\n---\n\n" + writer_prompt
-    request_prompt = _build_request_prompt(request_hints)
-    if request_prompt:
-        combined = combined + "\n\n" + request_prompt
+#     combined = get_thinking_system_prompt() + transition_instruction + "\n\n---\n\n" + writer_prompt
+#     request_prompt = _build_request_prompt(request_hints)
+#     if request_prompt:
+#         combined = combined + "\n\n" + request_prompt
 
-    if selected_chat_model != ModelType.CHAT_MODEL_REASONING:
-        artifacts_prompt = """
-ARTIFACTS MODE:
-Artifacts is a document/code panel beside the chat. Changes are reflected in real-time.
+#     if selected_chat_model != ModelType.CHAT_MODEL_REASONING:
+#         artifacts_prompt = """
+# ARTIFACTS MODE:
+# Artifacts is a document/code panel beside the chat. Changes are reflected in real-time.
 
-When asked to write code, use artifacts via `createDocument`. Specify language in backticks (e.g., ```python). Default language is Python.
+# When asked to write code, use artifacts via `createDocument`. Specify language in backticks (e.g., ```python). Default language is Python.
 
-DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK.
+# DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK.
 
-**When to use `createDocument`:**
-- Substantial content (>10 lines) or code
-- Content users will likely save/reuse
-- When explicitly requested
+# **When to use `createDocument`:**
+# - Substantial content (>10 lines) or code
+# - Content users will likely save/reuse
+# - When explicitly requested
 
-**When NOT to use `createDocument`:**
-- Informational/explanatory content
-- Conversational responses
+# **When NOT to use `createDocument`:**
+# - Informational/explanatory content
+# - Conversational responses
 
-**Using `updateDocument`:**
-- Full document rewrites for major changes
-- Targeted updates for specific, isolated changes
+# **Using `updateDocument`:**
+# - Full document rewrites for major changes
+# - Targeted updates for specific, isolated changes
 
-**When NOT to use `updateDocument`:**
-- Immediately after creating a document
-"""
-        combined = combined + "\n\n" + artifacts_prompt.strip()
+# **When NOT to use `updateDocument`:**
+# - Immediately after creating a document
+# """
+#         combined = combined + "\n\n" + artifacts_prompt.strip()
 
-    return combined.strip()
+#     return combined.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -529,3 +529,122 @@ def _build_request_prompt(request_hints: Optional[Dict[str, Any]]) -> str:
         return ""
 
     return "USER CONTEXT (may help for location-based questions):\n" + "\n".join(fields)
+
+
+def get_combined_system_prompt(
+    selected_chat_model: ModelType,
+    request_hints: Optional[Dict[str, Any]] = None,
+) -> str:
+    return f"""# SYSTEM ROLE: Data360 Chat AI Chatbot
+
+You are a dual-process data assistant for World Bank and international development data and metadata related questions. You have two phases: a research/planning phase and a writer phase.
+
+## WORKFLOW OVERVIEW
+
+You operate in two mandatory, sequential phases. You MUST separate them with the token: `{THINKING_TO_ANSWER_TOKEN}`. In Phase 1, you are in research/planning mode so you call the tools and write the research/planning packet. In Phase 2, you are in user-facing mode so you write the final user-facing answer.
+
+Today is {get_date_string()}.
+
+**LANGUAGE RULE:** Respond in the user's query language unless specified otherwise.
+
+## PHASE 1: RESEARCH/PLANNING
+**GOAL:** Discover and fetch data. This phase focuses on tool interaction.
+**EXECUTION ORDER:**
+1. **Search First:** You MUST call `data360_search_indicators` and related tools first to identify valid `indicator_id` and `database_id` values. Get at least the first 10 results.
+2. **Exception:** If the specific IDs are already present in the immediate conversation history from a previous turn, you may skip searching and proceed to fetching.
+3. **Data Retrieval:** Once IDs are confirmed, call `data360_get_data` and `data360_get_metadata`.
+4. **DO NOT** call `data360_get_viz_spec` in this phase.
+
+### RESEARCH/PLANNING PACKET (Concise):
+Since the user can see the tool output widgets, do not repeat raw data here.
+- **Intent:** <User goal in their language>
+- **Selection Logic:** <Short note on why these indicators/countries were chosen>
+- **Data Gaps:** <Note any missing years or countries found during tools calls>
+- **CLARIFYING QUESTION:** <One question if needed, otherwise "None">
+
+---
+
+**IMPORTANT:**
+
+This is a CRITICAL INSTRUCTION. You cannot enter Phase 2 until this token `{THINKING_TO_ANSWER_TOKEN}` is emitted.
+After completing Phase 1, you MUST output this token `{THINKING_TO_ANSWER_TOKEN}` on a new line.
+
+---
+
+## PHASE 2: WRITER & VISUALIZER (User-Facing)
+**GOAL:** Synthesize findings and generate visuals.
+**RULES:**
+1. **Visualization:** If requested (chart/graph/plot), call `data360_get_viz_spec` NOW using the IDs from Phase 1.
+2. **Formatting:**
+   - **Numbers:** Always use commas (e.g., 1,234,567) or abbreviations (1.2 million).
+   - **Claim Tags:** Wrap every OBSERVATION VALUE (from tools or conversation history) with a claim tag: `<claim id="claim_id" policy="auto">value</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only.
+3. **Structure:** - Start with a clear summary in the user's language.
+   - Use the tool widget outputs as your reference.
+   - Use labels: "**Data:**", "**Analysis:**", and "**Sources:**".
+4. **Follow-ups:** End with 2-3 "Suggested follow-ups" phrased as user questions.
+
+
+**CRITICAL:** AFTER the {THINKING_TO_ANSWER_TOKEN} token (i.e., in THIS writer phase), NEVER call any `data360_*` tools except visualization tool `data360_get_viz_spec` — they were already used in the planner phase above.
+Use the research results from the planner's research packet as your source of truth.
+Use official country, region, and indicator names from the research packet or conversation history.
+If the research packet includes a Visualization URL, present it as a markdown link.
+If the research packet includes an API URL, present it under "**Direct API Access:**". If no API URL is available, do not fabricate one.
+
+WHEN INFORMATION IS MISSING:
+- If results are insufficient, ask at most ONE targeted clarifying question.
+- If out of scope, say so and suggest a refinement.
+- When you cannot answer: (1) explain why, (2) suggest alternatives.
+- NEVER guess numbers, indicator IDs, or coverage. If the information is not available, say so and suggest alternatives.
+
+PRESENTATION:
+- Use labels: "**Data:**", "**Analysis:**", "**Note:**" as appropriate.
+- Explain technical terms or indicators that may be unfamiliar.
+- Lead with a summary sentence, then provide tables or bullets.
+- For multi-entity results, invite the user to drill down.
+- Use markdown tables for 3+ related numeric values. Otherwise use bullets or paragraphs.
+- **NUMBER FORMATTING (CRITICAL):**
+  - For large numbers (money, GDP, population >1 million), **ALWAYS** use comma separators OR abbreviated forms
+  - Examples of CORRECT formatting:
+    * "860,692,200,000" (with commas) OR "861 billion" (abbreviated)
+    * "1,234,567" OR "1.2 million"
+    * "$45,500,000" OR "$45.5 million"
+  - **NEVER** show raw unformatted numbers like: 860692200000, 1234567, 45500000
+  - For percentages and small numbers (<1000), raw format is acceptable: "5.2%", "127"
+- **Number formatting:** For large numbers (money, GDP, population), use comma separators (e.g., "860,692,200,000") or abbreviated forms (e.g., "861 billion"). NEVER show raw unformatted numbers like 860692200000.
+- Always include units and time period with numeric data.
+- NEVER use scientific notation unless explicitly requested.
+- Indicate "(using latest available data)" when no time period was specified.
+- Cite sources under a "**Sources:**" label at the end.
+  - Format citations clearly: **Database name** — Indicator name — methodology note
+  - Example: "**World Bank — Health, Nutrition and Population Statistics** — Unemployment, total (% of total labor force) — modeled ILO estimate"
+  - Use bullets for multiple sources
+
+CLAIM TAGGING:
+When you provide any OBSERVATION VALUE (from tools or conversation history), **YOU MUST ALWAYS** enclose the value within a claim tag: `<claim id="claim_id" policy="policy">OBSERVATION VALUE</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only. Only the value must be enclosed in the claim tag, and place the unit and time period outside the claim tag.
+
+Example: "The GDP of the Philippines in 2020 is <claim id="ab2d1e34" policy="auto">361,751,145,451.597</claim> USD" or "The unemployment rate in Kenya in 2020 is <claim id="12e4a0cd" policy="auto">5.2</claim>%". The claim_id in these examples are just examples.
+
+You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
+
+DATA CAVEATS:
+- Include "**Limitations:**" if the research packet notes caveats.
+- Warn when comparing data with differing methodologies or time ranges.
+
+CONVERSATION FLOW:
+- If the topic shifts dramatically, suggest starting a new conversation.
+
+FOLLOW-UP QUESTIONS:
+End data answers with "**Suggested follow-ups:**" — 2-3 user-phrased questions. NEVER phrase as assistant offerings. Suggest questions that can be answered by the available tools, and phrase is as a question the user would ask.
+
+DOCUMENT TOOLS:
+You have access to `createDocument` and `updateDocument` for writing code or long-form content.
+
+─── ADVANCED DATA ACCESS ──────────────────────────────────────────
+If the research packet includes an API URL (from `data360_get_data_api_url`):
+- Present it under "**Direct API Access:**" so the user can query data directly.
+- If feasible, generate a short Python `requests` example.
+If the API URL was not generated, do not fabricate one.
+
+
+### SCOPE GUARD:
+If the research shows the topic is unrelated to development/economics, politely explain the limitation in the user's language and suggest a relevant alternative."""

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -552,7 +552,7 @@ Today is {get_date_string()}.
 **EXECUTION ORDER:**
 1. **Search First:** You MUST call `data360_search_indicators` and related tools first to identify valid `indicator_id` and `database_id` values. Get at least the first 10 results.
 2. **Exception:** If the specific IDs are already present in the immediate conversation history from a previous turn, you may skip searching and proceed to fetching.
-3. **Data Retrieval:** Once IDs are confirmed, call `data360_get_data` and `data360_get_metadata`.
+3. **Data Retrieval:** Once IDs are confirmed, call `data360_get_data` and `data360_get_metadata`. Add a 3-5 year time range to the data retrieval in case data is not available for the requested year.
 4. **DO NOT** call `data360_get_viz_spec` in this phase.
 
 ### RESEARCH/PLANNING PACKET (Concise):

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -29,6 +29,7 @@ Available tools (injected at runtime by tool_setup.py):
 from typing import Any, Dict, Optional
 
 from app.config import ModelType
+from app.utils.helpers import get_date_string
 
 # Delimiter between planner output and writer output in combined mode.
 THINKING_TO_ANSWER_TOKEN = "<ANSWER>"
@@ -482,21 +483,21 @@ DO NOT UPDATE DOCUMENTS IMMEDIATELY AFTER CREATING THEM. WAIT FOR USER FEEDBACK.
 # ---------------------------------------------------------------------------
 def get_direct_system_prompt() -> str:
     """System prompt for DIRECT intent (no specialized research needed)."""
-    return """The user's message was classified as direct chat (no specialized research needed).
-It is not analytical — e.g., a greeting, thanks, or a simple follow-up.
+    return f"""The user's message was classified as direct chat (no specialized research needed).
+It is not analytical — e.g., a greeting, thanks, or a simple follow-up. Today is {get_date_string()}.
 
-**Language:** Use the user's query language for your response unless they specify otherwise.
+**LANGUAGE:** Use the user's query language for your response unless they specify otherwise.
 
-**Pushback:** If the user's request involves stereotypes, bias, or unfounded generalizations, politely push back and decline to respond in that way.
+**PUSHBACK:** If the user's request involves stereotypes, bias, or unfounded generalizations, politely push back and decline to respond in that way.
 
 **CRITICAL**: You are in DIRECT chat mode. Answer immediately and concisely.
 
-**NEVER** use extended thinking blocks, reasoning tags, or any `<antThinking>` format.
-**NEVER** put your response inside any thinking/reasoning structure.
+**NEVER** use extended thinking blocks, reasoning tags, or any other format.
+**NEVER** put your response inside any other structure.
 
 Simply provide your answer directly in plain text.
 
-**CRITICAL - Claim Tags:** Even in DIRECT mode, if you mention ANY numerical values (whether from earlier tool calls, conversation history, or visualizations the user is referencing), you MUST wrap them in claim tags: `<claim id="claim_id" policy="auto">value</claim>`. Use the `claim_id` from the original data if available in conversation history. This ensures factual numerical values remain verifiable.
+**CRITICAL - Claim Tags:** Even in DIRECT mode, if you mention ANY observation value from earlier tools (whether from earlier tool calls, conversation history, or visualizations the user is referencing), you MUST wrap them in claim tags: `<claim id="claim_id" policy="auto">value</claim>`. Use the `claim_id` from the original data if available in conversation history. This ensures factual observation values remain verifiable.
 
 If the user asked something unrelated to development data, economics, or Data360, politely explain that this is outside your scope and suggest they try a development data-related question.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -620,11 +620,13 @@ PRESENTATION:
   - Use bullets for multiple sources
 
 CLAIM TAGGING:
-When you provide any OBSERVATION VALUE (from tools or conversation history), **YOU MUST ALWAYS** enclose the value within a claim tag: `<claim id="claim_id" policy="policy">OBSERVATION VALUE</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only. Only the value must be enclosed in the claim tag, and place the unit and time period outside the claim tag.
+When you provide any and all mention of an OBSERVATION VALUE or approximations of OBSERVATION VALUES (from tools or conversation history) throughout your response, **YOU MUST ALWAYS** enclose the value within a claim tag: `<claim id="claim_id" policy="policy">OBSERVATION VALUE</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only. Only the value must be enclosed in the claim tag, and place the unit and time period outside the claim tag.
 
 Example: "The GDP of the Philippines in 2020 is <claim id="ab2d1e34" policy="auto">361,751,145,451.597</claim> USD" or "The unemployment rate in Kenya in 2020 is <claim id="12e4a0cd" policy="auto">5.2</claim>%". The claim_id in these examples are just examples.
 
 You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
+
+**YOU MUSTNEVER** skip the claim tag for any OBSERVATION VALUE or approximations of OBSERVATION VALUES.
 
 DATA CAVEATS:
 - Include "**Limitations:**" if the research packet notes caveats.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.core.auth import (
     decode_access_token,
     get_azure_claims_for_user,
-    validate_azure_access_token,
+    validate_azure_access_token_async,
     validate_session_token,
 )
 from app.core.database import get_db
@@ -73,15 +73,31 @@ async def get_current_user(
             logger.debug(
                 "JWT decode failed, attempting Azure AD token validation (AUTH_PROVIDER=msal)"
             )
-            azure_payload = validate_azure_access_token(token)
+            azure_payload = await validate_azure_access_token_async(token)
             if azure_payload:
                 oid, email, name = get_azure_claims_for_user(azure_payload)
                 if oid and email:
+                    # Optional: serve from cache to avoid get_or_create_user_from_azure_claims on every request
+                    msal_cache_key = f"azure:{oid}"
+                    async with _user_cache_lock:
+                        now = time.monotonic()
+                        entry = _user_cache.get(msal_cache_key)
+                        if entry and (now - entry[0]) < settings.USER_CACHE_TTL_SECONDS:
+                            logger.debug("[deps] get_current_user cache hit (azure) oid=%s", oid)
+                            logger.info(
+                                "[deps] get_current_user done (azure cached) user_id=%s",
+                                entry[1].get("id"),
+                            )
+                            return entry[1]
+
                     user = await get_or_create_user_from_azure_claims(
                         db, azure_oid=oid, email=email, name=name
                     )
+                    user_dict = {"id": str(user.id), "type": user.type or "regular"}
+                    async with _user_cache_lock:
+                        _user_cache[msal_cache_key] = (time.monotonic(), user_dict)
                     logger.info("[deps] get_current_user done (azure) user_id=%s", user.id)
-                    return {"id": str(user.id), "type": user.type or "regular"}
+                    return user_dict
                 logger.warning("Azure AD token missing oid or email claim")
             else:
                 logger.warning(

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,3 +1,6 @@
+import asyncio
+import logging
+import time
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
@@ -22,6 +25,13 @@ from app.db.queries.user_queries import (
 
 security = HTTPBearer(auto_error=False)  # Don't auto-raise error, we'll check cookies first
 
+# Short-TTL cache for resolved user (reduces DB round-trips on repeated requests).
+# Key: user_id (str), Value: (cached_at_monotonic, {"id", "type"}).
+_user_cache: dict[str, tuple[float, dict]] = {}
+_user_cache_lock = asyncio.Lock()
+
+logger = logging.getLogger(__name__)
+
 
 async def get_current_user(
     request: Request,
@@ -32,10 +42,8 @@ async def get_current_user(
     Get current user from JWT token or session cookies.
     Checks cookies first (httpOnly cookie), then Authorization header (backward compatibility).
     If JWT expires but guest_session_id or user_session_id exists, restores the user.
+    Resolved user is cached for 2 minutes to reduce DB round-trips on repeated requests.
     """
-    import logging
-
-    logger = logging.getLogger(__name__)
     logger.info("[deps] get_current_user start")
 
     all_cookies = list(request.cookies.keys())
@@ -88,73 +96,63 @@ async def get_current_user(
             )
 
         if payload is not None:
-            # Valid token - check if password was changed after token was issued (session invalidation)
             user_id: str = payload.get("sub")
             if user_id is None:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload"
                 )
 
-            # Check if token is revoked (by JWT ID)
+            # Check if token is revoked (by JWT ID) – always hit DB for security
             jti = payload.get("jti")
-            if jti:
-                if await is_token_revoked(db, jti):
-                    logger.warning("Token revoked: jti=%s, user_id=%s", jti, user_id)
-                    # Token is revoked - fall through to session cookie check
+            if jti and await is_token_revoked(db, jti):
+                logger.warning("Token revoked: jti=%s, user_id=%s", jti, user_id)
+                payload = None
+            else:
+                # Optional: serve from cache to avoid get_user_by_id on every request
+                async with _user_cache_lock:
+                    now = time.monotonic()
+                    entry = _user_cache.get(user_id)
+                    if entry and (now - entry[0]) < settings.USER_CACHE_TTL_SECONDS:
+                        logger.debug("[deps] get_current_user cache hit user_id=%s", user_id)
+                        logger.info("[deps] get_current_user done (jwt cached) user_id=%s", user_id)
+                        return entry[1]
+
+                # Single DB call: fetch user for both password_changed_at and existence check
+                user = None
+                try:
+                    user_uuid = UUID(user_id)
+                    user = await get_user_by_id(db, user_uuid)
+                except (ValueError, TypeError) as e:
+                    logger.debug("Invalid user_id for get_user_by_id: %s", e)
+                except Exception as e:
+                    logger.error("Error verifying user existence: %s", e)
                     payload = None
-                else:
-                    # Check if password was changed after token was issued
-                    # This invalidates all sessions when password is changed
-                    # Note: Requires password_changed_at column in User table (migration needed)
-                    try:
-                        user_uuid = UUID(user_id)
-                        user = await get_user_by_id(db, user_uuid)
 
-                        if (
-                            user
-                            and hasattr(user, "password_changed_at")
-                            and user.password_changed_at
-                        ):
-                            # Get token issued at time (iat claim)
-                            token_issued_at = payload.get("iat")
-                            if token_issued_at:
-                                # Convert iat (Unix timestamp) to datetime
-                                token_issued_datetime = datetime.utcfromtimestamp(token_issued_at)
-
-                                # If password was changed after token was issued, token is invalid
-                                if user.password_changed_at > token_issued_datetime:
-                                    logger.warning(
-                                        "Token invalidated: password changed after token issuance. "
-                                        "user_id=%s, token_issued=%s, password_changed=%s",
-                                        user_id,
-                                        token_issued_datetime,
-                                        user.password_changed_at,
-                                    )
-                                    # Token is invalid - fall through to session cookie check
-                                    payload = None
-                    except (ValueError, TypeError, AttributeError) as e:
-                        # If password_changed_at doesn't exist or other error, continue (backward compatible)
-                        logger.debug("Could not check password_changed_at: %s", e)
-                        pass
-
-            # Verify user actually exists in the database (crucial for dev envs where DB is reset)
-            try:
-                user_uuid = UUID(user_id)
-                user = await get_user_by_id(db, user_uuid)
                 if not user:
                     logger.warning(
                         "Token valid but user not found in DB (DB reset?): user_id=%s", user_id
                     )
-                    payload = None  # Invalidate token
-            except Exception as e:
-                logger.error("Error verifying user existence: %s", e)
-                # Fail safe? Or continue?
-                # safer to invalidate if we can't check
-                pass
+                    payload = None
+                else:
+                    # Check if password was changed after token was issued (session invalidation)
+                    if jti and hasattr(user, "password_changed_at") and user.password_changed_at:
+                        token_issued_at = payload.get("iat")
+                        if token_issued_at:
+                            token_issued_datetime = datetime.utcfromtimestamp(token_issued_at)
+                            if user.password_changed_at > token_issued_datetime:
+                                logger.warning(
+                                    "Token invalidated: password changed after token issuance. "
+                                    "user_id=%s",
+                                    user_id,
+                                )
+                                payload = None
 
-            if payload is not None:
-                logger.info("[deps] get_current_user done (jwt) user_id=%s", user_id)
-                return {"id": user_id, "type": payload.get("type", "regular")}
+                    if payload is not None:
+                        user_dict = {"id": user_id, "type": payload.get("type", "regular")}
+                        async with _user_cache_lock:
+                            _user_cache[user_id] = (time.monotonic(), user_dict)
+                        logger.info("[deps] get_current_user done (jwt) user_id=%s", user_id)
+                        return user_dict
         # Token expired or invalid - fall through to guest session check
 
     # No valid token - check for session ID cookies (fallback for JWT key loss)
@@ -172,6 +170,22 @@ async def get_current_user(
             validated_user_id,
         )
         if validated_user_id:
+            # Optional: serve from cache
+            async with _user_cache_lock:
+                entry = _user_cache.get(validated_user_id)
+                if entry and (time.monotonic() - entry[0]) < settings.USER_CACHE_TTL_SECONDS:
+                    cached = entry[1]
+                    if cached.get("type") == "guest":
+                        logger.debug(
+                            "[deps] get_current_user cache hit (guest) user_id=%s",
+                            validated_user_id,
+                        )
+                        logger.info(
+                            "[deps] get_current_user done (guest_session cached) user_id=%s",
+                            validated_user_id,
+                        )
+                        return {**cached, "_restore_guest": True}
+
             # Try to restore guest user from validated session token
             try:
                 user_id = UUID(validated_user_id)
@@ -194,8 +208,11 @@ async def get_current_user(
 
                 if is_guest:
                     user_type = user.type if hasattr(user, "type") and user.type else "guest"
+                    user_dict = {"id": str(user.id), "type": user_type}
+                    async with _user_cache_lock:
+                        _user_cache[validated_user_id] = (time.monotonic(), user_dict)
                     logger.info("[deps] get_current_user done (guest_session) user_id=%s", user.id)
-                    return {"id": str(user.id), "type": user_type, "_restore_guest": True}
+                    return {**user_dict, "_restore_guest": True}
                 else:
                     # User doesn't exist or is not a guest user
                     if user is None:
@@ -228,6 +245,22 @@ async def get_current_user(
             validated_user_id,
         )
         if validated_user_id:
+            # Optional: serve from cache
+            async with _user_cache_lock:
+                entry = _user_cache.get(validated_user_id)
+                if entry and (time.monotonic() - entry[0]) < settings.USER_CACHE_TTL_SECONDS:
+                    cached = entry[1]
+                    if cached.get("type") == "regular":
+                        logger.debug(
+                            "[deps] get_current_user cache hit (user_session) user_id=%s",
+                            validated_user_id,
+                        )
+                        logger.info(
+                            "[deps] get_current_user done (user_session cached) user_id=%s",
+                            validated_user_id,
+                        )
+                        return {**cached, "_restore_user": True}
+
             # Try to restore regular user from validated session token
             try:
                 user_id = UUID(validated_user_id)
@@ -249,8 +282,11 @@ async def get_current_user(
 
                 if is_regular:
                     user_type = user.type if hasattr(user, "type") and user.type else "regular"
+                    user_dict = {"id": str(user.id), "type": user_type}
+                    async with _user_cache_lock:
+                        _user_cache[validated_user_id] = (time.monotonic(), user_dict)
                     logger.info("[deps] get_current_user done (user_session) user_id=%s", user.id)
-                    return {"id": str(user.id), "type": user_type, "_restore_user": True}
+                    return {**user_dict, "_restore_user": True}
                 else:
                     logger.warning(
                         "user_session_id points to guest user: user_id=%s, email=%s",
@@ -269,6 +305,18 @@ async def get_current_user(
             )
             try:
                 user_id = UUID(user_session_id)
+                uid_str = str(user_id)
+                async with _user_cache_lock:
+                    entry = _user_cache.get(uid_str)
+                    if entry and (time.monotonic() - entry[0]) < settings.USER_CACHE_TTL_SECONDS:
+                        cached = entry[1]
+                        if cached.get("type") == "regular":
+                            logger.debug(
+                                "[deps] get_current_user cache hit (user_session raw) user_id=%s",
+                                uid_str,
+                            )
+                            return {**cached, "_restore_user": True}
+
                 user = await get_user_by_id(db, user_id)
                 logger.debug(
                     "Regular user lookup (raw UUID fallback): user_id=%s, found=%s, email=%s",
@@ -284,10 +332,13 @@ async def get_current_user(
                         user.email.startswith("guest-") and user.email.endswith("@anonymous.local")
                     )
                 ):
+                    user_dict = {"id": str(user.id), "type": "regular"}
+                    async with _user_cache_lock:
+                        _user_cache[uid_str] = (time.monotonic(), user_dict)
                     logger.info(
                         "[deps] get_current_user done (user_session raw) user_id=%s", user.id
                     )
-                    return {"id": str(user.id), "type": "regular", "_restore_user": True}
+                    return {**user_dict, "_restore_user": True}
                 else:
                     logger.warning(
                         "user_session_id (raw UUID) points to guest user: user_id=%s, email=%s",
@@ -313,9 +364,6 @@ async def get_optional_user(
     Optional authentication - returns None if no token provided.
     Still attempts to restore users from session cookies (guest_session_id, user_session_id).
     """
-    import logging
-
-    logger = logging.getLogger(__name__)
     try:
         user = await get_current_user(request, credentials, db)
         logger.debug(
@@ -341,9 +389,6 @@ async def require_feedback_reviewer(
     Require authenticated user whose email is in FEEDBACK_REVIEWER_EMAILS.
     Use for feedback review/list endpoints. Raises 403 if not allowed.
     """
-    import logging
-
-    logger = logging.getLogger(__name__)
     allowed_raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
     allowed = [e.strip().lower() for e in allowed_raw.split(",") if e.strip()]
     if not allowed:

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -165,9 +165,12 @@ def _build_assistant_message(
     """Build the assistant message dict with routing parts for saving.
     When mode was unified, stream_processor.assistant_messages[0] already has
     both thinking and chat parts. When mode was chat, it has only chat parts.
+    Use message_id (sent to frontend in MessageStartPart) as the saved message id
+    so lastContext.byMessageId and the DB message id match.
     """
     routing_parts = _build_routing_parts(message_id, reasoning)
     assistant_message = stream_processor.assistant_messages[0].copy()
+    assistant_message["id"] = message_id
     assistant_message["parts"] = routing_parts + assistant_message["parts"]
     return assistant_message
 
@@ -456,7 +459,12 @@ async def create_chat(
         nonlocal stream_interrupted
         logger.info("[chat] stream_generator started stream_id=%s", stream_id)
         state = {"sequence": 0}
-        message_id = f"msg-{uuid4().hex}"
+
+        # This is the part message id
+        part_message_id = f"msg-{uuid4().hex}"
+
+        # This is the response message id
+        message_id = str(uuid4())
         use_thinking = False
         reasoning = ""
         stream_processor = None
@@ -465,13 +473,13 @@ async def create_chat(
         tool_defs_for_stream = tool_set["local"]["tool_definitions"]
 
         try:
-            yield MessageStartPart(messageId=message_id).to_sse().encode("utf-8")
+            yield MessageStartPart(messageId=part_message_id).to_sse().encode("utf-8")
             await asyncio.sleep(0)
 
             logger.info("[chat] _emit_routing_phase start (check_intent + routing LLM)")
             out = {}
             async for chunk in _emit_routing_phase(
-                message_id, stream_id, openai_messages, state, out, query=query_text
+                part_message_id, stream_id, openai_messages, state, out, query=query_text
             ):
                 yield chunk
             logger.info("[chat] _emit_routing_phase done use_thinking=%s", out.get("use_thinking"))
@@ -579,6 +587,7 @@ async def create_chat(
                         background_tasks,
                         request.id,
                         DataUsageData.model_validate(stream_processor.final_usage),
+                        message_id=message_id,
                     )
 
     response = StreamingResponse(

--- a/backend/app/api/v1/chat_stream.py
+++ b/backend/app/api/v1/chat_stream.py
@@ -170,7 +170,10 @@ async def stream_chat(
                     )
                     if processor.final_usage:
                         create_update_context_task(
-                            background_tasks, request.id, processor.final_usage
+                            background_tasks,
+                            request.id,
+                            processor.final_usage,
+                            message_id=processor.current_message_id,
                         )
 
         response = StreamingResponse(

--- a/backend/app/api/v1/chat_stream.py
+++ b/backend/app/api/v1/chat_stream.py
@@ -104,8 +104,8 @@ async def stream_chat(
             stream_id = uuid4()
             await create_stream_id(db, stream_id, request.id)
 
-        # 7. Create stream processor
-        processor = StreamEventProcessor(request.id)
+        # 7. Create stream processor (mode "chat": no thinking, plain tool/text stream)
+        processor = StreamEventProcessor(request.id, mode="chat")
 
         # 8. Create stream generator with non-blocking Redis storage
         # Track if stream was interrupted (client disconnect) vs completed normally

--- a/backend/app/api/v1/thinking_stream.py
+++ b/backend/app/api/v1/thinking_stream.py
@@ -104,8 +104,8 @@ async def stream_chat(
             stream_id = uuid4()
             await create_stream_id(db, stream_id, request.id)
 
-        # 7. Create stream processor
-        processor = StreamEventProcessor(request.id)
+        # 7. Create stream processor (mode "thinking" for reasoning/thinking stream)
+        processor = StreamEventProcessor(request.id, mode="thinking")
 
         # 8. Create stream generator with non-blocking Redis storage
         # Track if stream was interrupted (client disconnect) vs completed normally

--- a/backend/app/api/v1/utils/background_tasks.py
+++ b/backend/app/api/v1/utils/background_tasks.py
@@ -53,8 +53,11 @@ def create_update_context_task(
     background_tasks: BackgroundTasks,
     chat_id: UUID,
     usage: Dict[str, Any] | DataUsageData,
+    message_id: str | None = None,
 ) -> None:
-    """Schedule a background task to update chat context with usage."""
+    """Schedule a background task to update chat context with usage.
+    If message_id is set, usage is stored per-message so each response has its own usage.
+    """
     if not usage:
         return
 
@@ -63,6 +66,6 @@ def create_update_context_task(
 
     async def update_context_task():
         async with AsyncSessionLocal() as session:
-            await update_chat_last_context_by_id(session, chat_id, usage)
+            await update_chat_last_context_by_id(session, chat_id, usage, message_id=message_id)
 
     background_tasks.add_task(update_context_task)

--- a/backend/app/api/v1/utils/continue_stream.py
+++ b/backend/app/api/v1/utils/continue_stream.py
@@ -101,11 +101,23 @@ async def _continue_stream_in_background(
             async with AsyncSessionLocal() as session:
                 await save_messages(session, background_processor.assistant_messages)
 
-        # Update chat context
+        # Update chat context (per-message usage so each response has its own)
         if background_processor.final_usage:
+            usage_dict = (
+                background_processor.final_usage
+                if isinstance(background_processor.final_usage, dict)
+                else background_processor.final_usage.model_dump()
+            )
             async with AsyncSessionLocal() as session:
                 await update_chat_last_context_by_id(
-                    session, chat_id, background_processor.final_usage
+                    session,
+                    chat_id,
+                    usage_dict,
+                    message_id=(
+                        str(background_processor.current_message_id)
+                        if background_processor.current_message_id
+                        else None
+                    ),
                 )
 
     except Exception as e:

--- a/backend/app/api/v1/utils/tool_setup.py
+++ b/backend/app/api/v1/utils/tool_setup.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from typing import Any, Dict
 from uuid import UUID
 
@@ -17,6 +18,11 @@ from app.ai.tools import (
 from app.config import get_mcp_settings
 
 logger = logging.getLogger(__name__)
+
+# In-memory cache for MCP tool list to avoid calling list_tools on every chat.
+# (cached_at_monotonic, mcp_tools_list) or None when empty/error.
+_mcp_tools_cache: tuple[float, list] | None = None
+_mcp_tools_cache_lock = asyncio.Lock()
 
 
 async def create_tool_wrappers(user_id: UUID, db: AsyncSession) -> Dict[str, Dict[str, Any]]:
@@ -63,7 +69,9 @@ async def prepare_tools(
     """
     Prepare tools and tool definitions for OpenAI streaming.
     Returns (tools_dict, tool_definitions_list).
+    MCP tool list is cached for 5 minutes to avoid calling list_tools on every chat.
     """
+    global _mcp_tools_cache
     logger.info("[tool_setup] create_tool_wrappers (local tools) start")
     tool_set = {
         "local": {
@@ -80,15 +88,46 @@ async def prepare_tools(
     }
     logger.info("[tool_setup] create_tool_wrappers done")
 
-    # Add MCP tools (gracefully handle connection failures and timeouts)
-    mcp_load_timeout = get_mcp_settings().load_timeout
-    logger.info("[tool_setup] get_mcp_tools start (timeout=%ss)", mcp_load_timeout)
-    try:
-        mcp_tools = await asyncio.wait_for(
-            get_mcp_tools(),
-            timeout=mcp_load_timeout,
-        )
-        logger.info("[tool_setup] get_mcp_tools done count=%d", len(mcp_tools))
+    # Add MCP tools (with 5-minute cache; gracefully handle connection failures and timeouts)
+    mcp_tools: list = []
+    async with _mcp_tools_cache_lock:
+        now = time.monotonic()
+        if (
+            _mcp_tools_cache is not None
+            and (now - _mcp_tools_cache[0]) < get_mcp_settings().tools_cache_ttl_seconds
+        ):
+            mcp_tools = _mcp_tools_cache[1]
+            logger.info(
+                "[tool_setup] using cached MCP tools count=%d (age=%.0fs)",
+                len(mcp_tools),
+                now - _mcp_tools_cache[0],
+            )
+
+    if not mcp_tools:
+        mcp_load_timeout = get_mcp_settings().load_timeout
+        logger.info("[tool_setup] get_mcp_tools start (timeout=%ss)", mcp_load_timeout)
+        try:
+            mcp_tools = await asyncio.wait_for(
+                get_mcp_tools(),
+                timeout=mcp_load_timeout,
+            )
+            async with _mcp_tools_cache_lock:
+                _mcp_tools_cache = (time.monotonic(), mcp_tools)
+            logger.info("[tool_setup] get_mcp_tools done count=%d", len(mcp_tools))
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[tool_setup] get_mcp_tools timed out after %ss (MCP server unreachable or slow). "
+                "Continuing without MCP tools.",
+                mcp_load_timeout,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to load MCP tools (continuing without them): %s",
+                str(e),
+                exc_info=True,
+            )
+
+    if mcp_tools:
         for tool in mcp_tools:
             tool_set["mcp"]["tools"][tool["function"]["name"]] = {
                 "function": None,
@@ -97,17 +136,5 @@ async def prepare_tools(
             tool_set["mcp"]["tool_definitions"].append(tool)
         tool_names = [t["function"]["name"] for t in mcp_tools]
         logger.info("Successfully loaded %d MCP tools: %s", len(mcp_tools), tool_names)
-    except asyncio.TimeoutError:
-        logger.warning(
-            "[tool_setup] get_mcp_tools timed out after %ss (MCP server unreachable or slow). "
-            "Continuing without MCP tools.",
-            mcp_load_timeout,
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to load MCP tools (continuing without them): %s",
-            str(e),
-            exc_info=True,
-        )
 
     return tool_set

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -167,6 +167,9 @@ class MCPSettings(BaseSettings):
     ssl_verify: bool = True  # Set to False for dev environments with proxy/self-signed certs
     timeout: float = 30.0  # HTTP timeout in seconds for individual MCP requests
     load_timeout: float = 15.0  # Max seconds to wait when loading MCP tools at chat start; avoids hanging if server unreachable
+    tools_cache_ttl_seconds: float = (
+        300.0  # How long to cache MCP tool list (seconds); 0 = no cache
+    )
 
     model_config = ConfigDict(
         extra="forbid",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -117,6 +117,8 @@ class Settings(BaseSettings):
 
     # Authentication
     # Note: Authentication is always enabled. Guest users provide anonymous access.
+    # Resolved user (JWT/session) is cached for this many seconds to reduce DB round-trips.
+    USER_CACHE_TTL_SECONDS: int = 120  # 2 minutes
 
     # MSAL / Azure AD (optional). When AUTH_PROVIDER=msal, backend accepts Azure AD tokens.
     AUTH_PROVIDER: str = "guest"  # "guest" | "msal"

--- a/backend/app/core/auth/__init__.py
+++ b/backend/app/core/auth/__init__.py
@@ -7,7 +7,10 @@ Auth package: token validation/issuance and credential handling.
 - session_token: HMAC session tokens (fallback auth)
 """
 
-from app.core.auth.azure import get_azure_claims_for_user, validate_azure_access_token
+from app.core.auth.azure import (
+    get_azure_claims_for_user,
+    validate_azure_access_token_async,
+)
 from app.core.auth.jwt import create_access_token, decode_access_token
 from app.core.auth.password import get_password_hash, verify_password
 from app.core.auth.session_token import generate_session_token, validate_session_token
@@ -18,7 +21,7 @@ __all__ = [
     "get_azure_claims_for_user",
     "get_password_hash",
     "generate_session_token",
-    "validate_azure_access_token",
+    "validate_azure_access_token_async",
     "validate_session_token",
     "verify_password",
 ]

--- a/backend/app/core/auth/azure.py
+++ b/backend/app/core/auth/azure.py
@@ -6,15 +6,17 @@ Accepts both v1 (sts.windows.net) and v2 (login.microsoftonline.com/.../v2.0) is
 Fetches jwks_uri from OpenID metadata first, then falls back to known URLs.
 For Graph tokens (User.Read) set AZURE_AD_VALID_AUDIENCES to include the Graph GUID below.
 User-impersonation tokens have aud = the API (resource) app ID; add that to AZURE_AD_VALID_AUDIENCES.
+
+Uses async httpx for metadata and JWKS fetches so the event loop is not blocked.
 """
 
-import json
+import asyncio
 import logging
-import urllib.request
 from typing import Any, Optional
 
+import httpx
 import jwt
-from jwt import PyJWKClient
+from jwt.api_jwk import PyJWK
 
 from app.config import settings
 
@@ -23,42 +25,58 @@ logger = logging.getLogger(__name__)
 # Microsoft Graph API well-known audience (User.Read, openid, profile tokens)
 MSGRAPH_AUDIENCE = "00000003-0000-0000-c000-000000000000"
 
-# Cache: (label -> PyJWKClient)
-_jwks_clients: dict[str, PyJWKClient] = {}
+# Timeout for metadata and JWKS HTTP fetches
+_AZURE_HTTP_TIMEOUT = 5.0
+
 # Cache: tenant_id -> (jwks_v2, jwks_v1, jwks_v1_0)
 _metadata_jwks_cache: dict[str, tuple[Optional[str], Optional[str], Optional[str]]] = {}
+_metadata_jwks_cache_lock = asyncio.Lock()
+
+# Cache JWKS JSON by URI to avoid re-fetching
+_jwks_json_cache: dict[str, dict[str, Any]] = {}
+_jwks_json_cache_lock = asyncio.Lock()
 
 
-def _fetch_jwks_uri_from_metadata(metadata_url: str) -> Optional[str]:
-    """Fetch OpenID metadata and return jwks_uri. Returns None on error."""
+async def _fetch_json_async(url: str) -> Optional[dict[str, Any]]:
+    """Fetch URL and return JSON as dict. Non-blocking (async). Returns None on error."""
     try:
-        req = urllib.request.Request(metadata_url)
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read().decode())
-            return data.get("jwks_uri") or None
+        async with httpx.AsyncClient(timeout=_AZURE_HTTP_TIMEOUT) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            return resp.json()
     except Exception as e:
-        logger.debug("Failed to fetch metadata %s: %s", metadata_url, e)
+        logger.debug("Failed to fetch %s: %s", url, e)
         return None
 
 
-def _jwks_uris_for_tenant(tenant_id: str) -> list[tuple[str, str]]:
-    """Build list of (label, jwks_uri) to try. Uses metadata first, then fallbacks."""
+async def _fetch_jwks_uri_from_metadata_async(metadata_url: str) -> Optional[str]:
+    """Fetch OpenID metadata and return jwks_uri. Non-blocking (async). Returns None on error."""
+    data = await _fetch_json_async(metadata_url)
+    if data is None:
+        return None
+    return data.get("jwks_uri") or None
+
+
+async def _jwks_uris_for_tenant_async(tenant_id: str) -> list[tuple[str, str]]:
+    """Build list of (label, jwks_uri) using async metadata fetches. Populates _metadata_jwks_cache."""
     result: list[tuple[str, str]] = []
 
-    # Prefer jwks_uri from OpenID metadata (v2.0, v1.0, and legacy v1 paths)
-    if tenant_id not in _metadata_jwks_cache:
-        v2_meta = (
-            f"https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration"
-        )
-        v1_meta = f"https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration"
-        v1_0_meta = (
-            f"https://login.microsoftonline.com/{tenant_id}/v1.0/.well-known/openid-configuration"
-        )
-        jwks_v2 = _fetch_jwks_uri_from_metadata(v2_meta)
-        jwks_v1 = _fetch_jwks_uri_from_metadata(v1_meta)
-        jwks_v1_0 = _fetch_jwks_uri_from_metadata(v1_0_meta)
-        _metadata_jwks_cache[tenant_id] = (jwks_v2, jwks_v1, jwks_v1_0)
-    jwks_v2, jwks_v1, jwks_v1_0 = _metadata_jwks_cache[tenant_id]
+    async with _metadata_jwks_cache_lock:
+        if tenant_id not in _metadata_jwks_cache:
+            v2_meta = f"https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration"
+            v1_meta = (
+                f"https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration"
+            )
+            v1_0_meta = f"https://login.microsoftonline.com/{tenant_id}/v1.0/.well-known/openid-configuration"
+            jwks_v2, jwks_v1, jwks_v1_0 = await asyncio.gather(
+                _fetch_jwks_uri_from_metadata_async(v2_meta),
+                _fetch_jwks_uri_from_metadata_async(v1_meta),
+                _fetch_jwks_uri_from_metadata_async(v1_0_meta),
+            )
+            _metadata_jwks_cache[tenant_id] = (jwks_v2, jwks_v1, jwks_v1_0)
+
+        jwks_v2, jwks_v1, jwks_v1_0 = _metadata_jwks_cache[tenant_id]
+
     for label, uri in [
         ("metadata_v2", jwks_v2),
         ("metadata_v1.0", jwks_v1_0),
@@ -67,7 +85,6 @@ def _jwks_uris_for_tenant(tenant_id: str) -> list[tuple[str, str]]:
         if uri and uri not in (r[1] for r in result):
             result.append((label, uri))
 
-    # Fallbacks
     for label, uri in [
         ("v2.0", f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"),
         ("v1", f"https://login.microsoftonline.com/{tenant_id}/discovery/keys"),
@@ -79,10 +96,30 @@ def _jwks_uris_for_tenant(tenant_id: str) -> list[tuple[str, str]]:
     return result
 
 
-def _get_jwks_client(uri_key: str, jwks_uri: str) -> PyJWKClient:
-    if uri_key not in _jwks_clients:
-        _jwks_clients[uri_key] = PyJWKClient(jwks_uri)
-    return _jwks_clients[uri_key]
+async def _fetch_jwks_json_async(jwks_uri: str) -> Optional[dict[str, Any]]:
+    """Fetch JWKS document (async). Cached by URI."""
+    async with _jwks_json_cache_lock:
+        if jwks_uri in _jwks_json_cache:
+            return _jwks_json_cache[jwks_uri]
+
+    data = await _fetch_json_async(jwks_uri)
+    if data is not None:
+        async with _jwks_json_cache_lock:
+            _jwks_json_cache[jwks_uri] = data
+    return data
+
+
+def _get_signing_key_from_jwks(jwks_data: dict[str, Any], kid: str) -> Any:
+    """Find key by kid in JWKS and return the key object for jwt.decode. Returns None if not found."""
+    for key_dict in jwks_data.get("keys", []):
+        if key_dict.get("kid") == kid:
+            try:
+                pyjwk = PyJWK.from_dict(key_dict)
+                return pyjwk.key
+            except Exception as e:
+                logger.debug("Failed to load key from JWKS for kid=%s: %s", kid, e)
+                return None
+    return None
 
 
 def _valid_issuers(tenant_id: str) -> list[str]:
@@ -127,10 +164,10 @@ def _log_token_claims_for_debug(token: str) -> None:
         logger.warning("Could not decode token for debug logging: %s", e)
 
 
-def validate_azure_access_token(token: str) -> Optional[dict[str, Any]]:
+async def validate_azure_access_token_async(token: str) -> Optional[dict[str, Any]]:
     """
     Validate an Azure AD access token (v1 or v2) and return claims.
-    Fetches jwks_uri from OpenID metadata, then tries multiple JWKS endpoints.
+    Uses async httpx for metadata and JWKS fetches so the event loop is not blocked.
     """
     parts = token.split(".")
     if len(parts) != 3:
@@ -192,14 +229,17 @@ def validate_azure_access_token(token: str) -> Optional[dict[str, Any]]:
             logger.warning("Azure AD (skip_verify) decode failed: %s", e)
             return None
 
-    uris_to_try = _jwks_uris_for_tenant(tenant_id)
+    uris_to_try = await _jwks_uris_for_tenant_async(tenant_id)
     last_error: Optional[Exception] = None
 
     for label, jwks_uri in uris_to_try:
         try:
-            client = _get_jwks_client(label, jwks_uri)
-            signing_key = client.get_signing_key(kid)
-            key = signing_key.key
+            jwks_data = await _fetch_jwks_json_async(jwks_uri)
+            if jwks_data is None:
+                continue
+            key = _get_signing_key_from_jwks(jwks_data, kid)
+            if key is None:
+                continue
             payload = jwt.decode(
                 token,
                 key,

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -184,13 +184,32 @@ async def create_stream_id(
     return new_stream
 
 
+def _merge_usage_by_message_id(current: Optional[dict], usage: dict, message_id: str) -> dict:
+    """
+    Merge usage for a message into lastContext.
+    lastContext can be legacy (plain usage dict) or { "latest": usage, "byMessageId": { id: usage } }.
+    Returns the new context dict to store.
+    """
+    if not current or not isinstance(current, dict):
+        return {"latest": usage, "byMessageId": {message_id: usage}}
+    # Legacy: current is the usage object itself (has e.g. inputTokens, totalTokens)
+    if "inputTokens" in current or "totalTokens" in current:
+        return {"latest": current, "byMessageId": {message_id: usage}}
+    # New shape
+    by_id = dict(current.get("byMessageId") or {})
+    by_id[message_id] = usage
+    return {"latest": usage, "byMessageId": by_id}
+
+
 async def update_chat_last_context_by_id(
     session: AsyncSession,
     chat_id: UUID,
     context: dict,
+    message_id: Optional[str] = None,
 ) -> Optional[Chat]:
     """
     Update chat's lastContext field with usage/context data.
+    If message_id is provided, merges usage into byMessageId so each response has its own usage.
     Returns: Updated Chat object or None if not found
     """
     logger.info("=== update_chat_last_context_by_id called ===")
@@ -200,7 +219,12 @@ async def update_chat_last_context_by_id(
         logger.warning("Chat not found: %s", chat_id)
         return None
 
-    chat.lastContext = context
+    if message_id:
+        new_context = _merge_usage_by_message_id(chat.lastContext, context, message_id)
+    else:
+        new_context = context
+
+    chat.lastContext = new_context
     await session.commit()
     logger.info("Chat context updated successfully")
     await session.refresh(chat)

--- a/backend/app/utils/helpers.py
+++ b/backend/app/utils/helpers.py
@@ -46,7 +46,7 @@ def format_sse(payload: dict, mode: Literal["thinking", "chat"] = "chat") -> str
     return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
 
 
-def get_date_string():
+def get_date_string() -> str:
     return datetime.now(timezone.utc).strftime("%A, %B %d, %Y")
 
 

--- a/backend/app/utils/stream.py
+++ b/backend/app/utils/stream.py
@@ -17,7 +17,10 @@ from openai.types.chat.chat_completion_message_param import ChatCompletionMessag
 
 from app.ai.client import AsyncOpenAIChatClientProtocol
 from app.ai.mcp_tools.data360_mcp import call_mcp_tool
-from app.ai.observability.token_usage import build_data_usage_event
+from app.ai.observability.token_usage import (
+    build_data_usage_event,
+    build_data_usage_event_from_usage_only,
+)
 from app.ai.protocols.stream import (
     DataPart,
     DoneMarker,
@@ -685,20 +688,28 @@ async def stream_text(
                                                     thinking_id=thinking_id,
                                                 )
 
-                    # Check for usage data
+                    # Check for usage data (LiteLLM sends a final chunk with usage when
+                    # stream_options={"include_usage": True}; Azure uses same format)
                     if hasattr(chunk, "usage") and chunk.usage is not None:
                         usage_data = chunk.usage
-                        # Accumulate usage across turns
-                        if total_usage_data is None:
-                            # Initialize with first usage data
-                            total_usage_data = build_data_usage_event(
+                        try:
+                            event = build_data_usage_event(model=model, completion_response=chunk)
+                            if total_usage_data is None:
+                                total_usage_data = event
+                            else:
+                                total_usage_data += event
+                        except Exception as e:
+                            logger.warning(
+                                "build_data_usage_event failed (%s), using usage-only fallback",
+                                e,
+                            )
+                            fallback = build_data_usage_event_from_usage_only(
                                 model=model, completion_response=chunk
                             )
-
-                        else:
-                            total_usage_data += build_data_usage_event(
-                                model=model, completion_response=chunk
-                            )
+                            if total_usage_data is None:
+                                total_usage_data = fallback
+                            else:
+                                total_usage_data += fallback
 
             except Exception as stream_error:
                 # If stream iteration fails, log and continue to finish events
@@ -976,11 +987,21 @@ async def stream_text(
         if finish_reason is not None:
             finish_metadata["finishReason"] = finish_reason.replace("_", "-")
 
-        # Use accumulated usage data
+        # Use accumulated usage data (total_usage_data is DataUsageEvent; usage_data is raw)
         if total_usage_data is not None:
             finish_metadata["usage"] = total_usage_data.model_dump()
         elif usage_data is not None:
-            finish_metadata["usage"] = usage_data.model_dump()
+            try:
+                fallback_event = build_data_usage_event_from_usage_only(
+                    model=model,
+                    completion_response={"usage": usage_data},
+                )
+                finish_metadata["usage"] = fallback_event.model_dump()
+            except Exception as e:
+                logger.warning(
+                    "Could not build usage event from raw usage: %s",
+                    e,
+                )
 
         # Emit "generating" stage only if we're still in thinking (didn't switch via token)
         if effective_mode == "thinking":

--- a/backend/app/utils/stream_processor.py
+++ b/backend/app/utils/stream_processor.py
@@ -1,4 +1,11 @@
-"""Stream event processing for chat streaming."""
+"""Stream event processing for chat streaming.
+
+Usage tracking: Token usage is not emitted to the frontend as a "data-usage" event
+or message part. The processor only sets final_usage from finish/data-usage events;
+the API then updates chat.lastContext (byMessageId) in a background task. The frontend
+relies on lastContext for per-message and full-chat usage (with stream usage for the
+current response until refetch).
+"""
 
 import asyncio
 import json
@@ -166,30 +173,25 @@ class StreamEventProcessor:
             self.current_tool_parts.pop(tool_call_id, None)
 
     def _handle_data_usage_event(self, data: Dict[str, Any]) -> None:
-        """Handle 'data-usage' event. Extract inner usage and track like finish."""
+        """Handle 'data-usage' event. Usage is stored in final_usage for lastContext only (not emitted as a message part)."""
         # Payload may be full envelope {"type": "data-usage", "data": {...}} or just {...}
         inner = data.get("data") if isinstance(data.get("data"), dict) else None
         usage_data = inner if inner is not None else data
         if usage_data:
             self.final_usage = usage_data
-        part = {"type": "data-usage", "data": usage_data} if usage_data else data
-        self._append_to_message_parts_buffer(part)
 
     def _handle_finish_event(self, data: Dict[str, Any]) -> None:
-        """Handle 'finish' event - finalize message and track usage."""
+        """Handle 'finish' event - finalize message and track usage for lastContext (not emitted as a message part)."""
         # Finalize any pending text part before saving the message
         # This handles cases where text-end event wasn't emitted (e.g., when finish_reason is tool_calls)
         self._finalize_pending_text_part()
 
-        # Extract usage from finish messageMetadata and add as a part so the frontend
-        # can show response-level token usage (MessageActions looks for type "data-usage")
+        # Extract usage from finish messageMetadata for lastContext only (see module docstring).
         metadata = data.get("messageMetadata", {})
         usage = metadata.get("usage")
         if usage:
             usage_data = usage.get("data") if isinstance(usage.get("data"), dict) else usage
             self.final_usage = usage_data
-            if usage_data:
-                self._append_to_message_parts_buffer({"type": "data-usage", "data": usage_data})
 
         if self.message_parts_buffer and self.current_message_id:
             self.assistant_messages.append(

--- a/backend/app/utils/stream_processor.py
+++ b/backend/app/utils/stream_processor.py
@@ -166,14 +166,30 @@ class StreamEventProcessor:
             self.current_tool_parts.pop(tool_call_id, None)
 
     def _handle_data_usage_event(self, data: Dict[str, Any]) -> None:
-        """Handle 'data-usage' event."""
-        self._append_to_message_parts_buffer(data)
+        """Handle 'data-usage' event. Extract inner usage and track like finish."""
+        # Payload may be full envelope {"type": "data-usage", "data": {...}} or just {...}
+        inner = data.get("data") if isinstance(data.get("data"), dict) else None
+        usage_data = inner if inner is not None else data
+        if usage_data:
+            self.final_usage = usage_data
+        part = {"type": "data-usage", "data": usage_data} if usage_data else data
+        self._append_to_message_parts_buffer(part)
 
     def _handle_finish_event(self, data: Dict[str, Any]) -> None:
         """Handle 'finish' event - finalize message and track usage."""
         # Finalize any pending text part before saving the message
         # This handles cases where text-end event wasn't emitted (e.g., when finish_reason is tool_calls)
         self._finalize_pending_text_part()
+
+        # Extract usage from finish messageMetadata and add as a part so the frontend
+        # can show response-level token usage (MessageActions looks for type "data-usage")
+        metadata = data.get("messageMetadata", {})
+        usage = metadata.get("usage")
+        if usage:
+            usage_data = usage.get("data") if isinstance(usage.get("data"), dict) else usage
+            self.final_usage = usage_data
+            if usage_data:
+                self._append_to_message_parts_buffer({"type": "data-usage", "data": usage_data})
 
         if self.message_parts_buffer and self.current_message_id:
             self.assistant_messages.append(
@@ -186,12 +202,6 @@ class StreamEventProcessor:
                     "chatId": str(self.chat_id),
                 }
             )
-
-        # Track usage
-        metadata = data.get("messageMetadata", {})
-        usage = metadata.get("usage")
-        if usage:
-            self.final_usage = usage["data"]
 
     def _process_event_data(self, data: Dict[str, Any]) -> None:
         """Process a parsed event data dictionary."""

--- a/frontend/app/(chat)/chat/[id]/page.tsx
+++ b/frontend/app/(chat)/chat/[id]/page.tsx
@@ -108,10 +108,10 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
           autoResume={true}
           id={chat.id}
           initialChatModel={DEFAULT_CHAT_MODEL}
-          initialLastContext={chat.lastContext ?? undefined}
           initialMessages={uiMessages}
           initialVisibilityType={chat.visibility}
           isReadonly={!isOwner}
+          lastContext={chat.lastContext ?? undefined}
         />
         <DataStreamHandler />
       </>
@@ -124,10 +124,10 @@ async function ChatPage({ params }: { params: Promise<{ id: string }> }) {
         autoResume={true}
         id={chat.id}
         initialChatModel={chatModelFromCookie.value}
-        initialLastContext={chat.lastContext ?? undefined}
         initialMessages={uiMessages}
         initialVisibilityType={chat.visibility}
         isReadonly={!isOwner}
+        lastContext={chat.lastContext ?? undefined}
       />
       <DataStreamHandler />
     </>

--- a/frontend/components/chat.tsx
+++ b/frontend/components/chat.tsx
@@ -4,7 +4,7 @@ import { useChat } from "@ai-sdk/react";
 import { IngestSessionData360 } from "@pcn-js/data360";
 import { DefaultChatTransport } from "ai";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { unstable_serialize } from "swr/infinite";
 import { ChatHeader } from "@/components/chat-header";
@@ -27,7 +27,13 @@ import { getApiUrl } from "@/lib/api-client";
 import type { DBMessage, Vote } from "@/lib/db/schema";
 import { ChatSDKError } from "@/lib/errors";
 import type { Attachment, ChatMessage } from "@/lib/types";
-import type { AppUsage } from "@/lib/usage";
+import {
+  aggregateUsage,
+  getLatestUsage,
+  getUsageByMessageId,
+  type AppUsage,
+  type LastContext,
+} from "@/lib/usage";
 import {
   cn,
   convertToUIMessages,
@@ -56,7 +62,7 @@ export function Chat({
   initialVisibilityType,
   isReadonly,
   autoResume,
-  initialLastContext,
+  lastContext,
 }: {
   id: string;
   initialMessages: ChatMessage[];
@@ -64,7 +70,8 @@ export function Chat({
   initialVisibilityType: VisibilityType;
   isReadonly: boolean;
   autoResume: boolean;
-  initialLastContext?: AppUsage;
+  /** From API: { latest, byMessageId } or legacy plain usage */
+  lastContext?: LastContext | null;
 }) {
   const router = useRouter();
 
@@ -88,7 +95,10 @@ export function Chat({
   const { setDataStream } = useDataStream();
 
   const [input, setInput] = useState<string>("");
-  const [usage, setUsage] = useState<AppUsage | undefined>(initialLastContext);
+  const [usage, setUsage] = useState<AppUsage | undefined>(() =>
+    getLatestUsage(lastContext),
+  );
+  const latestUsageRef = useRef<AppUsage | undefined>(undefined);
   const [showCreditCardAlert, setShowCreditCardAlert] = useState(false);
   const [currentModelId, setCurrentModelId] = useState(initialChatModel);
   const currentModelIdRef = useRef(currentModelId);
@@ -98,9 +108,23 @@ export function Chat({
   const isWaitingForSavedPartsRef = useRef(false);
   const [isWaitingForSavedParts, setIsWaitingForSavedParts] = useState(false);
 
+  // lastContext is the canonical usage source (latest + byMessageId). We keep it in state so we can
+  // update it after refetch when a stream completes; otherwise we only have the initial load value.
+  const [lastContextState, setLastContextState] = useState<LastContext | null | undefined>(
+    () => lastContext ?? undefined,
+  );
+
   useEffect(() => {
     currentModelIdRef.current = currentModelId;
   }, [currentModelId]);
+
+  // When navigating to a different chat (lastContext from server changes), sync state and reset usage
+  useEffect(() => {
+    setLastContextState(lastContext ?? undefined);
+    const latest = getLatestUsage(lastContext);
+    setUsage(latest);
+    latestUsageRef.current = undefined;
+  }, [lastContext]);
 
   // Hook to handle streaming data-thinking events
   const dataThinkingStream = useDataThinkingStream();
@@ -214,8 +238,39 @@ export function Chat({
       // Add non-data-thinking events to dataStream for artifact handling
       setDataStream((ds) => (ds ? [...ds, dataPart] : [dataPart]));
 
-      if (dataPart.type === "data-usage") {
-        setUsage(dataPart.data);
+      // Usage from stream (data-usage part or finish.messageMetadata)
+      const partWithFinish = dataPart as {
+        type?: string;
+        data?: unknown;
+        messageMetadata?: { usage?: unknown };
+        "data-finish"?: { messageMetadata?: { usage?: unknown } };
+      };
+      if (partWithFinish.type === "data-usage" && "data" in dataPart) {
+        const payload = (dataPart as { data: AppUsage }).data;
+        latestUsageRef.current = payload;
+        setUsage(payload);
+      } else {
+        const finishPayload =
+          partWithFinish["data-finish"] ??
+          (partWithFinish.type === "finish" ? partWithFinish : null);
+        const meta = finishPayload?.messageMetadata;
+        if (
+          meta &&
+          typeof meta === "object" &&
+          "usage" in meta &&
+          meta.usage != null
+        ) {
+          const raw = meta.usage as
+            | AppUsage
+            | { type?: string; data?: AppUsage };
+          const usagePayload =
+            typeof raw === "object" && "data" in raw && raw.data != null
+              ? raw.data
+              : raw;
+          const payload = usagePayload as AppUsage;
+          latestUsageRef.current = payload;
+          setUsage(payload);
+        }
       }
     },
     onFinish: () => {
@@ -330,6 +385,19 @@ export function Chat({
             }
             return updated;
           });
+          // Refetch chat so lastContext (latest + byMessageId) is up to date; use it as primary usage source
+          try {
+            const chatRes = await fetchWithErrorHandlers(getApiUrl(`/api/chat/${id}`));
+            if (chatRes.ok) {
+              const chatData = (await chatRes.json()) as {
+                chat?: { lastContext?: LastContext | null };
+              };
+              const next = chatData.chat?.lastContext ?? undefined;
+              setLastContextState(next);
+            }
+          } catch {
+            // Non-fatal: we still have lastContextState from before; stream usage is already in state
+          }
         } catch {
           isWaitingForSavedPartsRef.current = false;
           setIsWaitingForSavedParts(false);
@@ -470,6 +538,29 @@ export function Chat({
 
   const isEmpty = messages.length === 0;
   const homeConfig = useHomeConfig();
+
+  const usageByMessageId = useMemo(
+    () => getUsageByMessageId(lastContextState) ?? {},
+    [lastContextState],
+  );
+
+  // Full-chat usage: lastContext (byMessageId); stream for last message until refetch.
+  const fullChatUsage = useMemo(() => {
+    const assistantMessages = messages.filter((m) => m.role === "assistant");
+    const usages: AppUsage[] = [];
+    const lastMessageUsage = usage ?? latestUsageRef.current;
+    for (let i = 0; i < assistantMessages.length; i++) {
+      const msg = assistantMessages[i];
+      const isLast = i === assistantMessages.length - 1;
+      const fromByMsg = usageByMessageId[msg.id];
+      const fromStream = isLast ? lastMessageUsage : undefined;
+      const u = fromByMsg ?? fromStream;
+      if (u != null) usages.push(u);
+    }
+    if (usages.length === 0) return undefined;
+    return aggregateUsage(usages);
+  }, [usageByMessageId, messages, usage]);
+
   const inputComponent = !isReadonly ? (
     <MultimodalInput
       ref={inputFocusRef}
@@ -495,7 +586,7 @@ export function Chat({
       status={status}
       stop={stop}
       suggestions={isEmpty ? homeConfig.suggestions : undefined}
-      usage={usage}
+      usage={fullChatUsage}
     />
   ) : null;
 
@@ -560,7 +651,9 @@ export function Chat({
               isWaitingForSavedParts={
                 isWaitingForSavedParts || isWaitingForSavedPartsRef.current
               }
+              lastMessageUsage={usage}
               messages={messages}
+              usageByMessageId={usageByMessageId}
               onFollowUpPopulateInput={onFollowUpPopulateInput}
               regenerate={regenerate}
               selectedModelId={initialChatModel}

--- a/frontend/components/data360/get-data.tsx
+++ b/frontend/components/data360/get-data.tsx
@@ -10,7 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { TimeSeriesChart } from "./charts";
-import type { GetDataOutput } from "./types";
+import type { GetDataInput, GetDataOutput } from "./types";
 
 const ChartIcon = ({ size = 24 }: { size?: number }) => (
   <svg fill="none" height={size} viewBox="0 0 24 24" width={size}>
@@ -31,7 +31,126 @@ const ChartIcon = ({ size = 24 }: { size?: number }) => (
   </svg>
 );
 
-export function GetData({ output }: { output: GetDataOutput }) {
+/** Human-readable dimension names for disaggregation filters */
+const DIMENSION_LABELS: Record<string, string> = {
+  REF_AREA: "Countries/areas",
+  SEX: "Sex",
+  AGE: "Age",
+  URBANISATION: "Urbanisation",
+  UNIT_MEASURE: "Unit",
+};
+
+export function GetDataRequestSummary({
+  input,
+  indicatorName,
+}: {
+  input: GetDataInput;
+  indicatorName?: string | null;
+}) {
+  const hasDatabase = input.database_id != null && String(input.database_id).trim() !== "";
+  const hasIndicator = input.indicator_id != null && String(input.indicator_id).trim() !== "";
+  const hasIndicatorName =
+    indicatorName != null && String(indicatorName).trim() !== "";
+  const filters = input.disaggregation_filters
+    ? Object.entries(input.disaggregation_filters).filter(
+        ([, v]) => v != null && String(v).trim() !== "",
+      )
+    : [];
+  const hasYears =
+    (input.start_year != null && Number.isFinite(Number(input.start_year))) ||
+    (input.end_year != null && Number.isFinite(Number(input.end_year)));
+  const hasPagination =
+    (input.limit != null && Number.isFinite(Number(input.limit))) ||
+    (input.offset != null && Number.isFinite(Number(input.offset)));
+
+  if (
+    !hasDatabase &&
+    !hasIndicator &&
+    !hasIndicatorName &&
+    filters.length === 0 &&
+    !hasYears &&
+    !hasPagination
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 p-3">
+      <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Request
+      </div>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-2">
+        {hasDatabase && (
+          <>
+            <dt className="font-medium text-muted-foreground">Database</dt>
+            <dd className="font-mono text-foreground">{input.database_id}</dd>
+          </>
+        )}
+        {hasIndicatorName && (
+          <>
+            <dt className="font-medium text-muted-foreground">Indicator name</dt>
+            <dd className="text-foreground">{indicatorName}</dd>
+          </>
+        )}
+        {hasIndicator && (
+          <>
+            <dt className="font-medium text-muted-foreground">Indicator ID</dt>
+            <dd className="break-all font-mono text-foreground">
+              {input.indicator_id}
+            </dd>
+          </>
+        )}
+        {hasYears && (
+          <>
+            <dt className="font-medium text-muted-foreground">Years</dt>
+            <dd className="text-foreground">
+              {input.start_year != null && input.end_year != null
+                ? `${input.start_year} – ${input.end_year}`
+                : input.start_year != null
+                  ? `From ${input.start_year}`
+                  : input.end_year != null
+                    ? `Through ${input.end_year}`
+                    : ""}
+            </dd>
+          </>
+        )}
+        {filters.length > 0 && (
+          <>
+            <dt className="font-medium text-muted-foreground">Filters</dt>
+            <dd className="text-foreground">
+              <span className="flex flex-wrap gap-x-2 gap-y-1">
+                {filters.map(([dim, val]) => (
+                  <span key={dim} className="rounded bg-muted px-1.5 py-0.5">
+                    <span className="text-muted-foreground">
+                      {DIMENSION_LABELS[dim] ?? dim}:
+                    </span>{" "}
+                    {val}
+                  </span>
+                ))}
+              </span>
+            </dd>
+          </>
+        )}
+        {hasPagination && (
+          <>
+            <dt className="font-medium text-muted-foreground">Page</dt>
+            <dd className="text-foreground">
+              Limit {input.limit ?? "—"}, offset {input.offset ?? 0}
+            </dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}
+
+export function GetData({
+  input,
+  output,
+}: {
+  input?: GetDataInput | null;
+  output: GetDataOutput;
+}) {
   // Group data by indicator
   const groupedByIndicator = useMemo(() => {
     if (!output.data || output.data.length === 0) {
@@ -50,6 +169,23 @@ export function GetData({ output }: { output: GetDataOutput }) {
 
   // Get unique indicators
   const indicators = Array.from(groupedByIndicator.keys());
+
+  // Indicator name(s) from data (for Request summary and header)
+  const indicatorNamesFromData = useMemo(() => {
+    if (!output.data || output.data.length === 0) {
+      return [];
+    }
+    const nameByIndicator = new Map<string, string>();
+    for (const point of output.data) {
+      const name = point.INDICATOR_NAME?.trim();
+      if (name && !nameByIndicator.has(point.INDICATOR)) {
+        nameByIndicator.set(point.INDICATOR, name);
+      }
+    }
+    return Array.from(nameByIndicator.values());
+  }, [output.data]);
+  const firstIndicatorName =
+    indicatorNamesFromData.length > 0 ? indicatorNamesFromData[0] : null;
 
   // Get all unique countries/areas
   const areas = useMemo(() => {
@@ -107,9 +243,17 @@ export function GetData({ output }: { output: GetDataOutput }) {
   // Handle error case
   if (output.error) {
     return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
-        <div className="font-medium">Error</div>
-        <div className="mt-1">{output.error}</div>
+      <div className="flex flex-col gap-3">
+        {input != null && (
+          <GetDataRequestSummary
+            input={input}
+            indicatorName={firstIndicatorName}
+          />
+        )}
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
+          <div className="font-medium">Error</div>
+          <div className="mt-1">{output.error}</div>
+        </div>
       </div>
     );
   }
@@ -117,8 +261,16 @@ export function GetData({ output }: { output: GetDataOutput }) {
   // Handle empty results
   if (!output.data || output.data.length === 0) {
     return (
-      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
-        No data available
+      <div className="flex flex-col gap-3">
+        {input != null && (
+          <GetDataRequestSummary
+            input={input}
+            indicatorName={firstIndicatorName}
+          />
+        )}
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No data available
+        </div>
       </div>
     );
   }
@@ -140,10 +292,17 @@ export function GetData({ output }: { output: GetDataOutput }) {
   if (output.data.length === 1) {
     const point = output.data[0];
     return (
-      <Card className="w-full border-border shadow-sm">
-        <CardHeader className="border-border border-b pb-4">
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-3">
+        {input != null && (
+          <GetDataRequestSummary
+            input={input}
+            indicatorName={point.INDICATOR_NAME ?? firstIndicatorName}
+          />
+        )}
+        <Card className="w-full border-border shadow-sm">
+          <CardHeader className="border-border border-b pb-4">
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
               <ChartIcon size={18} />
               <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
                 Indicator Data
@@ -261,19 +420,38 @@ export function GetData({ output }: { output: GetDataOutput }) {
           </div>
         </CardContent>
       </Card>
+      </div>
     );
   }
 
   // Multiple data points view
   return (
     <div className="flex w-full flex-col gap-4 overflow-hidden rounded-sm bg-background px-4 pb-4">
+      {input != null && (
+        <GetDataRequestSummary
+          input={input}
+          indicatorName={firstIndicatorName}
+        />
+      )}
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <div className="text-muted-foreground">
-            <ChartIcon size={20} />
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <div className="text-muted-foreground">
+              <ChartIcon size={20} />
+            </div>
+            <div className="font-semibold text-sm">Indicator Data</div>
           </div>
-          <div className="font-semibold text-sm">Indicator Data</div>
+          {indicatorNamesFromData.length > 0 && (
+            <div className="text-muted-foreground text-xs">
+              {indicatorNamesFromData.length === 1
+                ? indicatorNamesFromData[0]
+                : indicatorNamesFromData.slice(0, 3).join(" · ") +
+                  (indicatorNamesFromData.length > 3
+                    ? ` · +${indicatorNamesFromData.length - 3} more`
+                    : "")}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-3">
           <div className="text-muted-foreground text-xs">

--- a/frontend/components/data360/search-indicators.tsx
+++ b/frontend/components/data360/search-indicators.tsx
@@ -9,23 +9,88 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { SearchIndicatorsOutput } from "./types";
+import type { SearchIndicatorsInput, SearchIndicatorsOutput } from "./types";
 
 const SearchIconComponent = () => (
   <SearchIcon className="size-5 text-muted-foreground" />
 );
 
+export function SearchIndicatorsRequestSummary({
+  input,
+}: {
+  input: SearchIndicatorsInput;
+}) {
+  const hasQuery = input.query != null && String(input.query).trim() !== "";
+  const hasCountry =
+    input.required_country != null &&
+    String(input.required_country).trim() !== "";
+  const hasLimit =
+    input.limit != null && Number.isFinite(Number(input.limit));
+  const hasOffset =
+    input.offset != null && Number.isFinite(Number(input.offset));
+
+  if (!hasQuery && !hasCountry && !hasLimit && !hasOffset) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 p-3">
+      <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Request
+      </div>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-1.5 text-xs sm:grid-cols-2">
+        {hasQuery && (
+          <>
+            <dt className="font-medium text-muted-foreground">Query</dt>
+            <dd className="text-foreground">&ldquo;{input.query}&rdquo;</dd>
+          </>
+        )}
+        {hasCountry && (
+          <>
+            <dt className="font-medium text-muted-foreground">
+              Required country
+            </dt>
+            <dd className="font-mono text-foreground">
+              {input.required_country}
+            </dd>
+          </>
+        )}
+        {hasLimit && (
+          <>
+            <dt className="font-medium text-muted-foreground">Limit</dt>
+            <dd className="text-foreground">{input.limit}</dd>
+          </>
+        )}
+        {hasOffset && (
+          <>
+            <dt className="font-medium text-muted-foreground">Offset</dt>
+            <dd className="text-foreground">{input.offset}</dd>
+          </>
+        )}
+      </dl>
+    </div>
+  );
+}
+
 export function SearchIndicators({
+  input,
   output,
 }: {
+  input?: SearchIndicatorsInput | null;
   output: SearchIndicatorsOutput;
 }) {
+  const requestSummary =
+    input != null ? <SearchIndicatorsRequestSummary input={input} /> : null;
+
   // Handle error case
   if (output.error) {
     return (
-      <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
-        <div className="font-medium">Error</div>
-        <div className="mt-1">{output.error}</div>
+      <div className="flex flex-col gap-3">
+        {requestSummary}
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
+          <div className="font-medium">Error</div>
+          <div className="mt-1">{output.error}</div>
+        </div>
       </div>
     );
   }
@@ -33,8 +98,11 @@ export function SearchIndicators({
   // Handle empty results
   if (!output.indicators || output.indicators.length === 0) {
     return (
-      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
-        No indicators found
+      <div className="flex flex-col gap-3">
+        {requestSummary}
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No indicators found
+        </div>
       </div>
     );
   }
@@ -42,11 +110,14 @@ export function SearchIndicators({
   return (
     <TooltipProvider>
       <div className="flex w-full flex-col gap-4 overflow-hidden rounded-sm bg-background px-4 pb-4">
+        {requestSummary}
         {/* Header */}
         <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <SearchIconComponent />
-            <div className="font-semibold text-sm">Search Results</div>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <SearchIconComponent />
+              <div className="font-semibold text-sm">Search Results</div>
+            </div>
           </div>
           <div className="flex flex-col items-end gap-1">
             <div className="text-muted-foreground text-xs">

--- a/frontend/components/data360/types.ts
+++ b/frontend/components/data360/types.ts
@@ -40,6 +40,14 @@ export type SearchIndicatorItem = {
   dimensions: string[] | null;
 };
 
+/** Tool input for data360_search_indicators (from tool call arguments). */
+export type SearchIndicatorsInput = {
+  query?: string | null;
+  required_country?: string | null;
+  limit?: number | null;
+  offset?: number | null;
+};
+
 export type SearchIndicatorsOutput = {
   count: number;
   total_count: number;
@@ -49,6 +57,8 @@ export type SearchIndicatorsOutput = {
   indicators: SearchIndicatorItem[];
   required_country: string | null;
   error: string | null;
+  /** Query used for the search (may come from tool input when not in API response). */
+  query?: string | null;
 };
 
 export type GetDataDataPoint = {
@@ -78,6 +88,17 @@ export type GetDataDataPoint = {
   UNIT_MEASURE: string;
   UNIT_TYPE: string | null;
   claim_id: string;
+};
+
+/** Tool input for data360_get_data (from tool call arguments). */
+export type GetDataInput = {
+  database_id?: string;
+  indicator_id?: string;
+  disaggregation_filters?: Record<string, string | null>;
+  start_year?: number | null;
+  end_year?: number | null;
+  limit?: number | null;
+  offset?: number | null;
 };
 
 export type GetDataOutput = {

--- a/frontend/components/message-actions.tsx
+++ b/frontend/components/message-actions.tsx
@@ -18,12 +18,15 @@ export function PureMessageActions({
   vote,
   isLoading,
   setMode,
+  usageOverride,
 }: {
   chatId: string;
   message: ChatMessage;
   vote: Vote | undefined;
   isLoading: boolean;
   setMode?: (mode: "view" | "edit") => void;
+  /** Per-message usage from lastContext.byMessageId or stream for last message until refetch */
+  usageOverride?: AppUsage;
 }) {
   const { mutate } = useSWRConfig();
   const [_, copyToClipboard] = useCopyToClipboard();
@@ -39,14 +42,7 @@ export function PureMessageActions({
     .join("\n")
     .trim();
 
-  // Extract usage data from message parts
-  // The data-usage event is stored in parts with structure: { type: "data-usage", data: {...} }
-  const usagePart = message.parts?.find(
-    (part) => part.type === "data-usage"
-  );
-  const usageData: AppUsage | undefined = usagePart
-    ? (usagePart as { type: string; data?: AppUsage }).data
-    : undefined;
+  const usageData: AppUsage | undefined = usageOverride;
 
   const handleCopy = async () => {
     if (!textFromParts) {
@@ -303,6 +299,9 @@ export const MessageActions = memo(
       return false;
     }
     if (prevProps.isLoading !== nextProps.isLoading) {
+      return false;
+    }
+    if (!equal(prevProps.usageOverride, nextProps.usageOverride)) {
       return false;
     }
 

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -15,6 +15,7 @@ import {
 import type { Vote } from "@/lib/db/schema";
 import { parseFollowUps } from "@/lib/parse-follow-ups";
 import type { ChatMessage, StreamingThinkingPart } from "@/lib/types";
+import type { AppUsage } from "@/lib/usage";
 import { isNonRenderableStreamEvent } from "@/lib/types";
 import { cn, sanitizeText } from "@/lib/utils";
 import { ASK_ABOUT_SELECTION_CONTEXT_ATTR } from "./ask-about-selection-toolbar";
@@ -638,6 +639,7 @@ const PurePreviewMessage = ({
   followUpSuggestionsPopulateInput = true,
   onFollowUpPopulateInput,
   onScrollToMessageId,
+  usageOverride,
 }: {
   chatId: string;
   message: ChatMessage;
@@ -658,6 +660,8 @@ const PurePreviewMessage = ({
   followUpSuggestionsPopulateInput?: boolean;
   onFollowUpPopulateInput?: (text: string) => void;
   onScrollToMessageId?: (messageId: string) => void;
+  /** Per-message usage from lastContext.byMessageId or stream for last message until refetch */
+  usageOverride?: AppUsage;
 }) => {
   const [mode, setMode] = useState<"view" | "edit">("view");
   const { setArtifact } = useArtifact();
@@ -986,6 +990,7 @@ const PurePreviewMessage = ({
               key={`action-${message.id}`}
               message={message}
               setMode={setMode}
+              usageOverride={usageOverride}
               vote={vote}
             />
           )}
@@ -1022,6 +1027,9 @@ export const PreviewMessage = memo(
       return false;
     }
     if (prevProps.sendMessage !== nextProps.sendMessage) {
+      return false;
+    }
+    if (!equal(prevProps.usageOverride, nextProps.usageOverride)) {
       return false;
     }
     if (

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -21,9 +21,12 @@ import { cn, sanitizeText } from "@/lib/utils";
 import { ASK_ABOUT_SELECTION_CONTEXT_ATTR } from "./ask-about-selection-toolbar";
 import { useDataStream } from "./data-stream-provider";
 import { ChartPreview } from "./data360/chart-preview";
-import { GetData } from "./data360/get-data";
+import { GetData, GetDataRequestSummary } from "./data360/get-data";
+import {
+  SearchIndicators,
+  SearchIndicatorsRequestSummary,
+} from "./data360/search-indicators";
 import { GetWdiData } from "./data360/get-wdi-data";
-import { SearchIndicators } from "./data360/search-indicators";
 import { SearchRelevantIndicators } from "./data360/search-relevant-indicators";
 import { DocumentToolResult } from "./document";
 import { DocumentPreview } from "./document-preview";
@@ -462,7 +465,7 @@ function renderMessagePart(
     const toolPart = part as {
       toolCallId: string;
       state: "input-available" | "output-available";
-      input: unknown;
+      input: Record<string, unknown> | unknown;
       output: {
         count: number;
         total_count: number | null;
@@ -500,13 +503,52 @@ function renderMessagePart(
         error: string | null;
       };
     };
+    const getDataInput =
+      typeof toolPart.input === "object" && toolPart.input !== null
+        ? (() => {
+            const raw = toolPart.input as Record<string, unknown>;
+            const disaggregation_filters = raw.disaggregation_filters as
+              | Record<string, string | null>
+              | undefined;
+            return {
+              database_id:
+                typeof raw.database_id === "string" ? raw.database_id : undefined,
+              indicator_id:
+                typeof raw.indicator_id === "string" ? raw.indicator_id : undefined,
+              disaggregation_filters:
+                disaggregation_filters &&
+                typeof disaggregation_filters === "object"
+                  ? disaggregation_filters
+                  : undefined,
+              start_year:
+                typeof raw.start_year === "number" && Number.isFinite(raw.start_year)
+                  ? raw.start_year
+                  : undefined,
+              end_year:
+                typeof raw.end_year === "number" && Number.isFinite(raw.end_year)
+                  ? raw.end_year
+                  : undefined,
+              limit:
+                typeof raw.limit === "number" && Number.isFinite(raw.limit)
+                  ? raw.limit
+                  : undefined,
+              offset:
+                typeof raw.offset === "number" && Number.isFinite(raw.offset)
+                  ? raw.offset
+                  : undefined,
+            };
+          })()
+        : undefined;
     return (
       <Tool defaultOpen={true} key={toolPart.toolCallId}>
         <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
         <ToolContent>
-          {toolPart.state === "input-available" && (
-            <ToolInput input={toolPart.input} />
-          )}
+          {toolPart.state === "input-available" &&
+            (getDataInput != null ? (
+              <GetDataRequestSummary input={getDataInput} />
+            ) : (
+              <ToolInput input={toolPart.input} />
+            ))}
           {toolPart.state === "output-available" && (
             <ToolOutput
               errorText={undefined}
@@ -516,7 +558,7 @@ function renderMessagePart(
                   toolName={DATA360_GET_DATA_TOOL}
                   output={toolPart.output}
                 >
-                  <GetData output={toolPart.output} />
+                  <GetData input={getDataInput} output={toolPart.output} />
                 </IngestToolOutput>
               }
             />
@@ -531,7 +573,7 @@ function renderMessagePart(
     const toolPart = part as {
       toolCallId: string;
       state: "input-available" | "output-available";
-      input: unknown;
+      input: Record<string, unknown> | unknown;
       output: {
         count: number;
         total_count: number;
@@ -553,18 +595,53 @@ function renderMessagePart(
         error: string | null;
       };
     };
+    const searchIndicatorsInput =
+      typeof toolPart.input === "object" && toolPart.input !== null
+        ? (() => {
+            const raw = toolPart.input as Record<string, unknown>;
+            return {
+              query:
+                typeof raw.query === "string" ? raw.query : undefined,
+              required_country:
+                typeof raw.required_country === "string"
+                  ? raw.required_country
+                  : undefined,
+              limit:
+                typeof raw.limit === "number" && Number.isFinite(raw.limit)
+                  ? raw.limit
+                  : undefined,
+              offset:
+                typeof raw.offset === "number" && Number.isFinite(raw.offset)
+                  ? raw.offset
+                  : undefined,
+            };
+          })()
+        : undefined;
     return (
       <Tool defaultOpen={true} key={toolPart.toolCallId}>
         <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
         <ToolContent>
-          {toolPart.state === "input-available" && (
-            <ToolInput input={toolPart.input} />
-          )}
+          {toolPart.state === "input-available" &&
+            (searchIndicatorsInput != null ? (
+              <SearchIndicatorsRequestSummary
+                input={searchIndicatorsInput}
+              />
+            ) : (
+              <ToolInput input={toolPart.input} />
+            ))}
           {toolPart.state === "output-available" && (
             <ToolOutput
               errorText={undefined}
               useDefaultFormat={false}
-              output={<SearchIndicators output={toolPart.output} />}
+              output={
+                <SearchIndicators
+                  input={searchIndicatorsInput}
+                  output={{
+                    ...toolPart.output,
+                    query: searchIndicatorsInput?.query,
+                  }}
+                />
+              }
             />
           )}
         </ToolContent>

--- a/frontend/components/messages.tsx
+++ b/frontend/components/messages.tsx
@@ -8,6 +8,7 @@ import { useMessages } from "@/hooks/use-messages";
 import type { Vote } from "@/lib/db/schema";
 import { appConfig } from "@/lib/config";
 import type { ChatMessage } from "@/lib/types";
+import type { AppUsage } from "@/lib/usage";
 import { useArtifactSelector } from "@/hooks/use-artifact";
 import { useDataStream } from "./data-stream-provider";
 import { PreviewMessage, ThinkingMessage } from "./message";
@@ -37,6 +38,10 @@ type MessagesProps = {
     id: string;
     data: ChatMessage["parts"][number];
   }>;
+  /** Stream usage for the last assistant message until lastContext refetch */
+  lastMessageUsage?: AppUsage;
+  /** Per-message usage from lastContext.byMessageId */
+  usageByMessageId?: Record<string, AppUsage>;
 };
 
 function PureMessages({
@@ -55,6 +60,8 @@ function PureMessages({
   selectedModelId: _selectedModelId,
   streamingThinkingStage = null,
   streamingThinkingParts = [],
+  lastMessageUsage,
+  usageByMessageId,
 }: MessagesProps) {
   const artifactScrollBehavior = appConfig.artifactScrollBehavior;
   const artifactTriggerMessageId = useArtifactSelector(
@@ -285,6 +292,8 @@ function PureMessages({
             const isLoading =
               status === "streaming" && messages.length - 1 === index;
             const isLastMessage = index === messages.length - 1;
+            const isLastAssistantMessage =
+              isLastMessage && message.role === "assistant";
             const hasSavedThinkingParts =
               message.parts?.some(
                 (part) =>
@@ -333,6 +342,12 @@ function PureMessages({
                   }
                   streamingThinkingParts={
                     shouldUseStreamingParts ? streamingThinkingParts : []
+                  }
+                  usageOverride={
+                    message.role === "assistant"
+                      ? usageByMessageId?.[message.id] ??
+                        (isLastAssistantMessage ? lastMessageUsage : undefined)
+                      : undefined
                   }
                   vote={
                     votes
@@ -394,6 +409,12 @@ export const Messages = memo(PureMessages, (prevProps, nextProps) => {
     return false;
   }
   if (!equal(prevProps.messages, nextProps.messages)) {
+    return false;
+  }
+  if (!equal(prevProps.lastMessageUsage, nextProps.lastMessageUsage)) {
+    return false;
+  }
+  if (!equal(prevProps.usageByMessageId, nextProps.usageByMessageId)) {
     return false;
   }
   if (!equal(prevProps.votes, nextProps.votes)) {

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -11,7 +11,7 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
-import type { AppUsage } from "../usage";
+import type { LastContext } from "../usage";
 
 export const user = pgTable("User", {
   id: uuid("id").primaryKey().notNull().defaultRandom(),
@@ -31,7 +31,7 @@ export const chat = pgTable("Chat", {
   visibility: varchar("visibility", { enum: ["public", "private"] })
     .notNull()
     .default("private"),
-  lastContext: jsonb("lastContext").$type<AppUsage | null>(),
+  lastContext: jsonb("lastContext").$type<LastContext | null>(),
 });
 
 export type Chat = InferSelectModel<typeof chat>;

--- a/frontend/lib/usage.ts
+++ b/frontend/lib/usage.ts
@@ -3,3 +3,109 @@ import type { UsageData } from "tokenlens/helpers";
 
 // Server-merged usage: base usage + TokenLens summary + optional modelId
 export type AppUsage = LanguageModelUsage & UsageData & { modelId?: string };
+
+/** Chat lastContext: legacy (plain usage) or per-message shape from backend */
+export type LastContext =
+  | AppUsage
+  | { latest?: AppUsage; byMessageId?: Record<string, AppUsage> };
+
+/** Get the single "latest" usage from lastContext (for initial state / backward compat). */
+export function getLatestUsage(
+  lastContext: LastContext | null | undefined,
+): AppUsage | undefined {
+  if (lastContext == null) return undefined;
+  if (
+    typeof lastContext === "object" &&
+    "latest" in lastContext &&
+    lastContext.latest != null
+  )
+    return lastContext.latest as AppUsage;
+  if (typeof lastContext === "object" && "totalTokens" in lastContext)
+    return lastContext as AppUsage;
+  return undefined;
+}
+
+/** Get per-message usage map from lastContext. */
+export function getUsageByMessageId(
+  lastContext: LastContext | null | undefined,
+): Record<string, AppUsage> | undefined {
+  if (lastContext == null || typeof lastContext !== "object") return undefined;
+  if ("byMessageId" in lastContext && lastContext.byMessageId != null)
+    return lastContext.byMessageId as Record<string, AppUsage>;
+  return undefined;
+}
+
+const NUMERIC_USAGE_KEYS = [
+  "prompt_tokens",
+  "completion_tokens",
+  "totalTokens",
+  "inputTokens",
+  "outputTokens",
+  "cachedInputTokens",
+  "reasoningTokens",
+] as const;
+
+/** Canonical cost keys used by the UI. Map aliases into these when aggregating. */
+const COST_CANONICAL: Record<string, keyof typeof COST_KEYS> = {
+  inputUSD: "inputUSD",
+  inputTokenUSD: "inputUSD",
+  input_token_usd: "inputUSD",
+  outputUSD: "outputUSD",
+  outputTokenUSD: "outputUSD",
+  output_token_usd: "outputUSD",
+  cacheReadUSD: "cacheReadUSD",
+  cacheReadsUSD: "cacheReadUSD",
+  cache_read_usd: "cacheReadUSD",
+  reasoningUSD: "reasoningUSD",
+  reasoning_usd: "reasoningUSD",
+  totalUSD: "totalUSD",
+  total_usd: "totalUSD",
+};
+
+const COST_KEYS = {
+  inputUSD: true,
+  outputUSD: true,
+  cacheReadUSD: true,
+  reasoningUSD: true,
+  totalUSD: true,
+} as const;
+
+function addCostInto(
+  acc: Record<string, number>,
+  cost: Record<string, unknown>,
+): void {
+  for (const [k, v] of Object.entries(cost)) {
+    if (typeof v !== "number") continue;
+    const canonical =
+      COST_CANONICAL[k] ??
+      (k in COST_KEYS ? (k as keyof typeof COST_KEYS) : null);
+    if (canonical) acc[canonical] = (acc[canonical] ?? 0) + v;
+  }
+}
+
+/** Sum numeric usage fields across multiple AppUsage objects (for full-chat total). */
+export function aggregateUsage(usages: AppUsage[]): AppUsage {
+  const result: Record<string, unknown> = {};
+  const costAcc: Record<string, number> = {};
+  let contextPreserved: Record<string, unknown> | undefined;
+  for (const u of usages) {
+    for (const key of NUMERIC_USAGE_KEYS) {
+      const v = (u as Record<string, unknown>)[key];
+      if (typeof v === "number") {
+        result[key] = ((result[key] as number | undefined) ?? 0) + v;
+      }
+    }
+    const cost = (u as Record<string, unknown>).costUSD;
+    if (cost && typeof cost === "object" && !Array.isArray(cost)) {
+      addCostInto(costAcc, cost as Record<string, unknown>);
+    }
+    if (!contextPreserved) {
+      const ctx = (u as Record<string, unknown>).context;
+      if (ctx && typeof ctx === "object" && !Array.isArray(ctx))
+        contextPreserved = ctx as Record<string, unknown>;
+    }
+  }
+  if (Object.keys(costAcc).length > 0) result.costUSD = costAcc;
+  if (contextPreserved) result.context = contextPreserved;
+  return result as AppUsage;
+}

--- a/frontend/public/json/home-config.json
+++ b/frontend/public/json/home-config.json
@@ -4,10 +4,10 @@
     "subtitle": "Ask a question and explore trends using trusted development data."
   },
   "suggestions": [
-    "What is the child malnutrition rate in South Asia in 2021?",
-    "How has unemployment changed in Southeast Asia since 2010?",
-    "What was the poverty headcount ratio in Kenya in 2019?",
-    "How do health indicators compare across regions in 2020?"
+    "What is the child malnutrition rate for all South Asian countries for 2020?",
+    "How has unemployment changed for Ghana since 2010?",
+    "What was the poverty headcount ratio for the Philippines in 2019?",
+    "What is the latest public default rate for Brazil and Ukraine?"
   ],
   "followUpSuggestionsPopulateInput": true
 }


### PR DESCRIPTION
This PR fixes token usage display and bundles auth, caching, and UI improvements.

### Token usage (make usage work)
- **Backend**: Persist usage per message in `chat.lastContext.byMessageId`; stop emitting `data-usage` stream part; merge usage in chat_queries and pass `message_id` from chat/stream/continue flows.
- **Frontend**: Read per-message and full-chat usage from `lastContext` (refetched after stream); new `lib/usage.ts` helpers; `usageOverride` prop for messages; full-chat total in input/context area.

### Auth
- **Azure**: Async metadata/JWKS fetches (httpx) so the event loop isn’t blocked; less debug logging.
- **User resolution**: Short-TTL cache (2 min) for both MSAL and non-MSAL users to reduce DB round-trips (`USER_CACHE_TTL_SECONDS`).

### Caching
- **MCP tools**: Cache tool list (5 min, configurable) to avoid `list_tools` on every chat.

### Other
- Routing and direct prompts updated; clearer claims reference; test prompt simplified.
- Data360 get-data/search-indicators and types; year buffer; widgets and PCN tagging; home-config examples.