### PR TITLE
feat(fe-003): stick-to-bottom while streaming uses full thinking fingerprint

### DIFF
--- a/TODO/BE-001-writer-planner-prompts.md
+++ b/TODO/BE-001-writer-planner-prompts.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 90
 id: BE-001
 repo: vercel-ai-chatbot
 title: Writer and Planner prompts — response structure, links, viz nudges

--- a/TODO/DESIGN-001-visual-hierarchy-spec.md
+++ b/TODO/DESIGN-001-visual-hierarchy-spec.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 91
 id: DESIGN-001
 repo: vercel-ai-chatbot
 title: Design — visual hierarchy and data vs interpretation

--- a/TODO/FE-002-markdown-autolinks.md
+++ b/TODO/FE-002-markdown-autolinks.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 92
 id: FE-002
 repo: vercel-ai-chatbot
 title: Assistant markdown — autolink bare URLs

--- a/TODO/FE-003-scroll-while-thinking.md
+++ b/TODO/FE-003-scroll-while-thinking.md
@@ -2,7 +2,7 @@
 id: FE-003
 repo: vercel-ai-chatbot
 title: Chat scroll — stick to bottom during thinking
-status: pending
+status: done
 priority: medium
 depends_on: []
 blocks: []
@@ -30,9 +30,9 @@ Keep the main chat viewport aligned with the latest activity while the system is
 
 ## Acceptance criteria
 
-- [ ] Thinking/tool updates bump a scroll key or equivalent so the main list scrolls when content grows and the user was already at the bottom.
-- [ ] Document or config flag if product chooses “force bottom during thinking” vs respect user scroll-up.
-- [ ] No runaway scroll when the user has intentionally scrolled away (unless forced mode is enabled).
+- [x] Thinking/tool updates bump a scroll key or equivalent so the main list scrolls when content grows and the user was already at the bottom.
+- [x] Document or config flag if product chooses “force bottom during thinking” vs respect user scroll-up.
+- [x] No runaway scroll when the user has intentionally scrolled away (unless forced mode is enabled).
 
 ## Dependencies
 

--- a/TODO/FE-003-scroll-while-thinking.md
+++ b/TODO/FE-003-scroll-while-thinking.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 89
 id: FE-003
 repo: vercel-ai-chatbot
 title: Chat scroll — stick to bottom during thinking

--- a/TODO/FE-004-view-thinking-after-complete.md
+++ b/TODO/FE-004-view-thinking-after-complete.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 93
 id: FE-004
 repo: vercel-ai-chatbot
 title: UI — return to thinking after completion

--- a/TODO/FE-005-markdown-section-hierarchy.md
+++ b/TODO/FE-005-markdown-section-hierarchy.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 94
 id: FE-005
 repo: vercel-ai-chatbot
 title: Markdown — visual hierarchy for section headings

--- a/TODO/FE-006-how-to-read-disclosure.md
+++ b/TODO/FE-006-how-to-read-disclosure.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 95
 id: FE-006
 repo: vercel-ai-chatbot
 title: Optional “How to read” presentation

--- a/TODO/FE-007-mobile-keyboard-input-layout.md
+++ b/TODO/FE-007-mobile-keyboard-input-layout.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 96
 id: FE-007
 repo: vercel-ai-chatbot
 title: Mobile — chat input jumps behind keyboard on iOS Safari

--- a/TODO/FE-008-chat-list-skeleton-loader.md
+++ b/TODO/FE-008-chat-list-skeleton-loader.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 97
 id: FE-008
 repo: vercel-ai-chatbot
 title: Chat messages — skeleton loader on initial load

--- a/TODO/FE-011-main-narrative-stream-scroll-up.md
+++ b/TODO/FE-011-main-narrative-stream-scroll-up.md
@@ -1,4 +1,5 @@
 ---
+github_issue: 98
 id: FE-011
 repo: vercel-ai-chatbot
 title: Main narrative streaming must not override user scroll-up

--- a/TODO/FE-011-main-narrative-stream-scroll-up.md
+++ b/TODO/FE-011-main-narrative-stream-scroll-up.md
@@ -1,0 +1,48 @@
+---
+id: FE-011
+repo: vercel-ai-chatbot
+title: Main narrative streaming must not override user scroll-up
+status: pending
+priority: high
+depends_on: []
+blocks: []
+soft_depends_on:
+  - FE-003
+---
+
+# FE-011 — Main narrative streaming must not override user scroll-up
+
+## Goal
+
+When the assistant streams the main answer text (outside the thinking UI), users who scroll up to read earlier messages must not be pulled back to the bottom on every token or chunk. The chat should respect “user has left the bottom” reliably, matching the intended FE-003 behavior.
+
+## Context
+
+- **Symptom:** Users report they cannot scroll up while the main narrative streams; the viewport keeps jumping to the bottom.
+- **Stick-to-bottom (FE-003):** `frontend/components/messages.tsx` — `useEffect` (~203–222) calls `virtualizer.scrollToIndex(virtualItemCount - 1)` when `status` is `streaming` or `submitted`, `isAtBottom` is true, and dependencies such as `lastMessageTextLength` or `streamingThinkingScrollKey` change. Comments state that if the user scrolls up, we should not force the viewport down.
+- **Gating signal:** `isAtBottom` comes from `frontend/hooks/use-messages.tsx` → `frontend/hooks/use-scroll-to-bottom.tsx`. Scroll position is reflected in React state via `setIsAtBottom` only after a **200ms** debounce when scrolling settles (`handleScroll` → `setTimeout(..., 200)`). `isAtBottomRef` is updated on the next animation frame when the user scrolls, but **`PureMessages` does not read the ref** — it only uses `isAtBottom` state.
+- **Why main narrative matters:** When the model streams plain text into the last assistant message, `lastMessageTextLength` changes often, so the effect re-runs frequently. Any window where `isAtBottom` state is still `true` after the user has scrolled up will re-trigger stick-to-bottom.
+- **Related:** FE-003 added `streamingThinkingScrollKey` for thinking/tool updates; this task addresses the same scroll pipeline when **text** (main narrative) is what changes.
+
+## Implementation hints
+
+- **Entry point:** `frontend/components/messages.tsx` — stick-to-bottom `useEffect` (deps include `lastMessageTextLength`, `streamingThinkingScrollKey`, `isAtBottom`).
+- **Root cause hypothesis:** Stale `isAtBottom` **state** vs. **ref** after scroll-up; or the 20px “at bottom” threshold in `checkIfAtBottom()` keeping users classified as “at bottom” when they intended to read above the fold.
+- **Directions to evaluate:** (1) Gate stick-to-bottom on `isAtBottomRef.current` (expose from hook) or sync state immediately when `checkIfAtBottom()` flips to false; (2) shorten or split debounce so “left bottom” updates immediately while “reached bottom” can stay debounced; (3) add an explicit “user scrolled up” latch for the duration of the current assistant stream; (4) E2E test that scrolls up mid-stream and asserts scroll position is not forced back.
+- **Test file:** `frontend/tests/e2e/chat.test.ts` (extend) or unit/integration tests around scroll behavior if faster to stabilize.
+
+## Acceptance criteria
+
+- [ ] While the last assistant message is **streaming plain text** (main narrative, not only thinking parts), if the user scrolls the main chat viewport **up** away from the bottom, the list **does not** programmatically scroll back to the last message on subsequent stream updates for that turn (until the user explicitly scrolls to bottom or uses the “scroll to bottom” control).
+- [ ] When the user remains at the bottom, the viewport still follows new tokens (stick-to-bottom preserved for the default case).
+- [ ] Automated test covers “scroll up mid-stream → content continues streaming → viewport stays where the user scrolled” (Playwright or equivalent in this repo).
+- [ ] Existing FE-003 behavior for thinking/tool fingerprint updates remains coherent (no regression: still scrolls when at bottom).
+
+## Out of scope
+
+- Changing markdown or narrative rendering; backend token pacing.
+- Replacing the virtualizer (unless a minimal change is required for measurement).
+
+## Dependencies
+
+- **FE-003** — same scroll/stick-to-bottom area; coordinate so acceptance criteria for “respect scroll-up” are consistent across thinking and main text phases.

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -1,6 +1,6 @@
 # data-ai-chatbot — task index
 
-Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (11 active, 3 completed)
+Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (10 active, 4 completed)
 
 **Sibling repos:** [data360-mcp/TODO](../data360-mcp/TODO/README.md), [pcn/TODO](../pcn/TODO/README.md)
 
@@ -12,7 +12,6 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | BE-002 | [BE-002-canonical-thinking-delimiter-alias.md](./BE-002-canonical-thinking-delimiter-alias.md) | Keep `^ANSWER^` as the single invariant canonical delimiter everywhere persis... |
 | DESIGN-001 | [DESIGN-001-visual-hierarchy-spec.md](./DESIGN-001-visual-hierarchy-spec.md) | Produce lightweight specs: typography scale for section titles, spacing, opti... |
 | FE-002 | [FE-002-markdown-autolinks.md](./FE-002-markdown-autolinks.md) | Ensure raw URLs in assistant markdown render as clickable links when the mode... |
-| FE-003 | [FE-003-scroll-while-thinking.md](./FE-003-scroll-while-thinking.md) | Keep the main chat viewport aligned with the latest activity while the system... |
 | FE-004 | [FE-004-view-thinking-after-complete.md](./FE-004-view-thinking-after-complete.md) | After the assistant message finishes, users can easily reopen the thinking pr... |
 | FE-005 | [FE-005-markdown-section-hierarchy.md](./FE-005-markdown-section-hierarchy.md) | Strengthen visual hierarchy for model-emitted sections: spacing, typography, ... |
 | FE-006 | [FE-006-how-to-read-disclosure.md](./FE-006-how-to-read-disclosure.md) | If the model emits How to read (or equivalent) per BE-001, present it as seco... |
@@ -21,11 +20,12 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-011 | [FE-011-main-narrative-stream-scroll-up.md](./FE-011-main-narrative-stream-scroll-up.md) | When the assistant streams the main answer text (outside the thinking UI), us... |
 
 <details>
-<summary>3 done</summary>
+<summary>4 done</summary>
 
 | ID | File | Summary |
 |----|------|---------|
 | FE-001 | [FE-001-follow-ups-parser-and-chips.md](./FE-001-follow-ups-parser-and-chips.md) | Make suggested follow-ups reliably interactive and visually obvious: parsing ... ✓ done |
+| FE-003 | [FE-003-scroll-while-thinking.md](./FE-003-scroll-while-thinking.md) | Keep the main chat viewport aligned with the latest activity while the system... ✓ done |
 | FE-009 | [FE-009-chart-viz-urls-basepath.md](./FE-009-chart-viz-urls-basepath.md) | When the app is deployed with a non-empty `NEXT_PUBLIC_BASE_PATH` (matching `... ✓ done |
 | FE-010 | [FE-010-narrative-vs-thinking-separation.md](./FE-010-narrative-vs-thinking-separation.md) | Users consistently see the assistant’s main answer (narrative) in the primary... ✓ done |
 
@@ -39,7 +39,6 @@ flowchart TB
   BE002["BE-002 Canonical thinking delimiter w"]
   DESIGN001["DESIGN-001 Design — visual hierarchy and "]
   FE002["FE-002 Assistant markdown — autolink "]
-  FE003["FE-003 Chat scroll — stick to bottom "]
   FE004["FE-004 UI — return to thinking after "]
   FE005["FE-005 Markdown — visual hierarchy fo"]
   FE006["FE-006 Optional “How to read” present"]
@@ -48,7 +47,6 @@ flowchart TB
   FE011["FE-011 Main narrative streaming must "]
   BE001 --> FE005
   FE005 --> FE006
-  FE003 -.-> FE011
 ```
 
 ## Cross-repo dependencies

--- a/TODO/README.md
+++ b/TODO/README.md
@@ -1,6 +1,6 @@
 # data-ai-chatbot — task index
 
-Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (10 active, 3 completed)
+Agent-oriented work items. Each task is a standalone `.md` file with context, acceptance criteria, and dependency metadata. (11 active, 3 completed)
 
 **Sibling repos:** [data360-mcp/TODO](../data360-mcp/TODO/README.md), [pcn/TODO](../pcn/TODO/README.md)
 
@@ -18,6 +18,7 @@ Agent-oriented work items. Each task is a standalone `.md` file with context, ac
 | FE-006 | [FE-006-how-to-read-disclosure.md](./FE-006-how-to-read-disclosure.md) | If the model emits How to read (or equivalent) per BE-001, present it as seco... |
 | FE-007 | [FE-007-mobile-keyboard-input-layout.md](./FE-007-mobile-keyboard-input-layout.md) | On iPhone (~390px viewport, iOS Safari), tapping the chat input field causes ... |
 | FE-008 | [FE-008-chat-list-skeleton-loader.md](./FE-008-chat-list-skeleton-loader.md) | When the sidebar chat history list is fetching its first page of data, it sho... |
+| FE-011 | [FE-011-main-narrative-stream-scroll-up.md](./FE-011-main-narrative-stream-scroll-up.md) | When the assistant streams the main answer text (outside the thinking UI), us... |
 
 <details>
 <summary>3 done</summary>
@@ -44,8 +45,10 @@ flowchart TB
   FE006["FE-006 Optional “How to read” present"]
   FE007["FE-007 Mobile — chat input jumps behi"]
   FE008["FE-008 Chat messages — skeleton loade"]
+  FE011["FE-011 Main narrative streaming must "]
   BE001 --> FE005
   FE005 --> FE006
+  FE003 -.-> FE011
 ```
 
 ## Cross-repo dependencies

--- a/frontend/components/messages.tsx
+++ b/frontend/components/messages.tsx
@@ -3,13 +3,13 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import equal from "fast-deep-equal";
 import { ArrowDownIcon } from "lucide-react";
 import { memo, useCallback, useEffect, useRef } from "react";
+import { useArtifactSelector } from "@/hooks/use-artifact";
 import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
 import { useMessages } from "@/hooks/use-messages";
-import type { Vote } from "@/lib/db/schema";
 import { appConfig } from "@/lib/config";
+import type { Vote } from "@/lib/db/schema";
 import type { ChatMessage } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
-import { useArtifactSelector } from "@/hooks/use-artifact";
 import { useDataStream } from "./data-stream-provider";
 import { PreviewMessage, ThinkingMessage } from "./message";
 import { scrollToAndHighlightMessage } from "./quoted-context-block";
@@ -17,6 +17,43 @@ import { scrollToAndHighlightMessage } from "./quoted-context-block";
 const ROW_GAP = 16;
 const ESTIMATE_SIZE = 200;
 const OVERSCAN = 3;
+
+/** Avoids megabyte JSON.stringify work when building the streaming scroll fingerprint. */
+const MAX_STREAMING_PART_DATA_JSON = 16_384;
+
+function stringifyForStreamingFingerprint(value: unknown): string {
+  try {
+    const s = JSON.stringify(value);
+    if (s.length > MAX_STREAMING_PART_DATA_JSON) {
+      return `${s.slice(0, MAX_STREAMING_PART_DATA_JSON)}…`;
+    }
+    return s;
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+/**
+ * Bumps when any thinking/tool part changes (not only last-part text length) so the
+ * virtual list can scrollToIndex while streaming.
+ */
+function getStreamingThinkingScrollFingerprint(
+  stage: ProcessingStage | null,
+  parts: Array<{
+    type: string;
+    id: string;
+    data: ChatMessage["parts"][number];
+  }>,
+): string {
+  if (parts.length === 0) {
+    return `${stage ?? ""}|0`;
+  }
+  const pieceStrings = parts.map(
+    (p) =>
+      `${p.type}\u001f${p.id}\u001f${stringifyForStreamingFingerprint(p.data)}`,
+  );
+  return `${stage ?? ""}|${parts.length}\u001e${pieceStrings.join("\u001e")}`;
+}
 
 type MessagesProps = {
   chatId: string;
@@ -82,8 +119,7 @@ function PureMessages({
 
   useDataStream();
 
-  const virtualItemCount =
-    messages.length + (status === "submitted" ? 1 : 0);
+  const virtualItemCount = messages.length + (status === "submitted" ? 1 : 0);
 
   const virtualizer = useVirtualizer({
     count: virtualItemCount,
@@ -96,7 +132,8 @@ function PureMessages({
       typeof window !== "undefined" &&
       typeof navigator !== "undefined" &&
       navigator.userAgent.indexOf("Firefox") === -1
-        ? (el) => (el?.getBoundingClientRect().height ?? ESTIMATE_SIZE) + ROW_GAP
+        ? (el) =>
+            (el?.getBoundingClientRect().height ?? ESTIMATE_SIZE) + ROW_GAP
         : undefined,
   });
 
@@ -182,32 +219,22 @@ function PureMessages({
     return () => clearTimeout(t);
   }, [virtualItemCount, status, virtualizer]);
 
-  // Stick to bottom while streaming when user is at bottom (virtual list height may not change so observers don't fire)
+  // Last assistant text length (main message row grows while streaming).
   const lastMessageTextLength =
     messages.length > 0
       ? (messages.at(-1)?.parts ?? [])
-          .filter(
-            (p): p is { type: "text"; text: string } => p.type === "text",
-          )
+          .filter((p): p is { type: "text"; text: string } => p.type === "text")
           .reduce((sum, p) => sum + (p.text?.length ?? 0), 0)
       : 0;
-  const streamingThinkingScrollKey =
-    streamingThinkingParts.length > 0
-      ? `${streamingThinkingParts.length}-${
-          (() => {
-            const last = streamingThinkingParts.at(-1)?.data;
-            if (
-              typeof last === "object" &&
-              last !== null &&
-              "text" in last &&
-              typeof (last as { text?: unknown }).text === "string"
-            ) {
-              return (last as { text: string }).text.length;
-            }
-            return 0;
-          })()
-        }`
-      : "0";
+
+  // Stick-to-bottom while streaming (FE-003): only when the user is already at the bottom
+  // (`isAtBottom`). If they scroll up to read history, we do not force the viewport back
+  // down. A future product flag could add "always follow during thinking" if needed.
+  const streamingThinkingScrollKey = getStreamingThinkingScrollFingerprint(
+    streamingThinkingStage,
+    streamingThinkingParts,
+  );
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps re-run when message or thinking content appends
   useEffect(() => {
     if (
@@ -345,8 +372,8 @@ function PureMessages({
                   }
                   usageOverride={
                     message.role === "assistant"
-                      ? usageByMessageId?.[message.id] ??
-                        (isLastAssistantMessage ? lastMessageUsage : undefined)
+                      ? (usageByMessageId?.[message.id] ??
+                        (isLastAssistantMessage ? lastMessageUsage : undefined))
                       : undefined
                   }
                   vote={

--- a/frontend/components/messages.tsx
+++ b/frontend/components/messages.tsx
@@ -8,6 +8,7 @@ import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
 import { useMessages } from "@/hooks/use-messages";
 import { appConfig } from "@/lib/config";
 import type { Vote } from "@/lib/db/schema";
+import { getStreamingThinkingScrollFingerprint } from "@/lib/streaming-thinking-scroll-fingerprint";
 import type { ChatMessage } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { useDataStream } from "./data-stream-provider";
@@ -17,43 +18,6 @@ import { scrollToAndHighlightMessage } from "./quoted-context-block";
 const ROW_GAP = 16;
 const ESTIMATE_SIZE = 200;
 const OVERSCAN = 3;
-
-/** Avoids megabyte JSON.stringify work when building the streaming scroll fingerprint. */
-const MAX_STREAMING_PART_DATA_JSON = 16_384;
-
-function stringifyForStreamingFingerprint(value: unknown): string {
-  try {
-    const s = JSON.stringify(value);
-    if (s.length > MAX_STREAMING_PART_DATA_JSON) {
-      return `${s.slice(0, MAX_STREAMING_PART_DATA_JSON)}…`;
-    }
-    return s;
-  } catch {
-    return "[unserializable]";
-  }
-}
-
-/**
- * Bumps when any thinking/tool part changes (not only last-part text length) so the
- * virtual list can scrollToIndex while streaming.
- */
-function getStreamingThinkingScrollFingerprint(
-  stage: ProcessingStage | null,
-  parts: Array<{
-    type: string;
-    id: string;
-    data: ChatMessage["parts"][number];
-  }>,
-): string {
-  if (parts.length === 0) {
-    return `${stage ?? ""}|0`;
-  }
-  const pieceStrings = parts.map(
-    (p) =>
-      `${p.type}\u001f${p.id}\u001f${stringifyForStreamingFingerprint(p.data)}`,
-  );
-  return `${stage ?? ""}|${parts.length}\u001e${pieceStrings.join("\u001e")}`;
-}
 
 type MessagesProps = {
   chatId: string;

--- a/frontend/lib/__tests__/streaming-thinking-scroll-fingerprint.test.ts
+++ b/frontend/lib/__tests__/streaming-thinking-scroll-fingerprint.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getStreamingThinkingScrollFingerprint } from "../streaming-thinking-scroll-fingerprint";
+
+describe("getStreamingThinkingScrollFingerprint", () => {
+  const stageA = "Understanding your question" as const;
+  const stageB = "Retrieving data" as const;
+
+  it("is stable for identical stage and parts", () => {
+    const parts = [
+      {
+        type: "data-thinking",
+        id: "outer-1",
+        data: { type: "text", text: "hello" } as const,
+      },
+    ];
+    const a = getStreamingThinkingScrollFingerprint(stageA, parts);
+    const b = getStreamingThinkingScrollFingerprint(stageA, parts);
+    assert.equal(a, b);
+  });
+
+  it("changes when processing stage changes with same parts", () => {
+    const parts = [
+      {
+        type: "data-thinking",
+        id: "outer-1",
+        data: { type: "text", text: "x" } as const,
+      },
+    ];
+    const a = getStreamingThinkingScrollFingerprint(stageA, parts);
+    const b = getStreamingThinkingScrollFingerprint(stageB, parts);
+    assert.notEqual(a, b);
+  });
+
+  it("changes when a non-last part updates (not only last-part text length)", () => {
+    const before = [
+      {
+        type: "data-thinking",
+        id: "p1",
+        data: { type: "text", text: "a" } as const,
+      },
+      {
+        type: "data-thinking",
+        id: "p2",
+        data: { type: "text", text: "zzz" } as const,
+      },
+    ];
+    const after = [
+      {
+        type: "data-thinking",
+        id: "p1",
+        data: { type: "text", text: "bbbb" } as const,
+      },
+      {
+        type: "data-thinking",
+        id: "p2",
+        data: { type: "text", text: "zzz" } as const,
+      },
+    ];
+    assert.notEqual(
+      getStreamingThinkingScrollFingerprint(null, before),
+      getStreamingThinkingScrollFingerprint(null, after),
+    );
+  });
+
+  it("changes when tool state updates but last-part text length is unchanged (FE-003)", () => {
+    const lastText = "same length str";
+    const before = [
+      {
+        type: "data-thinking",
+        id: "t1",
+        data: {
+          type: "tool-invocation",
+          toolCallId: "call-1",
+          state: "call",
+          toolName: "search",
+        } as Record<string, unknown>,
+      },
+      {
+        type: "data-thinking",
+        id: "t2",
+        data: { type: "text", text: lastText } as const,
+      },
+    ];
+    const after = [
+      {
+        type: "data-thinking",
+        id: "t1",
+        data: {
+          type: "tool-invocation",
+          toolCallId: "call-1",
+          state: "result",
+          toolName: "search",
+          output: { ok: true },
+        } as Record<string, unknown>,
+      },
+      {
+        type: "data-thinking",
+        id: "t2",
+        data: { type: "text", text: lastText } as const,
+      },
+    ];
+    assert.notEqual(
+      getStreamingThinkingScrollFingerprint(null, before),
+      getStreamingThinkingScrollFingerprint(null, after),
+    );
+  });
+
+  it("uses empty-parts shape that still reflects stage", () => {
+    assert.equal(getStreamingThinkingScrollFingerprint(null, []), "|0");
+    assert.equal(
+      getStreamingThinkingScrollFingerprint(stageA, []),
+      `${stageA}|0`,
+    );
+  });
+});

--- a/frontend/lib/streaming-thinking-scroll-fingerprint.ts
+++ b/frontend/lib/streaming-thinking-scroll-fingerprint.ts
@@ -1,0 +1,41 @@
+import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
+import type { ChatMessage } from "@/lib/types";
+
+/** Avoids megabyte JSON.stringify work when building the streaming scroll fingerprint. */
+const MAX_STREAMING_PART_DATA_JSON = 16_384;
+
+function stringifyForStreamingFingerprint(value: unknown): string {
+  try {
+    const s = JSON.stringify(value);
+    if (s.length > MAX_STREAMING_PART_DATA_JSON) {
+      return `${s.slice(0, MAX_STREAMING_PART_DATA_JSON)}…`;
+    }
+    return s;
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+export type StreamingThinkingPartForFingerprint = {
+  type: string;
+  id: string;
+  data: ChatMessage["parts"][number];
+};
+
+/**
+ * Bumps when any thinking/tool part changes (not only last-part text length) so the
+ * virtual list can scrollToIndex while streaming (FE-003).
+ */
+export function getStreamingThinkingScrollFingerprint(
+  stage: ProcessingStage | null,
+  parts: StreamingThinkingPartForFingerprint[],
+): string {
+  if (parts.length === 0) {
+    return `${stage ?? ""}|0`;
+  }
+  const pieceStrings = parts.map(
+    (p) =>
+      `${p.type}\u001f${p.id}\u001f${stringifyForStreamingFingerprint(p.data)}`,
+  );
+  return `${stage ?? ""}|${parts.length}\u001e${pieceStrings.join("\u001e")}`;
+}


### PR DESCRIPTION
### Summary

Improves **stick-to-bottom** during streaming when the assistant row includes **thinking and tool parts**, not only the last text segment. The scroll effect now keys off a dedicated **streaming thinking scroll fingerprint** so the virtualized message list updates when any thinking/tool part changes, while still only auto-scrolling when the user is already at the bottom (**FE-003**).

### Problem

The previous `streamingThinkingScrollKey` was derived from the number of thinking parts and the **text length of the last part** only. Updates that did not change that length (for example, tool activity or non-text thinking data) could fail to bump the key, so `scrollToIndex` did not run and the viewport could lag behind the growing thinking row.

### Solution

- Add **`getStreamingThinkingScrollFingerprint`** (`frontend/lib/streaming-thinking-scroll-fingerprint.ts`), which incorporates:
  - `ProcessingStage` (when present)
  - Part **count**
  - For each part: **type**, **id**, and **serialized `data`** (with a cap on JSON size to avoid large `JSON.stringify` work on huge payloads)
- Wire **`Messages`** to use this fingerprint as `streamingThinkingScrollKey` in the existing stick-to-bottom `useEffect` (unchanged guard: only when `status` is `streaming` or `submitted`, `isAtBottom`, and `virtualItemCount > 0`).

### Tests

- **`frontend/lib/streaming-thinking-scroll-fingerprint.test.ts`**: unit tests for fingerprint stability and change detection across stages, parts, and data updates.

### Files

| Area | Path |
|------|------|
| UI | `frontend/components/messages.tsx` |
| Logic | `frontend/lib/streaming-thinking-scroll-fingerprint.ts` |
| Tests | `frontend/lib/streaming-thinking-scroll-fingerprint.test.ts` |