### PR TITLE
fix: Route frontend DB calls through backend API

### DIFF
--- a/backend/alembic/versions/f6a7b8c9d0e1_add_is_deleted_to_message.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_is_deleted_to_message.py
@@ -1,0 +1,36 @@
+"""add_is_deleted_to_message
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-02-26 09:57:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add isDeleted column with default false
+    op.add_column(
+        "Message_v2",
+        sa.Column(
+            "isDeleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("Message_v2", "isDeleted")

--- a/backend/alembic/versions/f6a7b8c9d0e1_add_is_deleted_to_message.py
+++ b/backend/alembic/versions/f6a7b8c9d0e1_add_is_deleted_to_message.py
@@ -1,4 +1,4 @@
-"""add_is_deleted_to_message
+"""add_deleted_at_to_message
 
 Revision ID: f6a7b8c9d0e1
 Revises: e5f6a7b8c9d0
@@ -13,24 +13,19 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "f6a7b8c9d0e1"
+revision: str = "f6a7b8c9d0e1"  # pragma: allowlist secret
 down_revision: Union[str, None] = "e5f6a7b8c9d0"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Add isDeleted column with default false
+    # Add deletedAt column - null means active, timestamp means soft-deleted
     op.add_column(
         "Message_v2",
-        sa.Column(
-            "isDeleted",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.text("false"),
-        ),
+        sa.Column("deletedAt", sa.DateTime(), nullable=True),
     )
 
 
 def downgrade() -> None:
-    op.drop_column("Message_v2", "isDeleted")
+    op.drop_column("Message_v2", "deletedAt")

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -52,6 +52,13 @@ from app.db.queries.chat_queries import (
 from app.db.queries.suggestion_queries import get_suggestions_by_document_id
 from app.utils.message_converter import convert_messages_to_openai_format
 from app.utils.resumable_stream import mark_stream_complete, store_stream_chunk
+from app.api.v1.schemas.chat_schemas import (
+    DeleteTrailingMessagesRequest,
+    DeleteTrailingMessagesResponse,
+    SuggestionResponse,
+    UpdateChatVisibilityRequest,
+    UpdateChatVisibilityResponse,
+)
 from app.utils.stream import patch_response_with_headers
 from app.utils.stream_processor import StreamEventProcessor
 from app.utils.user_id import get_user_id_uuid, user_ids_match
@@ -799,18 +806,14 @@ async def delete_chat(
     }
 
 
-class DeleteTrailingMessagesRequest(BaseModel):
-    id: str
-
-
-@router.delete("/messages")
+@router.delete("/messages", response_model=DeleteTrailingMessagesResponse)
 async def delete_trailing_messages(
     request: DeleteTrailingMessagesRequest,
     current_user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Delete a message and all subsequent messages in the same chat.
+    Soft-delete a message and all subsequent messages in the same chat.
     Used when editing a user message to remove the old message and its responses.
     """
     message_id = UUID(request.id)
@@ -831,18 +834,13 @@ async def delete_trailing_messages(
     )
 
     logger.info(
-        "Deleted %d trailing messages for chat_id=%s from message_id=%s",
+        "Soft-deleted %d trailing messages for chat_id=%s from message_id=%s",
         deleted_count, message.chatId, message_id,
     )
-    return {"deletedCount": deleted_count}
+    return DeleteTrailingMessagesResponse(deletedCount=deleted_count)
 
 
-class UpdateChatVisibilityRequest(BaseModel):
-    chatId: str
-    visibility: str
-
-
-@router.patch("/visibility")
+@router.patch("/visibility", response_model=UpdateChatVisibilityResponse)
 async def update_chat_visibility(
     request: UpdateChatVisibilityRequest,
     current_user: dict = Depends(get_current_user),
@@ -859,10 +857,12 @@ async def update_chat_visibility(
         raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
 
     updated_chat = await update_chat_visibility_by_id(db, chat_id, request.visibility)
-    return {"id": str(updated_chat.id), "visibility": updated_chat.visibility}
+    return UpdateChatVisibilityResponse(
+        id=str(updated_chat.id), visibility=updated_chat.visibility
+    )
 
 
-@router.get("/suggestions")
+@router.get("/suggestions", response_model=List[SuggestionResponse])
 async def get_suggestions(
     documentId: str = Query(...),
     current_user: dict = Depends(get_current_user),
@@ -879,15 +879,15 @@ async def get_suggestions(
         raise ChatSDKError("forbidden:api", status_code=status.HTTP_403_FORBIDDEN)
 
     return [
-        {
-            "id": str(s.id),
-            "documentId": str(s.document_id),
-            "originalText": s.original_text,
-            "suggestedText": s.suggested_text,
-            "description": s.description,
-            "isResolved": s.is_resolved,
-            "userId": str(s.user_id),
-            "createdAt": s.created_at.isoformat() if s.created_at else None,
-        }
+        SuggestionResponse(
+            id=str(s.id),
+            documentId=str(s.document_id),
+            originalText=s.original_text,
+            suggestedText=s.suggested_text,
+            description=s.description,
+            isResolved=s.is_resolved,
+            userId=str(s.user_id),
+            createdAt=s.created_at.isoformat() if s.created_at else None,
+        )
         for s in suggestions
     ]

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -39,7 +39,7 @@ from app.core.errors import ChatSDKError
 from app.db.queries.chat_queries import (
     create_stream_id,
     delete_chat_by_id,
-    delete_messages_by_chat_id_after_timestamp,
+    soft_delete_messages_by_chat_id_after_timestamp,
     get_chat_by_id,
     get_latest_messages_by_chat_id,
     get_message_by_id,
@@ -826,7 +826,7 @@ async def delete_trailing_messages(
     if not user_ids_match(current_user["id"], chat.userId):
         raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
 
-    deleted_count = await delete_messages_by_chat_id_after_timestamp(
+    deleted_count = await soft_delete_messages_by_chat_id_after_timestamp(
         db, message.chatId, message.createdAt
     )
 

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -39,6 +39,7 @@ from app.core.errors import ChatSDKError
 from app.db.queries.chat_queries import (
     create_stream_id,
     delete_chat_by_id,
+    soft_delete_message_by_id,
     soft_delete_messages_by_chat_id_after_timestamp,
     get_chat_by_id,
     get_latest_messages_by_chat_id,
@@ -53,8 +54,8 @@ from app.db.queries.suggestion_queries import get_suggestions_by_document_id
 from app.utils.message_converter import convert_messages_to_openai_format
 from app.utils.resumable_stream import mark_stream_complete, store_stream_chunk
 from app.api.v1.schemas.chat_schemas import (
-    DeleteTrailingMessagesRequest,
-    DeleteTrailingMessagesResponse,
+    DeleteMessagesRequest,
+    DeleteMessagesResponse,
     SuggestionResponse,
     UpdateChatVisibilityRequest,
     UpdateChatVisibilityResponse,
@@ -806,15 +807,15 @@ async def delete_chat(
     }
 
 
-@router.delete("/messages", response_model=DeleteTrailingMessagesResponse)
-async def delete_trailing_messages(
-    request: DeleteTrailingMessagesRequest,
+@router.delete("/messages", response_model=DeleteMessagesResponse)
+async def delete_messages(
+    request: DeleteMessagesRequest,
     current_user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Soft-delete a message and all subsequent messages in the same chat.
-    Used when editing a user message to remove the old message and its responses.
+    Soft-delete a message. If includeTrailing is True (default),
+    also soft-deletes all subsequent messages in the same chat.
     """
     message_id = UUID(request.id)
     message = await get_message_by_id(db, message_id)
@@ -829,15 +830,18 @@ async def delete_trailing_messages(
     if not user_ids_match(current_user["id"], chat.userId):
         raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
 
-    deleted_count = await soft_delete_messages_by_chat_id_after_timestamp(
-        db, message.chatId, message.createdAt
-    )
+    if request.includeTrailing:
+        deleted_count = await soft_delete_messages_by_chat_id_after_timestamp(
+            db, message.chatId, message.createdAt
+        )
+    else:
+        deleted_count = await soft_delete_message_by_id(db, message_id)
 
     logger.info(
-        "Soft-deleted %d trailing messages for chat_id=%s from message_id=%s",
-        deleted_count, message.chatId, message_id,
+        "Soft-deleted %d message(s) for chat_id=%s from message_id=%s (includeTrailing=%s)",
+        deleted_count, message.chatId, message_id, request.includeTrailing,
     )
-    return DeleteTrailingMessagesResponse(deletedCount=deleted_count)
+    return DeleteMessagesResponse(deletedCount=deleted_count)
 
 
 @router.patch("/visibility", response_model=UpdateChatVisibilityResponse)

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -39,13 +39,17 @@ from app.core.errors import ChatSDKError
 from app.db.queries.chat_queries import (
     create_stream_id,
     delete_chat_by_id,
+    delete_messages_by_chat_id_after_timestamp,
     get_chat_by_id,
     get_latest_messages_by_chat_id,
+    get_message_by_id,
     get_message_count_by_user_id,
     get_messages_by_chat_id,
     save_chat,
     save_messages,
+    update_chat_visibility_by_id,
 )
+from app.db.queries.suggestion_queries import get_suggestions_by_document_id
 from app.utils.message_converter import convert_messages_to_openai_format
 from app.utils.resumable_stream import mark_stream_complete, store_stream_chunk
 from app.utils.stream import patch_response_with_headers
@@ -793,3 +797,97 @@ async def delete_chat(
         "userId": str(deleted_chat.userId),
         "lastContext": deleted_chat.lastContext,
     }
+
+
+class DeleteTrailingMessagesRequest(BaseModel):
+    id: str
+
+
+@router.delete("/messages")
+async def delete_trailing_messages(
+    request: DeleteTrailingMessagesRequest,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Delete a message and all subsequent messages in the same chat.
+    Used when editing a user message to remove the old message and its responses.
+    """
+    message_id = UUID(request.id)
+    message = await get_message_by_id(db, message_id)
+
+    if not message:
+        raise ChatSDKError("not_found:message", status_code=status.HTTP_404_NOT_FOUND)
+
+    chat = await get_chat_by_id(db, message.chatId)
+    if not chat:
+        raise ChatSDKError("not_found:chat", status_code=status.HTTP_404_NOT_FOUND)
+
+    if not user_ids_match(current_user["id"], chat.userId):
+        raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
+
+    deleted_count = await delete_messages_by_chat_id_after_timestamp(
+        db, message.chatId, message.createdAt
+    )
+
+    logger.info(
+        "Deleted %d trailing messages for chat_id=%s from message_id=%s",
+        deleted_count, message.chatId, message_id,
+    )
+    return {"deletedCount": deleted_count}
+
+
+class UpdateChatVisibilityRequest(BaseModel):
+    chatId: str
+    visibility: str
+
+
+@router.patch("/visibility")
+async def update_chat_visibility(
+    request: UpdateChatVisibilityRequest,
+    current_user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a chat's visibility (public/private)."""
+    chat_id = UUID(request.chatId)
+    chat = await get_chat_by_id(db, chat_id)
+
+    if not chat:
+        raise ChatSDKError("not_found:chat", status_code=status.HTTP_404_NOT_FOUND)
+
+    if not user_ids_match(current_user["id"], chat.userId):
+        raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
+
+    updated_chat = await update_chat_visibility_by_id(db, chat_id, request.visibility)
+    return {"id": str(updated_chat.id), "visibility": updated_chat.visibility}
+
+
+@router.get("/suggestions")
+async def get_suggestions(
+    documentId: str = Query(...),
+    current_user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get suggestions for a document by document ID."""
+    document_id = UUID(documentId)
+    suggestions = await get_suggestions_by_document_id(db, document_id)
+
+    if not suggestions:
+        return []
+
+    if not user_ids_match(current_user["id"], suggestions[0].user_id):
+        raise ChatSDKError("forbidden:api", status_code=status.HTTP_403_FORBIDDEN)
+
+    return [
+        {
+            "id": str(s.id),
+            "documentId": str(s.document_id),
+            "originalText": s.original_text,
+            "suggestedText": s.suggested_text,
+            "description": s.description,
+            "isResolved": s.is_resolved,
+            "userId": str(s.user_id),
+            "createdAt": s.created_at.isoformat() if s.created_at else None,
+        }
+        for s in suggestions
+    ]

--- a/backend/app/api/v1/schemas/chat_schemas.py
+++ b/backend/app/api/v1/schemas/chat_schemas.py
@@ -1,6 +1,6 @@
 """Pydantic models for chat streaming API."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -41,24 +41,25 @@ class StreamRequest(BaseModel):
 # --- Request models for new endpoints ---
 
 
-class DeleteTrailingMessagesRequest(BaseModel):
-    """Request model for deleting trailing messages (edit/resend)."""
+class DeleteMessagesRequest(BaseModel):
+    """Request model for deleting messages."""
 
     id: str
+    includeTrailing: bool = True
 
 
 class UpdateChatVisibilityRequest(BaseModel):
     """Request model for updating chat visibility."""
 
     chatId: str
-    visibility: str
+    visibility: Literal["public", "private"]
 
 
 # --- Response models for new endpoints ---
 
 
-class DeleteTrailingMessagesResponse(BaseModel):
-    """Response model for delete trailing messages endpoint."""
+class DeleteMessagesResponse(BaseModel):
+    """Response model for delete messages endpoint."""
 
     deletedCount: int
 
@@ -67,7 +68,7 @@ class UpdateChatVisibilityResponse(BaseModel):
     """Response model for update chat visibility endpoint."""
 
     id: str
-    visibility: str
+    visibility: Literal["public", "private"]
 
 
 class SuggestionResponse(BaseModel):

--- a/backend/app/api/v1/schemas/chat_schemas.py
+++ b/backend/app/api/v1/schemas/chat_schemas.py
@@ -36,3 +36,48 @@ class StreamRequest(BaseModel):
     selectedVisibilityType: str  # "public" or "private"
     existingMessages: List[Dict[str, Any]] = []
     streamId: Optional[UUID] = None  # Optional stream ID for resumable streams
+
+
+# --- Request models for new endpoints ---
+
+
+class DeleteTrailingMessagesRequest(BaseModel):
+    """Request model for deleting trailing messages (edit/resend)."""
+
+    id: str
+
+
+class UpdateChatVisibilityRequest(BaseModel):
+    """Request model for updating chat visibility."""
+
+    chatId: str
+    visibility: str
+
+
+# --- Response models for new endpoints ---
+
+
+class DeleteTrailingMessagesResponse(BaseModel):
+    """Response model for delete trailing messages endpoint."""
+
+    deletedCount: int
+
+
+class UpdateChatVisibilityResponse(BaseModel):
+    """Response model for update chat visibility endpoint."""
+
+    id: str
+    visibility: str
+
+
+class SuggestionResponse(BaseModel):
+    """Response model for a single suggestion."""
+
+    id: str
+    documentId: str
+    originalText: str
+    suggestedText: str
+    description: Optional[str] = None
+    isResolved: bool
+    userId: str
+    createdAt: Optional[str] = None

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -49,6 +49,45 @@ async def get_latest_messages_by_chat_id(
     return list(reversed(messages))
 
 
+async def get_message_by_id(session: AsyncSession, message_id: UUID) -> Optional[Message]:
+    """Get a single message by its ID."""
+    result = await session.execute(select(Message).where(Message.id == message_id))
+    return result.scalar_one_or_none()
+
+
+async def delete_messages_by_chat_id_after_timestamp(
+    session: AsyncSession,
+    chat_id: UUID,
+    timestamp: datetime,
+) -> int:
+    """
+    Delete all messages in a chat at or after the given timestamp.
+    Also deletes associated votes.
+    Returns the count of deleted messages.
+    """
+    messages_to_delete = await session.execute(
+        select(Message.id).where(
+            and_(Message.chatId == chat_id, Message.createdAt >= timestamp)
+        )
+    )
+    message_ids = [row[0] for row in messages_to_delete.all()]
+
+    if not message_ids:
+        return 0
+
+    await session.execute(
+        delete(Vote).where(
+            and_(Vote.chatId == chat_id, Vote.messageId.in_(message_ids))
+        )
+    )
+    await session.execute(
+        delete(Message).where(Message.id.in_(message_ids))
+    )
+
+    await session.commit()
+    return len(message_ids)
+
+
 async def save_chat(
     session: AsyncSession,
     chat_id: UUID,
@@ -199,6 +238,21 @@ def _merge_usage_by_message_id(current: Optional[dict], usage: dict, message_id:
     by_id = dict(current.get("byMessageId") or {})
     by_id[message_id] = usage
     return {"latest": usage, "byMessageId": by_id}
+
+
+async def update_chat_visibility_by_id(
+    session: AsyncSession,
+    chat_id: UUID,
+    visibility: str,
+) -> Optional[Chat]:
+    """Update a chat's visibility (e.g. 'public' or 'private')."""
+    chat = await get_chat_by_id(session, chat_id)
+    if not chat:
+        return None
+    chat.visibility = visibility
+    await session.commit()
+    await session.refresh(chat)
+    return chat
 
 
 async def update_chat_last_context_by_id(

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -52,8 +52,12 @@ async def get_latest_messages_by_chat_id(
 
 
 async def get_message_by_id(session: AsyncSession, message_id: UUID) -> Optional[Message]:
-    """Get a single message by its ID."""
-    result = await session.execute(select(Message).where(Message.id == message_id))
+    """Get a single active (non-deleted) message by its ID."""
+    result = await session.execute(
+        select(Message).where(
+            and_(Message.id == message_id, Message.deletedAt.is_(None))
+        )
+    )
     return result.scalar_one_or_none()
 
 
@@ -73,7 +77,31 @@ async def soft_delete_messages_by_chat_id_after_timestamp(
             and_(
                 Message.chatId == chat_id,
                 Message.createdAt >= timestamp,
-                Message.deletedAt.is_(None)
+                Message.deletedAt.is_(None),
+            )
+        )
+        .values(deletedAt=datetime.utcnow())
+    )
+
+    await session.commit()
+    return result.rowcount
+
+
+async def soft_delete_message_by_id(
+    session: AsyncSession,
+    message_id: UUID,
+) -> int:
+    """
+    Soft-delete a single message by ID.
+    Sets deletedAt to the current time instead of removing the row.
+    Returns 1 if deleted, 0 if not found or already deleted.
+    """
+    result = await session.execute(
+        update(Message)
+        .where(
+            and_(
+                Message.id == message_id,
+                Message.deletedAt.is_(None),
             )
         )
         .values(deletedAt=datetime.utcnow())
@@ -169,8 +197,12 @@ async def save_messages(
         msg_data["id"] = msg_id
         msg_data["chatId"] = chat_id
 
-        # Skip if message already exists (idempotent: safe for duplicate requests / retries)
-        existing = await session.execute(select(Message).where(Message.id == msg_id))
+        # Skip if active message already exists (idempotent: safe for duplicate requests / retries)
+        existing = await session.execute(
+            select(Message).where(
+                and_(Message.id == msg_id, Message.deletedAt.is_(None))
+            )
+        )
         if existing.scalar_one_or_none() is not None:
             logger.warning(
                 "Message %s already exists, skipping insert (idempotent)",

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import and_, asc, delete, desc, func, select
+from sqlalchemy import and_, asc, delete, desc, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.chat import Chat
@@ -26,7 +26,9 @@ async def get_messages_by_chat_id(session: AsyncSession, chat_id: UUID) -> List[
     Returns: List of Message objects
     """
     result = await session.execute(
-        select(Message).where(Message.chatId == chat_id).order_by(asc(Message.createdAt))
+        select(Message)
+        .where(and_(Message.chatId == chat_id, Message.isDeleted == False))  # noqa: E712
+        .order_by(asc(Message.createdAt))
     )
     return list(result.scalars().all())
 
@@ -40,7 +42,7 @@ async def get_latest_messages_by_chat_id(
     """
     result = await session.execute(
         select(Message)
-        .where(Message.chatId == chat_id)
+        .where(and_(Message.chatId == chat_id, Message.isDeleted == False))  # noqa: E712
         .order_by(desc(Message.createdAt))
         .limit(limit)
     )
@@ -55,37 +57,30 @@ async def get_message_by_id(session: AsyncSession, message_id: UUID) -> Optional
     return result.scalar_one_or_none()
 
 
-async def delete_messages_by_chat_id_after_timestamp(
+async def soft_delete_messages_by_chat_id_after_timestamp(
     session: AsyncSession,
     chat_id: UUID,
     timestamp: datetime,
 ) -> int:
     """
-    Delete all messages in a chat at or after the given timestamp.
-    Also deletes associated votes.
-    Returns the count of deleted messages.
+    Soft-delete all messages in a chat at or after the given timestamp.
+    Sets isDeleted = True instead of removing rows.
+    Returns the count of soft-deleted messages.
     """
-    messages_to_delete = await session.execute(
-        select(Message.id).where(
-            and_(Message.chatId == chat_id, Message.createdAt >= timestamp)
+    result = await session.execute(
+        update(Message)
+        .where(
+            and_(
+                Message.chatId == chat_id,
+                Message.createdAt >= timestamp,
+                Message.isDeleted == False,  # noqa: E712
+            )
         )
-    )
-    message_ids = [row[0] for row in messages_to_delete.all()]
-
-    if not message_ids:
-        return 0
-
-    await session.execute(
-        delete(Vote).where(
-            and_(Vote.chatId == chat_id, Vote.messageId.in_(message_ids))
-        )
-    )
-    await session.execute(
-        delete(Message).where(Message.id.in_(message_ids))
+        .values(isDeleted=True)
     )
 
     await session.commit()
-    return len(message_ids)
+    return result.rowcount
 
 
 async def save_chat(

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -27,7 +27,7 @@ async def get_messages_by_chat_id(session: AsyncSession, chat_id: UUID) -> List[
     """
     result = await session.execute(
         select(Message)
-        .where(and_(Message.chatId == chat_id, Message.isDeleted == False))  # noqa: E712
+        .where(and_(Message.chatId == chat_id, Message.deletedAt.is_(None)))
         .order_by(asc(Message.createdAt))
     )
     return list(result.scalars().all())
@@ -42,7 +42,7 @@ async def get_latest_messages_by_chat_id(
     """
     result = await session.execute(
         select(Message)
-        .where(and_(Message.chatId == chat_id, Message.isDeleted == False))  # noqa: E712
+        .where(and_(Message.chatId == chat_id, Message.deletedAt.is_(None)))
         .order_by(desc(Message.createdAt))
         .limit(limit)
     )
@@ -64,7 +64,7 @@ async def soft_delete_messages_by_chat_id_after_timestamp(
 ) -> int:
     """
     Soft-delete all messages in a chat at or after the given timestamp.
-    Sets isDeleted = True instead of removing rows.
+    Sets deletedAt to the current time instead of removing rows.
     Returns the count of soft-deleted messages.
     """
     result = await session.execute(
@@ -73,10 +73,10 @@ async def soft_delete_messages_by_chat_id_after_timestamp(
             and_(
                 Message.chatId == chat_id,
                 Message.createdAt >= timestamp,
-                Message.isDeleted == False,  # noqa: E712
+                Message.deletedAt.is_(None)
             )
         )
-        .values(isDeleted=True)
+        .values(deletedAt=datetime.utcnow())
     )
 
     await session.commit()

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, String
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -18,7 +18,7 @@ class Message(BaseModel):
     parts = Column(JSON, nullable=False)
     attachments = Column(JSON, nullable=False)
     createdAt = Column(DateTime, nullable=False, default=datetime.utcnow)
-    isDeleted = Column(Boolean, nullable=False, default=False, server_default="false")
+    deletedAt = Column(DateTime, nullable=True, default=None)
 
     # Relationships
     chat = relationship("Chat", back_populates="messages")

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -18,6 +18,7 @@ class Message(BaseModel):
     parts = Column(JSON, nullable=False)
     attachments = Column(JSON, nullable=False)
     createdAt = Column(DateTime, nullable=False, default=datetime.utcnow)
+    isDeleted = Column(Boolean, nullable=False, default=False, server_default="false")
 
     # Relationships
     chat = relationship("Chat", back_populates="messages")

--- a/frontend/app/(chat)/actions.ts
+++ b/frontend/app/(chat)/actions.ts
@@ -5,11 +5,7 @@ import { cookies } from "next/headers";
 import type { VisibilityType } from "@/components/visibility-selector";
 import { titlePrompt } from "@/lib/ai/prompts";
 import { myProvider } from "@/lib/ai/providers";
-import {
-  deleteMessagesByChatIdAfterTimestamp,
-  getMessageById,
-  updateChatVisibilityById,
-} from "@/lib/db/queries";
+import { serverApiFetch } from "@/lib/server-api-client";
 import { getTextFromMessage } from "@/lib/utils";
 
 export async function saveChatModelAsCookie(model: string) {
@@ -32,12 +28,18 @@ export async function generateTitleFromUserMessage({
 }
 
 export async function deleteTrailingMessages({ id }: { id: string }) {
-  const [message] = await getMessageById({ id });
-
-  await deleteMessagesByChatIdAfterTimestamp({
-    chatId: message.chatId,
-    timestamp: message.createdAt,
+  const response = await serverApiFetch("/api/chat/messages", {
+    method: "DELETE",
+    body: JSON.stringify({ id }),
   });
+
+  if (!response.ok) {
+    console.error(
+      "Failed to delete trailing messages:",
+      response.status,
+      await response.text().catch(() => "")
+    );
+  }
 }
 
 export async function updateChatVisibility({
@@ -47,5 +49,16 @@ export async function updateChatVisibility({
   chatId: string;
   visibility: VisibilityType;
 }) {
-  await updateChatVisibilityById({ chatId, visibility });
+  const response = await serverApiFetch("/api/chat/visibility", {
+    method: "PATCH",
+    body: JSON.stringify({ chatId, visibility }),
+  });
+
+  if (!response.ok) {
+    console.error(
+      "Failed to update chat visibility:",
+      response.status,
+      await response.text().catch(() => "")
+    );
+  }
 }

--- a/frontend/app/(chat)/actions.ts
+++ b/frontend/app/(chat)/actions.ts
@@ -30,14 +30,14 @@ export async function generateTitleFromUserMessage({
 export async function deleteTrailingMessages({ id }: { id: string }) {
   const response = await serverApiFetch("/api/chat/messages", {
     method: "DELETE",
-    body: JSON.stringify({ id }),
+    body: JSON.stringify({ id, includeTrailing: true }),
   });
 
   if (!response.ok) {
     console.error(
       "Failed to delete trailing messages:",
       response.status,
-      await response.text().catch(() => "")
+      await response.text().catch(() => ""),
     );
   }
 }
@@ -58,7 +58,7 @@ export async function updateChatVisibility({
     console.error(
       "Failed to update chat visibility:",
       response.status,
-      await response.text().catch(() => "")
+      await response.text().catch(() => ""),
     );
   }
 }

--- a/frontend/app/(chat)/api/suggestions/route.ts
+++ b/frontend/app/(chat)/api/suggestions/route.ts
@@ -1,6 +1,6 @@
 import { getCurrentUser } from "@/lib/auth-service";
-import { serverApiFetch } from "@/lib/server-api-client";
 import { ChatSDKError } from "@/lib/errors";
+import { serverApiFetch } from "@/lib/server-api-client";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
   if (!documentId) {
     return new ChatSDKError(
       "bad_request:api",
-      "Parameter documentId is required."
+      "Parameter documentId is required.",
     ).toResponse();
   }
 
@@ -20,11 +20,14 @@ export async function GET(request: Request) {
   }
 
   const response = await serverApiFetch(
-    `/api/chat/suggestions?documentId=${documentId}`
+    `/api/chat/suggestions?documentId=${documentId}`,
   );
 
   if (!response.ok) {
-    return Response.json([], { status: 200 });
+    return new Response(response.body, {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   const suggestions = await response.json();

--- a/frontend/app/(chat)/api/suggestions/route.ts
+++ b/frontend/app/(chat)/api/suggestions/route.ts
@@ -1,5 +1,5 @@
 import { getCurrentUser } from "@/lib/auth-service";
-import { getSuggestionsByDocumentId } from "@/lib/db/queries";
+import { serverApiFetch } from "@/lib/server-api-client";
 import { ChatSDKError } from "@/lib/errors";
 
 export async function GET(request: Request) {
@@ -19,19 +19,14 @@ export async function GET(request: Request) {
     return new ChatSDKError("unauthorized:suggestions").toResponse();
   }
 
-  const suggestions = await getSuggestionsByDocumentId({
-    documentId,
-  });
+  const response = await serverApiFetch(
+    `/api/chat/suggestions?documentId=${documentId}`
+  );
 
-  const [suggestion] = suggestions;
-
-  if (!suggestion) {
+  if (!response.ok) {
     return Response.json([], { status: 200 });
   }
 
-  if (suggestion.userId !== user.id) {
-    return new ChatSDKError("forbidden:api").toResponse();
-  }
-
+  const suggestions = await response.json();
   return Response.json(suggestions, { status: 200 });
 }


### PR DESCRIPTION
## Summary

Route all frontend direct Drizzle/Postgres calls through the backend API and implement soft-delete for messages on edit/resend. This removes the need for the frontend to have `POSTGRES_URL` configured in Azure (currently requires a bandaid fix of adding `POSTGRES_URL` with `?sslmode=require` to the frontend `.env`), and preserves message history for observability (fixes #19).

## Changes

### Route Frontend DB Calls Through Backend API

#### Backend
- **`chat_queries.py`**: Add `get_message_by_id`, `update_chat_visibility_by_id`
- **`chat.py`**: Add 3 new endpoints: `DELETE /api/chat/messages`, `PATCH /api/chat/visibility`, `GET /api/chat/suggestions`

#### Frontend
- **`actions.ts`**: Replace `@/lib/db/queries` imports with `serverApiFetch` calls
- **`suggestions/route.ts`**: Replace Drizzle import with `serverApiFetch` call

---

### Soft-Delete Messages on Edit/Resend (fixes #19)

Instead of hard-deleting messages when editing a prompt, mark them as `isDeleted = true` to preserve the original response chain for observability.

- **`f6a7b8c9d0e1_add_is_deleted_to_message.py`** (NEW): Alembic migration adding `isDeleted` boolean column to `Message_v2`
- **`message.py`**: Add `isDeleted` field to Message model
- **`chat_queries.py`**: Rename `delete_messages_by_chat_id_after_timestamp` → `soft_delete_messages_by_chat_id_after_timestamp` (sets `isDeleted=true` instead of `DELETE`). Add `isDeleted == False` filter to `get_messages_by_chat_id` and `get_latest_messages_by_chat_id`
- **`chat.py`**: Update import to use renamed function

## Testing
- Tested locally via Docker: edit/resend flow works (Kenya → Uganda)
- DB verified: soft-deleted messages preserved with `isDeleted = true`, UI only shows active messages
- Verified zero remaining `@/lib/db/queries` imports in frontend app directory

## Result
- Frontend no longer needs `POSTGRES_URL` for any runtime operation
- Edited messages are preserved in the DB for observability instead of being deleted