### PR TITLE
feat(frontend): follow-up parser hardening, unit tests, and chip affordance (FE-001)

### DIFF
--- a/TODO/FE-001-follow-ups-parser-and-chips.md
+++ b/TODO/FE-001-follow-ups-parser-and-chips.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 71
 id: FE-001
 repo: vercel-ai-chatbot
 title: Follow-ups — parser hardening and chip affordance

--- a/TODO/FE-001-follow-ups-parser-and-chips.md
+++ b/TODO/FE-001-follow-ups-parser-and-chips.md
@@ -2,7 +2,7 @@
 id: FE-001
 repo: vercel-ai-chatbot
 title: Follow-ups — parser hardening and chip affordance
-status: pending
+status: done
 priority: medium
 depends_on: []
 blocks: []
@@ -29,9 +29,9 @@ Make suggested follow-ups reliably interactive and visually obvious: parsing rob
 
 ## Acceptance criteria
 
-- [ ] Parser tolerates minor heading variants **or** tests document the exact required string aligned with BE-001.
-- [ ] Unit tests cover edge cases (empty section, extra blank lines, numbered lists).
-- [ ] Chips read as buttons (outline/icon optional per design system); no accessibility regressions.
+- [x] Parser tolerates minor heading variants **or** tests document the exact required string aligned with BE-001.
+- [x] Unit tests cover edge cases (empty section, extra blank lines, numbered lists).
+- [x] Chips read as buttons (outline/icon optional per design system); no accessibility regressions.
 
 ## Dependencies
 

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -1,6 +1,6 @@
 # data-ai-chatbot — task index
 
-Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (10 active)
+Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (9 active, 1 completed)
 
 **Sibling repos:** [data360-mcp/TODO](../data360-mcp/TODO/README.md), [pcn/TODO](../pcn/TODO/README.md)
 
@@ -10,7 +10,6 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 |----|------|---------|
 | BE-001 | [BE-001-writer-planner-prompts.md](./BE-001-writer-planner-prompts.md) | Align model output with the agreed structure: Summary → optional Visualizatio... |
 | DESIGN-001 | [DESIGN-001-visual-hierarchy-spec.md](./DESIGN-001-visual-hierarchy-spec.md) | Produce lightweight specs: typography scale for section titles, spacing, opti... |
-| FE-001 | [FE-001-follow-ups-parser-and-chips.md](./FE-001-follow-ups-parser-and-chips.md) | Make suggested follow-ups reliably interactive and visually obvious: parsing ... |
 | FE-002 | [FE-002-markdown-autolinks.md](./FE-002-markdown-autolinks.md) | Ensure raw URLs in assistant markdown render as clickable links when the mode... |
 | FE-003 | [FE-003-scroll-while-thinking.md](./FE-003-scroll-while-thinking.md) | Keep the main chat viewport aligned with the latest activity while the system... |
 | FE-004 | [FE-004-view-thinking-after-complete.md](./FE-004-view-thinking-after-complete.md) | After the assistant message finishes, users can easily reopen the thinking pr... |
@@ -19,13 +18,21 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-007 | [FE-007-mobile-keyboard-input-layout.md](./FE-007-mobile-keyboard-input-layout.md) | On iPhone (~390px viewport, iOS Safari), tapping the chat input field causes ... |
 | FE-008 | [FE-008-chat-list-skeleton-loader.md](./FE-008-chat-list-skeleton-loader.md) | When the sidebar chat history list is fetching its first page of data, it sho... |
 
+<details>
+<summary>1 done</summary>
+
+| ID | File | Summary |
+|----|------|---------|
+| FE-001 | [FE-001-follow-ups-parser-and-chips.md](./FE-001-follow-ups-parser-and-chips.md) | Make suggested follow-ups reliably interactive and visually obvious: parsing ... ✓ done |
+
+</details>
+
 ## Dependency graph (this repo)
 
 ```mermaid
 flowchart TB
   BE001["BE-001 Writer and Planner prompts — r"]
   DESIGN001["DESIGN-001 Design — visual hierarchy and "]
-  FE001["FE-001 Follow-ups — parser hardening "]
   FE002["FE-002 Assistant markdown — autolink "]
   FE003["FE-003 Chat scroll — stick to bottom "]
   FE004["FE-004 UI — return to thinking after "]

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -4,30 +4,31 @@ import { DATA360_GET_DATA_TOOL } from "@pcn-js/data360";
 import { IngestToolOutput } from "@pcn-js/ui";
 import type { ToolUIPart } from "ai";
 import equal from "fast-deep-equal";
+import { MessageSquare } from "lucide-react";
 import { type Dispatch, memo, type SetStateAction, useState } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
+import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
   getData360SourcesFromParts,
   isIndicatorUrl,
 } from "@/lib/data360";
 import type { Vote } from "@/lib/db/schema";
-import { getBasePath } from "@/lib/config";
 import { parseFollowUps } from "@/lib/parse-follow-ups";
 import type { ChatMessage, StreamingThinkingPart } from "@/lib/types";
-import type { AppUsage } from "@/lib/usage";
 import { isNonRenderableStreamEvent } from "@/lib/types";
+import type { AppUsage } from "@/lib/usage";
 import { cn, sanitizeText } from "@/lib/utils";
 import { ASK_ABOUT_SELECTION_CONTEXT_ATTR } from "./ask-about-selection-toolbar";
 import { useDataStream } from "./data-stream-provider";
 import { ChartPreview } from "./data360/chart-preview";
 import { GetData, GetDataRequestSummary } from "./data360/get-data";
+import { GetWdiData } from "./data360/get-wdi-data";
 import {
   SearchIndicators,
   SearchIndicatorsRequestSummary,
 } from "./data360/search-indicators";
-import { GetWdiData } from "./data360/get-wdi-data";
 import { SearchRelevantIndicators } from "./data360/search-relevant-indicators";
 import { DocumentToolResult } from "./document";
 import { DocumentPreview } from "./document-preview";
@@ -513,20 +514,26 @@ function renderMessagePart(
               | undefined;
             return {
               database_id:
-                typeof raw.database_id === "string" ? raw.database_id : undefined,
+                typeof raw.database_id === "string"
+                  ? raw.database_id
+                  : undefined,
               indicator_id:
-                typeof raw.indicator_id === "string" ? raw.indicator_id : undefined,
+                typeof raw.indicator_id === "string"
+                  ? raw.indicator_id
+                  : undefined,
               disaggregation_filters:
                 disaggregation_filters &&
                 typeof disaggregation_filters === "object"
                   ? disaggregation_filters
                   : undefined,
               start_year:
-                typeof raw.start_year === "number" && Number.isFinite(raw.start_year)
+                typeof raw.start_year === "number" &&
+                Number.isFinite(raw.start_year)
                   ? raw.start_year
                   : undefined,
               end_year:
-                typeof raw.end_year === "number" && Number.isFinite(raw.end_year)
+                typeof raw.end_year === "number" &&
+                Number.isFinite(raw.end_year)
                   ? raw.end_year
                   : undefined,
               limit:
@@ -601,8 +608,7 @@ function renderMessagePart(
         ? (() => {
             const raw = toolPart.input as Record<string, unknown>;
             return {
-              query:
-                typeof raw.query === "string" ? raw.query : undefined,
+              query: typeof raw.query === "string" ? raw.query : undefined,
               required_country:
                 typeof raw.required_country === "string"
                   ? raw.required_country
@@ -624,9 +630,7 @@ function renderMessagePart(
         <ToolContent>
           {toolPart.state === "input-available" &&
             (searchIndicatorsInput != null ? (
-              <SearchIndicatorsRequestSummary
-                input={searchIndicatorsInput}
-              />
+              <SearchIndicatorsRequestSummary input={searchIndicatorsInput} />
             ) : (
               <ToolInput input={toolPart.input} />
             ))}
@@ -1035,7 +1039,7 @@ const PurePreviewMessage = ({
                       {followUps.map((suggestion) => (
                         <Suggestion
                           key={suggestion}
-                          className="h-auto whitespace-normal px-3 py-1.5 text-left text-sm"
+                          className="h-auto gap-2 whitespace-normal px-3 py-1.5 text-left text-sm"
                           onClick={() => {
                             window.history.pushState(
                               {},
@@ -1056,7 +1060,13 @@ const PurePreviewMessage = ({
                           }}
                           suggestion={suggestion}
                         >
-                          {suggestion}
+                          <span className="inline-flex items-start gap-2">
+                            <MessageSquare
+                              aria-hidden
+                              className="mt-0.5 size-4 shrink-0 opacity-70"
+                            />
+                            <span>{suggestion}</span>
+                          </span>
                         </Suggestion>
                       ))}
                     </div>

--- a/frontend/lib/__tests__/parse-follow-ups.test.ts
+++ b/frontend/lib/__tests__/parse-follow-ups.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseFollowUps } from "../parse-follow-ups";
+
+describe("parseFollowUps", () => {
+  it("returns empty array for empty input", () => {
+    assert.deepEqual(parseFollowUps(""), []);
+  });
+
+  it("returns nothing when the heading is missing", () => {
+    const text = `Here is the answer.
+
+- Not a follow-up section
+- Still not`;
+    assert.deepEqual(parseFollowUps(text), []);
+  });
+
+  it("parses bullet list after heading", () => {
+    const text = `**Suggested follow-ups:**
+- First question?
+- Second question?`;
+    assert.deepEqual(parseFollowUps(text), [
+      "First question?",
+      "Second question?",
+    ]);
+  });
+
+  it("tolerates heading variants (case, bold, colon, markdown heading)", () => {
+    assert.deepEqual(parseFollowUps("suggested follow-ups:\n- A"), ["A"]);
+    assert.deepEqual(parseFollowUps("**Suggested follow-ups**\n- B"), ["B"]);
+    assert.deepEqual(parseFollowUps("### **Suggested follow-ups:**\n- C"), [
+      "C",
+    ]);
+  });
+
+  it("parses *, •, and numbered list markers", () => {
+    const text = `**Suggested follow-ups:**
+* Star item
+• Bullet item
+1. One
+2. Two`;
+    assert.deepEqual(parseFollowUps(text), [
+      "Star item",
+      "Bullet item",
+      "One",
+      "Two",
+    ]);
+  });
+
+  it("skips blank lines after heading and between items", () => {
+    const text = `**Suggested follow-ups:**
+
+
+- First
+
+- Second`;
+    assert.deepEqual(parseFollowUps(text), ["First", "Second"]);
+  });
+
+  it("caps at four items", () => {
+    const text = `**Suggested follow-ups:**
+- One
+- Two
+- Three
+- Four
+- Five
+- Six`;
+    assert.deepEqual(parseFollowUps(text), ["One", "Two", "Three", "Four"]);
+  });
+
+  it("ignores non-list lines before the first list item", () => {
+    const text = `**Suggested follow-ups:**
+You might also ask:
+- Real question?`;
+    assert.deepEqual(parseFollowUps(text), ["Real question?"]);
+  });
+});

--- a/frontend/lib/parse-follow-ups.ts
+++ b/frontend/lib/parse-follow-ups.ts
@@ -1,10 +1,19 @@
 /**
  * Parse "Suggested follow-ups:" section from assistant message markdown.
- * Matches a line containing "Suggested follow-ups" (with optional **) then
- * list items (- or * or • or 1. etc.). Returns up to 4 questions.
+ *
+ * **Heading (case-insensitive):** optional markdown `### ` prefix, optional
+ * bold `**` around the label, optional trailing `:`. Example lines that match:
+ * `Suggested follow-ups:`, `**Suggested follow-ups**`, `### **Suggested follow-ups:**`
+ *
+ * **List items:** `-`, `*`, `•`, or numbered `1.` … with space after the marker.
+ * Blank lines after the heading or between items are skipped (the list does not
+ * have to be contiguous with no gaps). Non-list lines before the first item are
+ * ignored; non-list lines after items are ignored until the next list line or
+ * end of text. At most 4 items are returned.
  */
-const FOLLOW_UPS_HEADING = /\*{0,2}Suggested follow-ups\*{0,2}\s*:?/im;
-const LIST_ITEM = /^\s*[-*•]\s+(.+)$|^\s*\d+\.\s+(.+)$/m;
+const FOLLOW_UPS_HEADING =
+  /^\s*(?:#{1,3}\s+)?\*{0,2}Suggested follow-ups\*{0,2}\s*:?/im;
+const LIST_ITEM = /^\s*[-*•]\s+(.+)$|^\s*\d+\.\s+(.+)$/;
 
 export function parseFollowUps(text: string): string[] {
   if (!text || typeof text !== "string") return [];
@@ -22,7 +31,7 @@ export function parseFollowUps(text: string): string[] {
     if (!inSection) continue;
 
     const trimmed = line.trim();
-    if (trimmed === "") break;
+    if (trimmed === "") continue;
 
     const match = trimmed.match(LIST_ITEM);
     if (match) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "lint": "npx ultracite@latest check",
     "format": "npx ultracite@latest fix",
     "env:check": "tsx scripts/env-check.ts",
-    "test": "export PLAYWRIGHT=True && pnpm exec playwright test"
+    "test": "export PLAYWRIGHT=True && pnpm exec playwright test",
+    "test:unit": "tsx --test lib/__tests__/**/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^1.0.15",


### PR DESCRIPTION
## Summary

Closes #63 

Implements **FE-001** (follow-up parser hardening, unit tests, and clearer suggestion chips). Suggested follow-ups are easier to parse when the model adds blank lines or markdown heading prefixes, and the UI makes chips read more clearly as clickable actions.

## Changes

- **`parseFollowUps` (`frontend/lib/parse-follow-ups.ts`)**  
  - Documents the expected heading and list formats (for alignment with backend/prompt work, e.g. BE-001).  
  - Tolerates optional `### `-style headings and the existing bold/colon variants.  
  - **Skips blank lines** after the heading and between list items instead of stopping at the first empty line, so multi-line spacing from the model does not drop later bullets.

- **Unit tests (`frontend/lib/__tests__/parse-follow-ups.test.ts`)**  
  - Covers missing heading, bullets, heading variants, `*` / `•` / numbered lists, blank lines, the four-item cap, and intro text before the first bullet.

- **Suggestion chips (`frontend/components/message.tsx`)**  
  - Keeps outline `Button`-style chips; adds a small **message** icon (`aria-hidden`) so the affordance matches “suggested reply” without changing the visible label text.

- **Scripts (`frontend/package.json`)**  
  - Adds `pnpm test:unit` using Node’s test runner via `tsx`.

- **Tasks**  
  - Marks **FE-001** as done and refreshes `TODO/README.md`.

## How to test

```bash
cd frontend && pnpm test:unit
```

Manually: complete an assistant reply that includes a `Suggested follow-ups:` block with blank lines between items; confirm all bullets show as chips and behave as before (send / populate input per existing behavior).

## Related

- Task: `TODO/FE-001-follow-ups-parser-and-chips.md`  
- Coordinate heading wording with **BE-001** if the model output format is tightened on the backend.