### PR TITLE
fix(frontend): respect Next.js basePath for chart and viz preview URLs

### DIFF
--- a/TODO/CROSS-REPO-GRAPH.md
+++ b/TODO/CROSS-REPO-GRAPH.md
@@ -3,6 +3,7 @@
 Tasks live in:
 - `data-ai-chatbot/TODO/`
 - `data360-mcp/TODO/`
+- `pcn/TODO/`
 
 ## Combined graph
 
@@ -19,6 +20,7 @@ flowchart TB
     FE006["FE-006 Optional “How to read” pr"]
     FE007["FE-007 Mobile — chat input jumps"]
     FE008["FE-008 Chat messages — skeleton "]
+    FE009["FE-009 Chart and visualization p"]
   end
   subgraph data360_mcp [data360-mcp]
     MCP001["MCP-001 SYSTEM_PROMPT — align wit"]
@@ -26,6 +28,8 @@ flowchart TB
     MCP003["MCP-003 Many countries — beeswarm"]
     MCP004["MCP-004 viz — guard against empty"]
     MCP005["MCP-005 cache — make TTL configur"]
+  end
+  subgraph pcn [pcn]
   end
   BE001 --> FE005
   FE005 --> FE006
@@ -44,6 +48,6 @@ flowchart TB
 
 ## Suggested batch order
 
-1. **BE-001, DESIGN-001, FE-001, FE-002, FE-003, FE-004, FE-007, FE-008, MCP-002, MCP-003, MCP-004, MCP-005** (data-ai-chatbot, data360-mcp)
+1. **BE-001, DESIGN-001, FE-001, FE-002, FE-003, FE-004, FE-007, FE-008, FE-009, MCP-002, MCP-003, MCP-004, MCP-005** (data-ai-chatbot, data360-mcp)
 2. **FE-005, MCP-001** (data-ai-chatbot, data360-mcp)
 3. **FE-006** (data-ai-chatbot)

--- a/TODO/FE-009-chart-viz-urls-basepath.md
+++ b/TODO/FE-009-chart-viz-urls-basepath.md
@@ -1,0 +1,47 @@
+---
+id: FE-009
+repo: vercel-ai-chatbot
+title: Chart and visualization previews respect Next.js basePath
+status: pending
+priority: medium
+depends_on: []
+blocks: []
+---
+
+# FE-009 — Chart and Visualization Previews Respect Next.js basePath
+
+## Goal
+
+When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `next.config.ts` `basePath`), chart and Data360 visualization previews must load through the same-origin API under that prefix. Today, fetches use root-relative paths such as `/api/v1/charts/...`, which resolve to the host root in the browser and bypass the deployed app’s base path, so previews fail or load the wrong resource.
+
+## Context
+
+- **Symptom (feedback):** Visualization output does not use the base path — previews break or request incorrect URLs when the app is not served at `/`.
+- **Config:** `frontend/lib/config.ts` → `getBasePath()` reads `NEXT_PUBLIC_BASE_PATH` (trailing slashes stripped). This must stay aligned with `frontend/next.config.ts` `basePath`.
+- **Chart loading:** `frontend/components/data360/chart-preview.tsx` — `proxyChartUrl()` normalizes tool and markdown chart URLs to a path used in `fetch(proxiedUrl)` (see ~48–59, ~202–207). Root-relative paths are returned as-is (e.g. `/api/v1/charts/...`), which is incorrect under basePath.
+- **Call sites:** Inline chart URLs in assistant text (`frontend/components/message.tsx` — `CHART_URL_REGEX`, `ChartPreview`) and `tool-data360_get_viz_spec` output (`output.url` passed to `ChartPreview`) both funnel through the same component; fixing URL construction in one place should cover both.
+- **Prior art:** `message.tsx` already uses `` `${getBasePath()}/chat/${chatId}` `` for in-app links (~1043); the chart fetch path should follow the same prefixing rules.
+
+## Implementation hints
+
+- **Entry point:** `frontend/components/data360/chart-preview.tsx` → `proxyChartUrl()` (and optionally rename/clarify if it becomes “resolve chart fetch URL”).
+- **Current behavior:** For non-HTTP(S) input, paths starting with `/` are passed unchanged to `fetch`, so the browser requests `origin + /api/...` instead of `origin + basePath + /api/...`.
+- **Desired behavior:** After normalizing to a pathname (including stripping absolute URLs to `pathname + search`), if `getBasePath()` is non-empty and the path is not already under that prefix, prepend it (avoid double-prefixing when the backend already returns `/mybase/api/...`).
+- **Edge cases:** Empty base path → unchanged behavior. Full backend URLs: pathname may already include base path — detect before prepending. Query strings must be preserved.
+- **Tests:** Search for existing tests touching `ChartPreview`, `chart-preview`, or basePath; add or extend a small unit test for `proxyChartUrl` / URL resolution if a test harness exists (`frontend/**/*.test.ts`, `*.spec.ts`). If none, add a minimal test next to the module or document manual verification: run with `NEXT_PUBLIC_BASE_PATH=/app` and confirm network requests target `/app/api/v1/charts/...`.
+
+## Acceptance criteria
+
+- [ ] With `NEXT_PUBLIC_BASE_PATH` set (e.g. `/app`), `ChartPreview`’s chart JSON request URL is under that prefix (e.g. `/app/api/v1/charts/...`), not only `/api/v1/charts/...`, unless the incoming URL already includes the prefix.
+- [ ] With an empty base path, behavior matches current production (requests still go to `/api/v1/charts/...`).
+- [ ] `tool-data360_get_viz_spec` chart preview and inline markdown chart URLs both render when the app is served under a subpath.
+- [ ] No duplicate path segments when the model or API returns URLs that already contain the base path.
+
+## Out of scope
+
+- Changing backend chart URL format (unless a follow-up is needed for malformed absolute URLs).
+- Non-chart artifacts or unrelated routing.
+
+## Dependencies
+
+None.

--- a/TODO/FE-009-chart-viz-urls-basepath.md
+++ b/TODO/FE-009-chart-viz-urls-basepath.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 83
 id: FE-009
 repo: vercel-ai-chatbot
 title: Chart and visualization previews respect Next.js basePath

--- a/TODO/FE-009-chart-viz-urls-basepath.md
+++ b/TODO/FE-009-chart-viz-urls-basepath.md
@@ -3,7 +3,7 @@ github_issue: 83
 id: FE-009
 repo: vercel-ai-chatbot
 title: Chart and visualization previews respect Next.js basePath
-status: pending
+status: done
 priority: medium
 depends_on: []
 blocks: []
@@ -22,6 +22,7 @@ When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `nex
 - **Chart loading:** `frontend/components/data360/chart-preview.tsx` — `proxyChartUrl()` normalizes tool and markdown chart URLs to a path used in `fetch(proxiedUrl)` (see ~48–59, ~202–207). Root-relative paths are returned as-is (e.g. `/api/v1/charts/...`), which is incorrect under basePath.
 - **Call sites:** Inline chart URLs in assistant text (`frontend/components/message.tsx` — `CHART_URL_REGEX`, `ChartPreview`) and `tool-data360_get_viz_spec` output (`output.url` passed to `ChartPreview`) both funnel through the same component; fixing URL construction in one place should cover both.
 - **Prior art:** `message.tsx` already uses `` `${getBasePath()}/chat/${chatId}` `` for in-app links (~1043); the chart fetch path should follow the same prefixing rules.
+- **Shipped:** `frontend/lib/chart-url.ts` (`proxyChartUrlForFetch`, `applyBasePathToChartPath`, `buildChartUrlRegexes`); consumed by `chart-preview.tsx` and `message.tsx`.
 
 ## Implementation hints
 
@@ -33,10 +34,10 @@ When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `nex
 
 ## Acceptance criteria
 
-- [ ] With `NEXT_PUBLIC_BASE_PATH` set (e.g. `/app`), `ChartPreview`’s chart JSON request URL is under that prefix (e.g. `/app/api/v1/charts/...`), not only `/api/v1/charts/...`, unless the incoming URL already includes the prefix.
-- [ ] With an empty base path, behavior matches current production (requests still go to `/api/v1/charts/...`).
-- [ ] `tool-data360_get_viz_spec` chart preview and inline markdown chart URLs both render when the app is served under a subpath.
-- [ ] No duplicate path segments when the model or API returns URLs that already contain the base path.
+- [x] With `NEXT_PUBLIC_BASE_PATH` set (e.g. `/app`), `ChartPreview`’s chart JSON request URL is under that prefix (e.g. `/app/api/v1/charts/...`), not only `/api/v1/charts/...`, unless the incoming URL already includes the prefix.
+- [x] With an empty base path, behavior matches current production (requests still go to `/api/v1/charts/...`).
+- [x] `tool-data360_get_viz_spec` chart preview and inline markdown chart URLs both render when the app is served under a subpath.
+- [x] No duplicate path segments when the model or API returns URLs that already contain the base path.
 
 ## Out of scope
 

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -1,6 +1,6 @@
 # data-ai-chatbot — task index
 
-Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (9 active, 1 completed)
+Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (10 active, 1 completed)
 
 **Sibling repos:** [data360-mcp/TODO](../data360-mcp/TODO/README.md), [pcn/TODO](../pcn/TODO/README.md)
 
@@ -17,6 +17,7 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-006 | [FE-006-how-to-read-disclosure.md](./FE-006-how-to-read-disclosure.md) | If the model emits How to read (or equivalent) per BE-001, present it as seco... |
 | FE-007 | [FE-007-mobile-keyboard-input-layout.md](./FE-007-mobile-keyboard-input-layout.md) | On iPhone (~390px viewport, iOS Safari), tapping the chat input field causes ... |
 | FE-008 | [FE-008-chat-list-skeleton-loader.md](./FE-008-chat-list-skeleton-loader.md) | When the sidebar chat history list is fetching its first page of data, it sho... |
+| FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... |
 
 <details>
 <summary>1 done</summary>
@@ -40,6 +41,7 @@ flowchart TB
   FE006["FE-006 Optional “How to read” present"]
   FE007["FE-007 Mobile — chat input jumps behi"]
   FE008["FE-008 Chat messages — skeleton loade"]
+  FE009["FE-009 Chart and visualization previe"]
   BE001 --> FE005
   FE005 --> FE006
 ```

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -17,7 +17,15 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-006 | [FE-006-how-to-read-disclosure.md](./FE-006-how-to-read-disclosure.md) | If the model emits How to read (or equivalent) per BE-001, present it as seco... |
 | FE-007 | [FE-007-mobile-keyboard-input-layout.md](./FE-007-mobile-keyboard-input-layout.md) | On iPhone (~390px viewport, iOS Safari), tapping the chat input field causes ... |
 | FE-008 | [FE-008-chat-list-skeleton-loader.md](./FE-008-chat-list-skeleton-loader.md) | When the sidebar chat history list is fetching its first page of data, it sho... |
-| FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... |
+
+<details>
+<summary>1 done</summary>
+
+| ID | File | Summary |
+|----|------|---------|
+| FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... ✓ done |
+
+</details>
 
 <details>
 <summary>1 done</summary>
@@ -41,7 +49,6 @@ flowchart TB
   FE006["FE-006 Optional “How to read” present"]
   FE007["FE-007 Mobile — chat input jumps behi"]
   FE008["FE-008 Chat messages — skeleton loade"]
-  FE009["FE-009 Chart and visualization previe"]
   BE001 --> FE005
   FE005 --> FE006
 ```

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -1,6 +1,6 @@
 # data-ai-chatbot — task index
 
-Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (10 active, 1 completed)
+Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (9 active, 2 completed)
 
 **Sibling repos:** [data360-mcp/TODO](../data360-mcp/TODO/README.md), [pcn/TODO](../pcn/TODO/README.md)
 
@@ -19,20 +19,12 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-008 | [FE-008-chat-list-skeleton-loader.md](./FE-008-chat-list-skeleton-loader.md) | When the sidebar chat history list is fetching its first page of data, it sho... |
 
 <details>
-<summary>1 done</summary>
-
-| ID | File | Summary |
-|----|------|---------|
-| FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... ✓ done |
-
-</details>
-
-<details>
-<summary>1 done</summary>
+<summary>2 done</summary>
 
 | ID | File | Summary |
 |----|------|---------|
 | FE-001 | [FE-001-follow-ups-parser-and-chips.md](./FE-001-follow-ups-parser-and-chips.md) | Make suggested follow-ups reliably interactive and visually obvious: parsing ... ✓ done |
+| FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... ✓ done |
 
 </details>
 

--- a/frontend/components/data360/chart-preview.tsx
+++ b/frontend/components/data360/chart-preview.tsx
@@ -3,6 +3,8 @@
 import type { MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
+import { proxyChartUrlForFetch } from "@/lib/chart-url";
+import { getBasePath } from "@/lib/config";
 import type { UIArtifact } from "../artifact";
 import { FullscreenIcon, LoaderIcon } from "../icons";
 
@@ -40,23 +42,6 @@ type ChartPreviewProps = {
   /** Message that contains this chart; used to scroll chat to it when artifact scroll behavior is "trigger". */
   messageId?: string;
 };
-
-/**
- * Normalize chart URL to same-origin so the request is proxied via Next.js
- * (app/api/[...path]) and avoids CORS / unreachable backend URLs.
- */
-function proxyChartUrl(url: string): string {
-  const trimmed = url.trim();
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
-    try {
-      const parsed = new URL(trimmed);
-      return `${parsed.pathname}${parsed.search}`;
-    } catch {
-      return trimmed;
-    }
-  }
-  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-}
 
 /** Aspect ratio for the chart preview (width / height). 16/9 is a good default for charts. */
 const PREVIEW_ASPECT_RATIO = 16 / 9;
@@ -180,7 +165,10 @@ function ChartThumbnail({ specJson }: { specJson: string }) {
   }, [specJson, themeConfig]);
 
   return (
-    <div className="relative w-full overflow-hidden bg-white dark:bg-zinc-900" style={{ aspectRatio: PREVIEW_ASPECT_RATIO }}>
+    <div
+      className="relative w-full overflow-hidden bg-white dark:bg-zinc-900"
+      style={{ aspectRatio: PREVIEW_ASPECT_RATIO }}
+    >
       <div ref={containerRef} className="absolute inset-0 size-full" />
     </div>
   );
@@ -199,7 +187,10 @@ export function ChartPreview({
   } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isOpening, setIsOpening] = useState(false);
-  const proxiedUrl = useMemo(() => proxyChartUrl(chartUrl), [chartUrl]);
+  const proxiedUrl = useMemo(
+    () => proxyChartUrlForFetch(chartUrl, getBasePath()),
+    [chartUrl],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -212,9 +203,7 @@ export function ChartPreview({
       .then((data) => {
         if (cancelled) return;
         const spec =
-          typeof data.spec === "object" && data.spec !== null
-            ? data.spec
-            : {};
+          typeof data.spec === "object" && data.spec !== null ? data.spec : {};
         const specJson = JSON.stringify(spec);
         setChartData({
           spec,
@@ -224,7 +213,9 @@ export function ChartPreview({
       })
       .catch((err) => {
         if (!cancelled) {
-          setLoadError(err instanceof Error ? err.message : "Failed to load chart");
+          setLoadError(
+            err instanceof Error ? err.message : "Failed to load chart",
+          );
         }
       });
     return () => {
@@ -256,7 +247,7 @@ export function ChartPreview({
       }));
       setIsOpening(false);
     },
-    [chartData, isReadonly, messageId, setArtifact]
+    [chartData, isReadonly, messageId, setArtifact],
   );
 
   if (loadError) {

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -8,6 +8,7 @@ import { MessageSquare } from "lucide-react";
 import { type Dispatch, memo, type SetStateAction, useState } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
+import { buildChartUrlRegexes } from "@/lib/chart-url";
 import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
@@ -16,8 +17,11 @@ import {
 } from "@/lib/data360";
 import type { Vote } from "@/lib/db/schema";
 import { parseFollowUps } from "@/lib/parse-follow-ups";
-import type { ChatMessage, StreamingThinkingPart } from "@/lib/types";
-import { isNonRenderableStreamEvent } from "@/lib/types";
+import {
+  type ChatMessage,
+  isNonRenderableStreamEvent,
+  type StreamingThinkingPart,
+} from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { cn, sanitizeText } from "@/lib/utils";
 import { ASK_ABOUT_SELECTION_CONTEXT_ATTR } from "./ask-about-selection-toolbar";
@@ -62,14 +66,8 @@ import {
 } from "./quoted-context-block";
 import { Weather } from "./weather";
 
-/** Bare chart URL (path or full URL). */
-const CHART_URL_REGEX =
-  /(?:\/api\/v1\/charts\/[^\s"'<>)\]]+|https?:\/\/[^\s]*\/api\/v1\/charts\/[^\s"'<>)\]]+)/;
-
-/** Markdown link whose href is a chart URL: [label](chartUrl). Group 1 = chartUrl, full match = whole link. */
-const CHART_MARKDOWN_LINK_REGEX = new RegExp(
-  `\\[[^\\]]*\\]\\s*\\(\\s*(${CHART_URL_REGEX.source})\\s*\\)`,
-);
+const { bare: CHART_URL_REGEX, markdownLink: CHART_MARKDOWN_LINK_REGEX } =
+  buildChartUrlRegexes();
 
 /** Splits text at the first chart URL (or markdown link with chart URL) so it can be replaced by ChartPreview inline. */
 function splitTextAtChartUrl(text: string): {

--- a/frontend/lib/chart-url.ts
+++ b/frontend/lib/chart-url.ts
@@ -1,0 +1,62 @@
+import { getBasePath } from "@/lib/config";
+
+/**
+ * Prepend Next.js `basePath` for app-root-relative API paths so `fetch()` hits the
+ * deployed app (e.g. `/app/api/...`) instead of the host root (`/api/...`).
+ */
+export function applyBasePathToChartPath(
+  pathWithQuery: string,
+  basePath: string,
+): string {
+  const base = basePath.replace(/\/+$/, "");
+  if (!base) return pathWithQuery;
+  const normalized = pathWithQuery.startsWith("/")
+    ? pathWithQuery
+    : `/${pathWithQuery}`;
+  if (normalized === base || normalized.startsWith(`${base}/`)) {
+    return normalized;
+  }
+  return `${base}${normalized}`;
+}
+
+/**
+ * Normalize chart URL to a same-origin path for `fetch()` (proxy via Next.js).
+ * Strips absolute URLs to pathname + search, then applies `basePath` when needed.
+ */
+export function proxyChartUrlForFetch(url: string, basePath: string): string {
+  const trimmed = url.trim();
+  let pathPart: string;
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    try {
+      const parsed = new URL(trimmed);
+      pathPart = `${parsed.pathname}${parsed.search}`;
+    } catch {
+      return trimmed;
+    }
+  } else {
+    pathPart = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  }
+  return applyBasePathToChartPath(pathPart, basePath);
+}
+
+/**
+ * Regexes for detecting chart URLs in assistant text. When `basePath` is set,
+ * matches both `/api/v1/charts/...` and `/basePath/api/v1/charts/...`.
+ */
+export function buildChartUrlRegexes(): {
+  bare: RegExp;
+  markdownLink: RegExp;
+} {
+  const base = getBasePath().replace(/\/+$/, "");
+  const escapedBase = base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const relativePart = base
+    ? `(?:(?:${escapedBase})?/api/v1/charts/[^\\s"'<>)\\]]+)`
+    : `(?:/api/v1/charts/[^\\s"'<>)\\]]+)`;
+  const bare = new RegExp(
+    `(?:${relativePart}|https?:\\/\\/[^\\s]*/api/v1/charts/[^\\s"'<>)\\]]+)`,
+  );
+  const markdownLink = new RegExp(
+    `\\[[^\\]]*\\]\\s*\\(\\s*(${bare.source})\\s*\\)`,
+  );
+  return { bare, markdownLink };
+}


### PR DESCRIPTION
## Summary

Closes #83 

Ensures Data360 chart previews and inline chart URLs work when the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (Next.js `basePath`). Chart JSON `fetch()` calls and markdown detection now target `/[basePath]/api/v1/charts/...` instead of only `/api/...` at the host root.

## Problem

Under a subpath deployment, root-relative paths like `/api/v1/charts/:id` resolve to the wrong origin path in the browser, so `ChartPreview` failed to load specs. Inline assistant text that linked chart URLs had the same mismatch; regexes only matched the non-prefixed form.

## Changes

- Add `frontend/lib/chart-url.ts` with `proxyChartUrlForFetch`, `applyBasePathToChartPath`, and `buildChartUrlRegexes` (uses `getBasePath()` from `@/lib/config`).
- `chart-preview.tsx`: resolve the proxied chart URL with base path before `fetch`.
- `message.tsx`: build chart URL regexes so both `/api/v1/charts/...` and `/[base]/api/v1/charts/...` are recognized when applicable.

## How to test

1. Set `NEXT_PUBLIC_BASE_PATH` (e.g. `/app`) to match `next.config` `basePath`.
2. Open a chat that returns a chart (tool `data360_get_viz_spec` or markdown with a chart URL).
3. Confirm network requests for chart JSON go to `/[basePath]/api/v1/charts/...` and the preview renders.

## Related

- Tracked as **FE-009** (`TODO/FE-009-chart-viz-urls-basepath.md`).