### PR TITLE
Expand LangGraph chat pipeline with multi-agent scout/planner/research and EXPLAIN branching

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -104,6 +104,10 @@ LOG_FILE=logs/chatbot.log
 # LOG_LEVEL=DEBUG
 # LOG_MAX_BYTES=10485760
 # LOG_BACKUP_COUNT=5
+# Log LangGraph LLM prompts, streamed token fragments, completions, and tool I/O (dev only; may contain PII).
+# GRAPH_DEBUG_LOG_LLM=true
+# Optional: append the same records to this file (default if unset: backend/logs/graph_llm_debug.log).
+# GRAPH_DEBUG_LOG_LLM_FILE=/tmp/graph_llm_debug.log
 
 
 # Auth: guest (login = Try as guest only) | user (email/password + Try as guest) | msal

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -104,7 +104,8 @@ LOG_FILE=logs/chatbot.log
 # LOG_LEVEL=DEBUG
 # LOG_MAX_BYTES=10485760
 # LOG_BACKUP_COUNT=5
-# Log LangGraph LLM prompts, streamed token fragments, completions, and tool I/O (dev only; may contain PII).
+# Log full LangGraph flow: user input, every astream_events step (all nodes), LLM streams/completions,
+# tools, chain state updates, final answer (dev only; may contain PII). Token streams go to the file at DEBUG on console.
 # GRAPH_DEBUG_LOG_LLM=true
 # Optional: append the same records to this file (default if unset: backend/logs/graph_llm_debug.log).
 # GRAPH_DEBUG_LOG_LLM_FILE=/tmp/graph_llm_debug.log

--- a/backend/app/ai/graph/graph_debug_log.py
+++ b/backend/app/ai/graph/graph_debug_log.py
@@ -1,11 +1,22 @@
-"""Opt-in debug logging for LangGraph LLM prompts and streamed tokens.
+"""Opt-in debug logging for the LangGraph chat pipeline.
 
 Enable with ``GRAPH_DEBUG_LOG_LLM=true`` in the environment. Logs may contain
 user messages and tool output — use only in trusted dev environments.
 
-When enabled, records are emitted to the application logger and appended to
-``GRAPH_DEBUG_LOG_LLM_FILE`` when set, or to ``backend/logs/graph_llm_debug.log``
-by default (see :func:`_append_graph_debug_file`).
+**Full flow coverage** (when enabled):
+
+- :func:`log_pipeline_input` — user ``query_text``, recent OpenAI messages, model.
+- :func:`log_langgraph_raw_event` — every ``astream_events(v2)`` record: chain
+  start/end (state updates per node), LLM stream/completion for **any** node,
+  tool start/end, plus other event types (truncated).
+- :func:`log_llm_messages_preview` — optional extra snapshots before ``ainvoke``
+  in narrator / ``run_tool_loop`` (research, explain, recovery).
+- :func:`log_pipeline_output` / :func:`log_pipeline_error` — assembled answer and
+  failures.
+
+Records go to the debug file (always when enabled). High-volume token streams
+use ``logger.debug`` so default ``LOG_LEVEL=INFO`` stays readable; the file still
+contains all stream fragments.
 """
 
 from __future__ import annotations
@@ -17,6 +28,9 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Upper bound for serialized ``on_chain_*`` / misc event ``data`` in flow logs.
+_FLOW_DATA_REPR_MAX = 10_000
 
 _file_lock = threading.Lock()
 
@@ -113,7 +127,7 @@ def log_llm_stream_delta(*, message_id: str, graph_node: str, delta: str) -> Non
         return
     frag = trunc_for_log(delta, max_len=1500)
     body = f"message_id={message_id} node={graph_node} chars={len(delta)} fragment={frag!r}"
-    logger.info(
+    logger.debug(
         "[graph_llm_stream] message_id=%s node=%s chars=%d fragment=%r",
         message_id,
         graph_node,
@@ -155,6 +169,210 @@ def completion_text_from_model_output(msg: Any) -> str:
                 parts.append(str(block))
         return "".join(parts)
     return str(c)
+
+
+def _unwrap_chat_generation(output: Any) -> Any:
+    """Match LangGraph ``on_chat_model_end`` payload (generation vs message)."""
+    if output is None:
+        return None
+    msg = getattr(output, "message", None)
+    if msg is not None:
+        return msg
+    return output
+
+
+def _summarize_chain_output_dict(out: dict[str, Any]) -> str:
+    """Multi-line summary of a node ``output`` state dict (truncated per field)."""
+    lines: list[str] = []
+    for key, val in sorted(out.items(), key=lambda kv: kv[0]):
+        if key.startswith("_"):
+            continue
+        if isinstance(val, str):
+            lines.append(f"{key}={trunc_for_log(val, 2000)!r}")
+        elif isinstance(val, list):
+            lines.append(
+                f"{key}=<list len={len(val)}> preview={trunc_for_log(repr(val[:3]), 800)!r}"
+            )
+        elif isinstance(val, dict):
+            subk = list(val.keys())[:20]
+            lines.append(f"{key}=<dict keys={subk}>")
+        else:
+            lines.append(f"{key}={trunc_for_log(repr(val), 800)!r}")
+    return "\n".join(lines) if lines else "(empty output dict)"
+
+
+def log_pipeline_input(*, message_id: str, input_state: dict[str, Any]) -> None:
+    """Log the graph run input: query and recent messages (start of full flow)."""
+    if not graph_llm_log_enabled():
+        return
+    qt = str(input_state.get("query_text") or "")
+    mt = str(input_state.get("model_type") or "")
+    forced = input_state.get("forced_intent")
+    ss = str(input_state.get("session_summary") or "")
+    msgs = input_state.get("openai_messages") or []
+    recent = msgs[-6:] if isinstance(msgs, list) and len(msgs) > 6 else msgs
+    lines = [
+        f"message_id={message_id}",
+        f"query_text={trunc_for_log(qt, 6000)!r}",
+        f"model_type={mt!r}",
+        f"forced_intent={forced!r}",
+        f"session_summary={trunc_for_log(ss, 2000)!r}",
+        "openai_messages (last up to 6):",
+    ]
+    if isinstance(recent, list):
+        for i, m in enumerate(recent):
+            if isinstance(m, dict):
+                role = m.get("role", "?")
+                content = m.get("content", "")
+                if isinstance(content, list):
+                    content = repr(content)
+                lines.append(f"  [{i}] role={role!r} content={trunc_for_log(str(content), 3500)!r}")
+            else:
+                lines.append(f"  [{i}] {trunc_for_log(repr(m), 800)}")
+    else:
+        lines.append(f"  (not a list): {trunc_for_log(repr(msgs), 1500)}")
+    body = "\n".join(lines)
+    logger.info("[graph_flow_input]\n%s", body)
+    _append_graph_debug_file("graph_flow_input", body)
+
+
+def log_pipeline_output(
+    *,
+    message_id: str,
+    out: dict[str, Any],
+    final_state: dict[str, Any] | None = None,
+) -> None:
+    """Log assembled client-visible outcome after a successful graph run."""
+    if not graph_llm_log_enabled():
+        return
+    failed = out.get("stream_failed")
+    ans = str(out.get("answer_text") or "")
+    rr = str(out.get("routing_reasoning") or "")
+    intent = str(out.get("intent") or "")
+    sess = str(out.get("session_summary") or "")
+    smc = out.get("summarized_message_count", "")
+    parts = out.get("assistant_parts_for_db") or []
+    n_parts = len(parts) if isinstance(parts, list) else "?"
+    fs = final_state if isinstance(final_state, dict) else {}
+    if fs:
+        intent = intent or str(fs.get("intent") or "")
+    rp = str(fs.get("research_packet") or "") if fs else ""
+    fq = fs.get("followup_questions") if fs else None
+    lines = [
+        f"message_id={message_id}",
+        f"stream_failed={failed!r}",
+        f"intent={intent!r}",
+        f"routing_reasoning={trunc_for_log(rr, 2500)!r}",
+        f"answer_text={trunc_for_log(ans, 12000)!r}",
+        f"session_summary={trunc_for_log(sess, 2000)!r}",
+        f"summarized_message_count={smc!r}",
+        f"assistant_parts_for_db count={n_parts}",
+    ]
+    if rp:
+        lines.append(f"research_packet={trunc_for_log(rp, 6000)!r}")
+    if fq:
+        lines.append(f"followup_questions={trunc_for_log(repr(fq), 2000)!r}")
+    body = "\n".join(lines)
+    logger.info("[graph_flow_output]\n%s", body)
+    _append_graph_debug_file("graph_flow_output", body)
+
+
+def log_pipeline_error(*, message_id: str, error_id: str, exc: BaseException) -> None:
+    """Log terminal graph/model failure (file + short INFO; traceback stays on outer WARNING)."""
+    if not graph_llm_log_enabled():
+        return
+    body = (
+        f"message_id={message_id} error_id={error_id} "
+        f"type={type(exc).__name__!r} message={trunc_for_log(str(exc), 4000)!r}"
+    )
+    logger.info("[graph_flow_error] %s", body)
+    _append_graph_debug_file("graph_flow_error", body)
+
+
+def log_langgraph_raw_event(*, message_id: str, event: dict[str, Any]) -> None:
+    """Log one LangGraph ``astream_events`` v2 payload (covers all nodes in the graph)."""
+    if not graph_llm_log_enabled():
+        return
+    if not isinstance(event, dict):
+        _append_graph_debug_file(
+            "graph_flow_misc", f"message_id={message_id} non_dict_event={event!r}"
+        )
+        return
+    evt_type = str(event.get("event") or "")
+    evt_name = str(event.get("name") or "")
+    meta = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    node = str(meta.get("langgraph_node") or "")
+    run_id = str(event.get("run_id") or "")
+    data = event.get("data") if isinstance(event.get("data"), dict) else {}
+
+    if evt_type == "on_chat_model_stream":
+        chunk = data.get("chunk")
+        content = chunk.content if (chunk and hasattr(chunk, "content")) else ""
+        if not content:
+            return
+        graph_node = node or evt_name or "unknown"
+        log_llm_stream_delta(message_id=message_id, graph_node=graph_node, delta=content)
+        return
+
+    if evt_type == "on_chat_model_end":
+        out_raw = data.get("output")
+        out_msg = _unwrap_chat_generation(out_raw)
+        end_text = completion_text_from_model_output(out_msg)
+        graph_node = node or evt_name or "unknown"
+        if end_text:
+            log_llm_completion_preview(message_id=message_id, graph_node=graph_node, text=end_text)
+        else:
+            body = (
+                f"message_id={message_id} langgraph_node={graph_node!r} "
+                f"(no text content) payload_type={type(out_msg).__name__!r}"
+            )
+            logger.info("[graph_flow_llm_end] %s", body)
+            _append_graph_debug_file("graph_flow_llm_end", body)
+        return
+
+    if evt_type in ("on_tool_start", "on_tool_end"):
+        tool_name = (
+            evt_name or (data.get("name") if isinstance(data.get("name"), str) else "") or "tool"
+        )
+        detail_key = "input" if evt_type == "on_tool_start" else "output"
+        raw_detail = data.get(detail_key, "")
+        summary = trunc_for_log(repr(raw_detail), 3500)
+        body = (
+            f"message_id={message_id} langgraph_node={node!r} tool={tool_name!r} "
+            f"event={evt_type!r} run_id={run_id!r} {detail_key}={summary}"
+        )
+        logger.info("[graph_flow_tool_event] %s", trunc_for_log(body, 5000))
+        _append_graph_debug_file("graph_flow_tool_event", body)
+        return
+
+    if evt_type in ("on_chain_start", "on_chain_end"):
+        blocks: list[str] = []
+        if "input" in data:
+            blocks.append(f"input={trunc_for_log(repr(data.get('input')), 4000)}")
+        out = data.get("output")
+        if isinstance(out, dict):
+            blocks.append("output:\n" + _summarize_chain_output_dict(out))
+        elif out is not None:
+            blocks.append(f"output={trunc_for_log(repr(out), _FLOW_DATA_REPR_MAX)}")
+        if not blocks:
+            blocks.append(trunc_for_log(repr(data), _FLOW_DATA_REPR_MAX))
+        summary = "\n".join(blocks)
+        body = (
+            f"message_id={message_id} event={evt_type!r} name={evt_name!r} "
+            f"langgraph_node={node!r} run_id={run_id!r}\n{summary}"
+        )
+        logger.info("[graph_flow_chain] %s", trunc_for_log(body.replace("\n", " | "), 4000))
+        _append_graph_debug_file("graph_flow_chain", body)
+        return
+
+    # Other events (on_chat_model_start, on_parser_* , …) — compact
+    body = (
+        f"message_id={message_id} event={evt_type!r} name={evt_name!r} "
+        f"langgraph_node={node!r} run_id={run_id!r}\n"
+        f"data={trunc_for_log(repr(data), _FLOW_DATA_REPR_MAX)}"
+    )
+    logger.debug("[graph_flow_misc] %s", trunc_for_log(body.replace("\n", " | "), 3000))
+    _append_graph_debug_file("graph_flow_misc", body)
 
 
 def log_llm_tool_manual(

--- a/backend/app/ai/graph/graph_debug_log.py
+++ b/backend/app/ai/graph/graph_debug_log.py
@@ -1,0 +1,184 @@
+"""Opt-in debug logging for LangGraph LLM prompts and streamed tokens.
+
+Enable with ``GRAPH_DEBUG_LOG_LLM=true`` in the environment. Logs may contain
+user messages and tool output — use only in trusted dev environments.
+
+When enabled, records are emitted to the application logger and appended to
+``GRAPH_DEBUG_LOG_LLM_FILE`` when set, or to ``backend/logs/graph_llm_debug.log``
+by default (see :func:`_append_graph_debug_file`).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_file_lock = threading.Lock()
+
+
+def trunc_for_log(text: str, max_len: int = 4000) -> str:
+    """Truncate a string for log lines; keeps total log size bounded."""
+    if len(text) <= max_len:
+        return text
+    return f"{text[:max_len]}... [truncated, total_len={len(text)}]"
+
+
+def graph_llm_log_enabled() -> bool:
+    from app.config import settings
+
+    return bool(getattr(settings, "GRAPH_DEBUG_LOG_LLM", False))
+
+
+def _backend_root() -> Path:
+    """Directory containing ``app/`` (the backend package root)."""
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _resolved_graph_debug_log_path() -> Path | None:
+    """Return destination path for graph LLM debug file, or None if disabled."""
+    if not graph_llm_log_enabled():
+        return None
+    from app.config import settings
+
+    raw = (getattr(settings, "GRAPH_DEBUG_LOG_LLM_FILE", "") or "").strip()
+    if raw:
+        p = Path(raw)
+        return p if p.is_absolute() else Path.cwd() / p
+    return _backend_root() / "logs" / "graph_llm_debug.log"
+
+
+def _append_graph_debug_file(category: str, content: str) -> None:
+    """Append one debug record to the graph LLM debug file (stream-friendly flush)."""
+    path = _resolved_graph_debug_log_path()
+    if path is None:
+        return
+    ts = datetime.now(timezone.utc).isoformat()
+    sep = "=" * 72
+    block = f"{sep}\n{ts} [{category}]\n{content.rstrip()}\n"
+    with _file_lock:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as f:
+                f.write(block)
+                f.flush()
+        except OSError as exc:
+            logger.warning("GRAPH_DEBUG_LOG_LLM file write failed (%s): %s", path, exc)
+
+
+def log_llm_messages_preview(
+    *,
+    message_id: str,
+    graph_node: str,
+    messages: list[Any],
+    iteration: int | None = None,
+    per_message_max: int = 2500,
+) -> None:
+    """Log each LangChain message (type + truncated content) before an LLM call."""
+    if not graph_llm_log_enabled():
+        return
+    lines: list[str] = []
+    for i, m in enumerate(messages):
+        cls = type(m).__name__
+        raw = getattr(m, "content", "")
+        if isinstance(raw, str):
+            body = trunc_for_log(raw, max_len=per_message_max)
+        else:
+            body = trunc_for_log(repr(raw), max_len=per_message_max)
+        lines.append(f"  [{i}] {cls}: {body}")
+    iter_part = f" iteration={iteration}" if iteration is not None else ""
+    joined = "\n".join(lines)
+    body = (
+        f"message_id={message_id} node={graph_node}{iter_part} "
+        f"message_count={len(messages)}\n{joined}"
+    )
+    logger.info(
+        "[graph_llm_prompt] message_id=%s node=%s%s message_count=%d\n%s",
+        message_id,
+        graph_node,
+        iter_part,
+        len(messages),
+        "\n".join(lines),
+    )
+    _append_graph_debug_file("graph_llm_prompt", body)
+
+
+def log_llm_stream_delta(*, message_id: str, graph_node: str, delta: str) -> None:
+    """Log one streamed token fragment as seen by the SSE bridge."""
+    if not graph_llm_log_enabled() or not delta:
+        return
+    frag = trunc_for_log(delta, max_len=1500)
+    body = f"message_id={message_id} node={graph_node} chars={len(delta)} fragment={frag!r}"
+    logger.info(
+        "[graph_llm_stream] message_id=%s node=%s chars=%d fragment=%r",
+        message_id,
+        graph_node,
+        len(delta),
+        frag,
+    )
+    _append_graph_debug_file("graph_llm_stream", body)
+
+
+def log_llm_completion_preview(*, message_id: str, graph_node: str, text: str) -> None:
+    """Log full assistant text from ``on_chat_model_end`` (when present)."""
+    if not graph_llm_log_enabled() or not text:
+        return
+    preview = trunc_for_log(text, max_len=4000)
+    body = f"message_id={message_id} node={graph_node} chars={len(text)} text={preview!r}"
+    logger.info(
+        "[graph_llm_completion] message_id=%s node=%s chars=%d text=%r",
+        message_id,
+        graph_node,
+        len(text),
+        preview,
+    )
+    _append_graph_debug_file("graph_llm_completion", body)
+
+
+def completion_text_from_model_output(msg: Any) -> str:
+    """Best-effort plain text from a ChatGeneration / AIMessage ``output``."""
+    if msg is None:
+        return ""
+    c = getattr(msg, "content", "")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        parts: list[str] = []
+        for block in c:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+            else:
+                parts.append(str(block))
+        return "".join(parts)
+    return str(c)
+
+
+def log_llm_tool_manual(
+    *,
+    message_id: str,
+    graph_node: str,
+    tool_name: str,
+    phase: str,
+    payload_summary: str,
+) -> None:
+    """Log manual tool notify payloads (truncated summary string)."""
+    if not graph_llm_log_enabled():
+        return
+    detail = trunc_for_log(payload_summary, max_len=2000)
+    body = (
+        f"message_id={message_id} node={graph_node} tool={tool_name} "
+        f"phase={phase} detail={detail!r}"
+    )
+    logger.info(
+        "[graph_llm_tool] message_id=%s node=%s tool=%s phase=%s detail=%r",
+        message_id,
+        graph_node,
+        tool_name,
+        phase,
+        detail,
+    )
+    _append_graph_debug_file("graph_llm_tool", body)

--- a/backend/app/ai/graph/llm_factory.py
+++ b/backend/app/ai/graph/llm_factory.py
@@ -25,6 +25,29 @@ def _streaming_usage_model_kwargs(streaming: bool) -> dict[str, Any]:
     return {"stream_options": {"include_usage": True}}
 
 
+def get_routing_llm() -> ChatLiteLLM:
+    """Return a ChatLiteLLM instance for the intent router.
+
+    The routing model is configured independently from the main chat model via
+    ``settings.ROUTING_MODEL``.  Fixed at temperature=0 (deterministic JSON
+    classification), no streaming (we need a complete response before routing),
+    and JSON response format so the output is always parseable.
+
+    Because this LLM is called inside the ``router_node`` LangGraph node,
+    LangGraph automatically tags the resulting ``on_chat_model_end`` event with
+    ``langgraph_node="router"``.  The SSE bridge then accumulates usage via the
+    standard path — no manual ``router_usage`` plumbing needed.
+    """
+    full_model = f"{settings.models.MODEL_PROVIDER}{settings.ROUTING_MODEL}"
+    return ChatLiteLLM(
+        model=full_model,
+        temperature=0,
+        streaming=False,
+        max_tokens=300,
+        model_kwargs={"response_format": {"type": "json_object"}},
+    )
+
+
 def get_chat_llm(
     model_type: ModelType | str,
     temperature: float = 0.7,

--- a/backend/app/ai/graph/llm_invoke.py
+++ b/backend/app/ai/graph/llm_invoke.py
@@ -1,0 +1,54 @@
+"""Safe LLM ``ainvoke`` for LangGraph nodes — avoids crashing the stream on policy/API errors."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from langchain_core.messages import AIMessage
+
+try:
+    from litellm.exceptions import ContentPolicyViolationError
+except ImportError:  # pragma: no cover
+
+    class ContentPolicyViolationError(Exception):  # type: ignore[misc, no-redef]
+        """Fallback if litellm is not installed."""
+
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+LLM_POLICY_BLOCKED_TEXT = "[blocked]"
+LLM_STEP_FAILED_TEXT = "Sorry, this step could not be completed. Please try again in a moment."
+
+
+def assistant_text_part(text: str) -> dict:
+    """Single assistant message part for DB / state assembly."""
+    return {"type": "text", "text": text, "state": "done"}
+
+
+LLMOutcome = Literal["ok", "policy", "other"]
+
+
+async def safe_llm_ainvoke(
+    llm: object,
+    messages: list,
+    *,
+    context: str,
+) -> tuple[AIMessage | None, LLMOutcome]:
+    """Call ``llm.ainvoke(messages)``; return ``(message, outcome)`` without raising."""
+    try:
+        msg: AIMessage = await llm.ainvoke(messages)  # type: ignore[union-attr]
+        return msg, "ok"
+    except ContentPolicyViolationError as exc:
+        logger.warning("[%s] LLM blocked by content policy: %s", context, exc)
+        return None, "policy"
+    except Exception as exc:
+        logger.warning(
+            "[%s] LLM call failed: %s",
+            context,
+            exc,
+            exc_info=logger.isEnabledFor(logging.DEBUG),
+        )
+        return None, "other"

--- a/backend/app/ai/graph/memory.py
+++ b/backend/app/ai/graph/memory.py
@@ -23,6 +23,15 @@ TOKEN_BUDGETS: dict[str, int] = {
     "research": 32_000,  # planner benefits from long history for data continuity
     "narrator": 16_000,  # writer needs research packet + enough recent history
     "direct": 8_000,  # direct chat covers typical conversational context
+    "explain": 16_000,  # metadata calls are cheaper but benefit from history for follow-ups
+    "clarifier": 2_000,  # only needs last 2 turns to formulate one question
+    "suggester": 4_000,  # only needs last 3 turns + off-scope query context
+    "summarizer": 8_000,  # summarizer compresses history; moderate budget
+    "scout": 8_000,  # scout checks data availability before full research
+    "planner": 8_000,  # planner decomposes queries using scout findings
+    "recovery": 16_000,  # recovery retries failed research; needs full context
+    "followup": 4_000,  # followup generates questions from recent context only
+    "transformer": 4_000,  # only needs the current query to decide DATA_GROUNDABLE vs DEFINITIONAL
 }
 _DEFAULT_BUDGET = 16_000
 

--- a/backend/app/ai/graph/memory.py
+++ b/backend/app/ai/graph/memory.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from langchain_core.messages import BaseMessage, trim_messages
 
+from .message_utils import _sanitize_tool_sequences
+
 logger = logging.getLogger(__name__)
 
 # ── Per-node token budgets (input tokens only, excluding system + output) ──────
@@ -73,7 +75,10 @@ def trim_for_node(
                 trimmed_count,
                 budget,
             )
-        return trimmed
+        # trim_messages(strategy="last") can cut a tool-call sequence mid-interaction
+        # (dropping the AIMessage that issued the tool call while keeping the ToolMessage
+        # response, or vice-versa).  Sanitize to avoid Azure/OpenAI 400 errors.
+        return _sanitize_tool_sequences(trimmed)
     except Exception as exc:
         logger.warning(
             "[memory] trim_messages failed for node=%s: %s — returning full history",

--- a/backend/app/ai/graph/memory.py
+++ b/backend/app/ai/graph/memory.py
@@ -24,7 +24,7 @@ TOKEN_BUDGETS: dict[str, int] = {
     "narrator": 16_000,  # writer needs research packet + enough recent history
     "direct": 8_000,  # direct chat covers typical conversational context
     "explain": 16_000,  # metadata calls are cheaper but benefit from history for follow-ups
-    "clarifier": 2_000,  # only needs last 2 turns to formulate one question
+    "clarifier": 8_000,  # needs enough history to see established context (country, topic)
     "suggester": 4_000,  # only needs last 3 turns + off-scope query context
     "summarizer": 8_000,  # summarizer compresses history; moderate budget
     "scout": 8_000,  # scout checks data availability before full research

--- a/backend/app/ai/graph/message_utils.py
+++ b/backend/app/ai/graph/message_utils.py
@@ -28,6 +28,10 @@ def openai_to_langchain(openai_messages: list[dict[str, Any]]) -> list[BaseMessa
     - assistant messages (plain text or with tool_calls)
     - tool messages (tool results)
     - system messages (passed through as SystemMessage)
+
+    The result is sanitized: orphaned ToolMessages and AIMessages with tool_calls
+    whose responses were cut off (e.g. due to history slicing) are removed so that
+    Azure / OpenAI never receive an invalid message sequence.
     """
     lc_messages: list[BaseMessage] = []
 
@@ -72,7 +76,69 @@ def openai_to_langchain(openai_messages: list[dict[str, Any]]) -> list[BaseMessa
         else:
             logger.debug("openai_to_langchain: skipping unknown role=%s", role)
 
-    return lc_messages
+    return _sanitize_tool_sequences(lc_messages)
+
+
+def _sanitize_tool_sequences(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Remove incomplete tool-call sequences from a message list.
+
+    When conversation history is sliced (e.g. "last 6 messages"), a tool
+    interaction can be cut mid-sequence, producing either:
+      - A ToolMessage with no preceding AIMessage that has matching tool_calls
+        (the AIMessage fell outside the slice window)
+      - An AIMessage with tool_calls whose ToolMessage responses were not included
+        (the ToolMessages fell outside the slice window)
+
+    Azure and OpenAI both reject such sequences with a 400 error.  This function
+    removes the offending messages so the LLM receives a valid sequence.
+
+    Algorithm (3 passes):
+      1. Collect all ToolMessage IDs present in the list.
+      2. Collect "valid" tool_call_ids — only those belonging to an AIMessage that
+         is itself present AND whose full response set is also present.
+         (An AIMessage whose originating pair is cut off is never validated.)
+      3. Keep only messages that belong to a validated complete interaction,
+         or are plain messages with no tool involvement.
+    """
+    # Pass 1: which tool_call_ids have a ToolMessage response in this list?
+    ids_with_response: set[str] = {
+        msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage) and msg.tool_call_id
+    }
+
+    # Pass 2: which tool_call_ids come from a *present* AIMessage with a *complete*
+    # response set?  Both conditions must hold — the AIMessage must be in the list
+    # AND all its expected ToolMessage responses must also be in the list.
+    valid_ids: set[str] = set()
+    for msg in messages:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            ids = {tc.get("id", "") for tc in msg.tool_calls if tc.get("id")}
+            if ids and ids.issubset(ids_with_response):
+                valid_ids.update(ids)
+
+    # Pass 3: filter.
+    result: list[BaseMessage] = []
+    for msg in messages:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            ids = {tc.get("id", "") for tc in msg.tool_calls if tc.get("id")}
+            if ids and ids.issubset(valid_ids):
+                result.append(msg)
+            else:
+                logger.debug(
+                    "_sanitize_tool_sequences: dropping AIMessage with incomplete tool_calls ids=%s",
+                    ids - valid_ids,
+                )
+        elif isinstance(msg, ToolMessage):
+            if msg.tool_call_id in valid_ids:
+                result.append(msg)
+            else:
+                logger.debug(
+                    "_sanitize_tool_sequences: dropping orphaned ToolMessage tool_call_id=%s",
+                    msg.tool_call_id,
+                )
+        else:
+            result.append(msg)
+
+    return result
 
 
 def _extract_text(content: Any) -> str:

--- a/backend/app/ai/graph/node_utils.py
+++ b/backend/app/ai/graph/node_utils.py
@@ -1,0 +1,103 @@
+"""Shared utilities for LangGraph pipeline nodes.
+
+Provides a reusable ReAct-style tool call loop used by both the research node
+(full data retrieval) and the explain node (metadata-only retrieval).
+"""
+
+import logging
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+
+from app.ai.observability.token_usage import append_llm_usage_fallback
+
+from .graph_tool_notify import notify_tool_end, notify_tool_start
+
+logger = logging.getLogger(__name__)
+
+
+async def run_tool_loop(
+    *,
+    llm: Any,
+    messages: list[BaseMessage],
+    tool_map: dict[str, Any],
+    max_iterations: int,
+    state: dict,
+    graph_node: str,
+) -> tuple[str, dict | None]:
+    """Run a ReAct-style tool call loop until the LLM stops requesting tools.
+
+    Args:
+        llm:            LangChain LLM already bound with tools (``llm.bind_tools(...)``).
+        messages:       Initial message list (system + history). Modified in-place.
+        tool_map:       Dict mapping tool name → LangChain tool callable.
+        max_iterations: Maximum number of LLM call rounds (safety cap).
+        state:          Pipeline state dict (used for usage tracking and SSE queue).
+        graph_node:     LangGraph node name (used for SSE tool notifications and logging).
+
+    Returns:
+        (final_content, final_usage):
+          - final_content: the last plain-text LLM response (the research/explain packet)
+          - final_usage:   token usage dict from the last response, or None
+    """
+    final_content: str = ""
+    final_usage: dict | None = None
+
+    for iteration in range(max_iterations):
+        logger.info("[%s] LLM call iteration=%d", graph_node, iteration)
+        response: AIMessage = await llm.ainvoke(messages)
+        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+        messages.append(response)
+        final_content = response.content or ""
+
+        # Capture usage metadata if available
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            final_usage = {
+                "input_tokens": response.usage_metadata.get("input_tokens", 0),
+                "output_tokens": response.usage_metadata.get("output_tokens", 0),
+            }
+
+        if not response.tool_calls:
+            logger.info(
+                "[%s] no more tool calls after %d iterations — done",
+                graph_node,
+                iteration + 1,
+            )
+            break
+
+        # Execute each tool call and feed results back
+        for tc in response.tool_calls:
+            tool_name: str = tc["name"]
+            tool_args: dict = tc.get("args", {})
+            tool_call_id: str = tc.get("id", tool_name)
+
+            logger.info("[%s] calling tool=%s", graph_node, tool_name)
+            tool = tool_map.get(tool_name)
+            await notify_tool_start(
+                state,
+                graph_node=graph_node,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_input=tool_args,
+            )
+            if tool is None:
+                tool_result = f"Tool '{tool_name}' not available."
+                logger.warning("[%s] unknown tool=%s", graph_node, tool_name)
+            else:
+                try:
+                    tool_result = await tool.ainvoke(tool_args)
+                except Exception as exc:
+                    tool_result = f"Tool '{tool_name}' error: {exc}"
+                    logger.error("[%s] tool=%s error: %s", graph_node, tool_name, exc)
+            await notify_tool_end(
+                state,
+                graph_node=graph_node,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                output=tool_result,
+            )
+            messages.append(ToolMessage(content=str(tool_result), tool_call_id=tool_call_id))
+    else:
+        logger.warning("[%s] reached max_iterations=%d", graph_node, max_iterations)
+
+    return final_content, final_usage

--- a/backend/app/ai/graph/node_utils.py
+++ b/backend/app/ai/graph/node_utils.py
@@ -25,24 +25,30 @@ async def run_tool_loop(
     max_iterations: int,
     state: dict,
     graph_node: str,
-) -> tuple[str, dict | None]:
+    collect_tool_results: bool = False,
+) -> tuple[str, dict | None, list[dict]]:
     """Run a ReAct-style tool call loop until the LLM stops requesting tools.
 
     Args:
-        llm:            LangChain LLM already bound with tools (``llm.bind_tools(...)``).
-        messages:       Initial message list (system + history). Modified in-place.
-        tool_map:       Dict mapping tool name → LangChain tool callable.
-        max_iterations: Maximum number of LLM call rounds (safety cap).
-        state:          Pipeline state dict (used for usage tracking and SSE queue).
-        graph_node:     LangGraph node name (used for SSE tool notifications and logging).
+        llm:                  LangChain LLM already bound with tools.
+        messages:             Initial message list (system + history). Modified in-place.
+        tool_map:             Dict mapping tool name → LangChain tool callable.
+        max_iterations:       Maximum number of LLM call rounds (safety cap).
+        state:                Pipeline state dict (usage tracking and SSE queue).
+        graph_node:           LangGraph node name (SSE notifications and logging).
+        collect_tool_results: When True, accumulate raw tool outputs for the caller.
+                              Used by research_node to pass results directly to narrator.
 
     Returns:
-        (final_content, final_usage):
-          - final_content: the last plain-text LLM response (the research/explain packet)
-          - final_usage:   token usage dict from the last response, or None
+        (final_content, final_usage, tool_results):
+          - final_content:  the last plain-text LLM response (routing/metadata packet)
+          - final_usage:    token usage dict from the last response, or None
+          - tool_results:   list of {"tool_name", "tool_args", "output"} dicts
+                            (empty list when collect_tool_results=False)
     """
     final_content: str = ""
     final_usage: dict | None = None
+    tool_results: list[dict] = []
 
     for iteration in range(max_iterations):
         logger.info("[%s] LLM call iteration=%d", graph_node, iteration)
@@ -104,7 +110,16 @@ async def run_tool_loop(
                 output=tool_result,
             )
             messages.append(ToolMessage(content=str(tool_result), tool_call_id=tool_call_id))
+
+            if collect_tool_results:
+                tool_results.append(
+                    {
+                        "tool_name": tool_name,
+                        "tool_args": tool_args,
+                        "output": tool_result,
+                    }
+                )
     else:
         logger.warning("[%s] reached max_iterations=%d", graph_node, max_iterations)
 
-    return final_content, final_usage
+    return final_content, final_usage, tool_results

--- a/backend/app/ai/graph/node_utils.py
+++ b/backend/app/ai/graph/node_utils.py
@@ -59,16 +59,26 @@ async def run_tool_loop(
             iteration=iteration,
         )
         response: AIMessage = await llm.ainvoke(messages)
-        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node=graph_node)
         messages.append(response)
         final_content = response.content or ""
 
-        # Capture usage metadata if available
+        # Capture full usage metadata if available
         if hasattr(response, "usage_metadata") and response.usage_metadata:
-            final_usage = {
-                "input_tokens": response.usage_metadata.get("input_tokens", 0),
-                "output_tokens": response.usage_metadata.get("output_tokens", 0),
-            }
+            um = response.usage_metadata
+            final_usage = (
+                dict(um)
+                if isinstance(um, dict)
+                else um.model_dump(exclude_none=True)
+                if hasattr(um, "model_dump")
+                else {
+                    "input_tokens": getattr(um, "input_tokens", 0) or 0,
+                    "output_tokens": getattr(um, "output_tokens", 0) or 0,
+                    "total_tokens": getattr(um, "total_tokens", 0) or 0,
+                    "cache_read_input_tokens": getattr(um, "cache_read_input_tokens", 0) or 0,
+                    "reasoning_tokens": getattr(um, "reasoning_tokens", 0) or 0,
+                }
+            )
 
         if not response.tool_calls:
             logger.info(

--- a/backend/app/ai/graph/node_utils.py
+++ b/backend/app/ai/graph/node_utils.py
@@ -11,6 +11,7 @@ from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 
+from .graph_debug_log import log_llm_messages_preview
 from .graph_tool_notify import notify_tool_end, notify_tool_start
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,12 @@ async def run_tool_loop(
 
     for iteration in range(max_iterations):
         logger.info("[%s] LLM call iteration=%d", graph_node, iteration)
+        log_llm_messages_preview(
+            message_id=str(state.get("message_id", "")),
+            graph_node=graph_node,
+            messages=messages,
+            iteration=iteration,
+        )
         response: AIMessage = await llm.ainvoke(messages)
         append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
         messages.append(response)

--- a/backend/app/ai/graph/nodes/clarifier.py
+++ b/backend/app/ai/graph/nodes/clarifier.py
@@ -68,7 +68,7 @@ async def clarifier_node(state: ChatPipelineState) -> dict:
 
     logger.info("[clarifier_node] asking about missing_slots=%s", missing_slots)
     response: AIMessage = await llm.ainvoke(messages)
-    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="clarifier")
 
     final_content: str = (response.content or "").strip()
     final_usage: dict | None = None

--- a/backend/app/ai/graph/nodes/clarifier.py
+++ b/backend/app/ai/graph/nodes/clarifier.py
@@ -1,0 +1,81 @@
+"""Clarifier node: asks one focused question to resolve a missing query slot.
+
+No tools — single LLM call.  The clarifying question is returned as a visible
+text response.  The user's reply re-enters the pipeline at the router on the
+next turn (no in-graph loopback needed).
+
+Token budget is small (2K) since the clarifier only needs the last 2 turns + context.
+"""
+
+import logging
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from app.ai.observability.token_usage import append_llm_usage_fallback
+from app.ai.prompts import get_clarifier_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+
+async def clarifier_node(state: ChatPipelineState) -> dict:
+    """Ask the user one targeted question to resolve the missing slot.
+
+    Injects ``missing_slots`` and ``routing_reasoning`` from the router into
+    the conversation context so the LLM knows exactly which slot is absent.
+
+    ``streaming=True`` ensures token-level events flow through the SSE bridge
+    as ``langgraph_node="clarifier"`` → plain text-delta (visible to the user).
+
+    Returns state updates for ``clarification_question``, ``assistant_parts``,
+    and ``final_usage``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    missing_slots: list[str] = state.get("missing_slots", [])
+    routing_reasoning: str = state.get("routing_reasoning", "")
+    # query_text: str = state.get("query_text", "")
+
+    llm = get_chat_llm(model_type, streaming=True)
+    language: str = state.get("detected_language", "") or ""
+    system_prompt: str = get_clarifier_system_prompt(language=language)
+
+    # Use limited history (last 4 messages) — clarifier only needs recent context
+    history = openai_to_langchain(state.get("openai_messages", []))
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="clarifier",
+    )
+
+    # Inject routing context as a hidden system hint so the LLM knows what's missing
+    context_parts = []
+    if missing_slots:
+        context_parts.append(f"Missing slots: {', '.join(missing_slots)}")
+    if routing_reasoning:
+        context_parts.append(f"Router reasoning: {routing_reasoning}")
+    if context_parts:
+        messages.append(HumanMessage(content="[CONTEXT] " + " | ".join(context_parts)))
+
+    logger.info("[clarifier_node] asking about missing_slots=%s", missing_slots)
+    response: AIMessage = await llm.ainvoke(messages)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+
+    final_content: str = response.content or ""
+    final_usage: dict | None = None
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        final_usage = dict(response.usage_metadata)
+
+    logger.info("[clarifier_node] clarification_question length=%d", len(final_content))
+
+    assistant_part = {"type": "text", "text": final_content, "state": "done"}
+    existing_parts: list[dict] = state.get("assistant_parts", [])
+
+    return {
+        "clarification_question": final_content,
+        "assistant_parts": existing_parts + [assistant_part],
+        "final_usage": final_usage,
+    }

--- a/backend/app/ai/graph/nodes/clarifier.py
+++ b/backend/app/ai/graph/nodes/clarifier.py
@@ -44,8 +44,14 @@ async def clarifier_node(state: ChatPipelineState) -> dict:
     language: str = state.get("detected_language", "") or ""
     system_prompt: str = get_clarifier_system_prompt(language=language)
 
-    # Use limited history (last 4 messages) — clarifier only needs recent context
     history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Prepend session summary so the clarifier has full context even when
+    # conversation history was truncated (e.g. country established 10+ turns ago).
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[CONVERSATION SUMMARY]\n{session_summary}")] + history
+
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,
         node="clarifier",
@@ -64,10 +70,21 @@ async def clarifier_node(state: ChatPipelineState) -> dict:
     response: AIMessage = await llm.ainvoke(messages)
     append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
 
-    final_content: str = response.content or ""
+    final_content: str = (response.content or "").strip()
     final_usage: dict | None = None
     if hasattr(response, "usage_metadata") and response.usage_metadata:
         final_usage = dict(response.usage_metadata)
+
+    # If the LLM determined all slots are already filled from context, it returns
+    # "[PROCEED]" — we swallow this and emit nothing to the user (the router will
+    # reclassify on the next turn with the full context now visible).
+    if final_content.strip().upper() == "[PROCEED]":
+        logger.info("[clarifier_node] all slots filled from context — emitting nothing")
+        return {
+            "clarification_question": "",
+            "assistant_parts": state.get("assistant_parts", []),
+            "final_usage": final_usage,
+        }
 
     logger.info("[clarifier_node] clarification_question length=%d", len(final_content))
 

--- a/backend/app/ai/graph/nodes/direct.py
+++ b/backend/app/ai/graph/nodes/direct.py
@@ -40,7 +40,8 @@ async def direct_node(state: ChatPipelineState) -> dict:
     local_tools: list = state.get("tool_set", {}).get("local", {}).get("langchain_tools", [])
 
     llm = get_chat_llm(model_type, streaming=True).bind_tools(local_tools)
-    system_prompt: str = get_direct_system_prompt()
+    language: str = state.get("detected_language", "") or ""
+    system_prompt: str = get_direct_system_prompt(language=language)
 
     history = openai_to_langchain(state.get("openai_messages", []))
     messages: list[BaseMessage] = trim_for_node(

--- a/backend/app/ai/graph/nodes/direct.py
+++ b/backend/app/ai/graph/nodes/direct.py
@@ -56,7 +56,7 @@ async def direct_node(state: ChatPipelineState) -> dict:
     for iteration in range(MAX_TOOL_ITERATIONS):
         logger.info("[direct_node] LLM call iteration=%d", iteration)
         response: AIMessage = await llm.ainvoke(messages)
-        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="direct")
         messages.append(response)
         final_content = response.content or ""
 

--- a/backend/app/ai/graph/nodes/explain.py
+++ b/backend/app/ai/graph/nodes/explain.py
@@ -1,0 +1,80 @@
+"""Explain node: answers definitional and methodology questions using metadata tools.
+
+Tools available: a subset of data-retrieval tools — search, metadata, and list only.
+No data-row retrieval (data360_get_data, data360_get_disaggregation, etc.) and no viz tools.
+
+The node produces a RESEARCH PACKET in the same format as research_node so the
+narrator can consume it without modification.  Token-budget trimming uses the
+"explain" budget which is lower than research (metadata calls are cheap).
+"""
+
+import logging
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+from app.ai.prompts import get_explain_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..node_utils import run_tool_loop
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+# Tools the explain node is allowed to call (metadata-only subset)
+EXPLAIN_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "data360_search_indicators",
+        "data360_get_metadata",
+        "data360_list_indicators",
+    }
+)
+
+MAX_TOOL_ITERATIONS = 5  # metadata calls are cheap; rarely need more than 2 rounds
+
+
+async def explain_node(state: ChatPipelineState) -> dict:
+    """Answer definitional/methodology questions and return a metadata research packet.
+
+    Runs a lightweight ReAct tool loop restricted to metadata tools (no data rows,
+    no viz).  The resulting packet is handed to the narrator for formatting.
+
+    The LLM uses ``streaming=True`` so ``graph.astream_events()`` emits token-level
+    events tagged with ``langgraph_node="explain"`` — the SSE bridge maps these to
+    the data-thinking envelope (hidden in the collapsible panel, same as research).
+
+    Returns state updates for ``research_packet``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    all_data_tools: list = state.get("tool_set", {}).get("mcp_data", {}).get("langchain_tools", [])
+
+    # Filter to metadata-only tools
+    explain_tools = [t for t in all_data_tools if t.name in EXPLAIN_TOOL_NAMES]
+    if not explain_tools:
+        logger.warning("[explain_node] no explain tools available — falling back to empty packet")
+        return {"research_packet": "No metadata tools available."}
+
+    llm = get_chat_llm(model_type, streaming=True).bind_tools(explain_tools)
+    language: str = state.get("detected_language", "") or ""
+    system_prompt: str = get_explain_system_prompt(language=language)
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="explain",
+    )
+
+    tool_map = {t.name: t for t in explain_tools}
+    final_content, _ = await run_tool_loop(
+        llm=llm,
+        messages=messages,
+        tool_map=tool_map,
+        max_iterations=MAX_TOOL_ITERATIONS,
+        state=state,
+        graph_node="explain",
+    )
+
+    logger.info("[explain_node] research_packet length=%d", len(final_content))
+    return {"research_packet": final_content}

--- a/backend/app/ai/graph/nodes/explain.py
+++ b/backend/app/ai/graph/nodes/explain.py
@@ -10,7 +10,7 @@ narrator can consume it without modification.  Token-budget trimming uses the
 
 import logging
 
-from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from app.ai.prompts import get_explain_system_prompt
 from app.config import ModelType
@@ -61,19 +61,27 @@ async def explain_node(state: ChatPipelineState) -> dict:
     system_prompt: str = get_explain_system_prompt(language=language)
 
     history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Inject session summary so the agent retains context across long conversations.
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[CONVERSATION SUMMARY]\n{session_summary}")] + history
+
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,
         node="explain",
     )
 
     tool_map = {t.name: t for t in explain_tools}
-    final_content, _ = await run_tool_loop(
+    final_content, _, _ = await run_tool_loop(
         llm=llm,
         messages=messages,
         tool_map=tool_map,
         max_iterations=MAX_TOOL_ITERATIONS,
         state=state,
         graph_node="explain",
+        # explain outputs metadata prose, not raw data rows — no tool result passthrough needed
+        collect_tool_results=False,
     )
 
     logger.info("[explain_node] research_packet length=%d", len(final_content))

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -9,13 +9,19 @@ Returns ``{"followup_questions": list, "assistant_parts": updated_list}``.
 import logging
 import re
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_followup_system_prompt
 from app.config import ModelType
 
 from ..llm_factory import get_chat_llm
+from ..llm_invoke import (
+    LLM_POLICY_BLOCKED_TEXT,
+    LLM_STEP_FAILED_TEXT,
+    assistant_text_part,
+    safe_llm_ainvoke,
+)
 from ..memory import trim_for_node
 from ..message_utils import openai_to_langchain
 from ..state import ChatPipelineState
@@ -77,7 +83,25 @@ async def followup_node(state: ChatPipelineState) -> dict:
     )
 
     logger.info("[followup_node] generating follow-up questions")
-    response: AIMessage = await llm.ainvoke(messages)
+    response, outcome = await safe_llm_ainvoke(llm, messages, context="followup")
+    existing_parts: list[dict] = state.get("assistant_parts", [])
+
+    if outcome == "policy":
+        return {
+            "followup_questions": [],
+            "assistant_parts": existing_parts + [assistant_text_part(LLM_POLICY_BLOCKED_TEXT)],
+            "final_usage": None,
+            "content_policy_blocked": True,
+        }
+
+    if outcome != "ok":
+        return {
+            "followup_questions": [],
+            "assistant_parts": existing_parts + [assistant_text_part(LLM_STEP_FAILED_TEXT)],
+            "final_usage": None,
+        }
+
+    assert response is not None
     append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="followup")
 
     final_content: str = response.content or ""

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -1,0 +1,102 @@
+"""Follow-up node: generates 2-3 targeted follow-up questions after the main answer.
+
+Non-streaming (streaming=False).  Appends to assistant_parts with a special
+separator so the questions appear naturally after the narrator's answer.
+
+Returns ``{"followup_questions": list, "assistant_parts": updated_list}``.
+"""
+
+import logging
+import re
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from app.ai.observability.token_usage import append_llm_usage_fallback
+from app.ai.prompts import get_followup_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+# How many recent messages to pass to the follow-up LLM (keeps it lightweight)
+_RECENT_HISTORY_LIMIT = 6
+
+
+def _extract_questions(text: str) -> list[str]:
+    """Extract numbered list items from the follow-up response for telemetry.
+
+    Matches lines starting with a number followed by . or ) and optional whitespace.
+    """
+    lines = text.splitlines()
+    questions: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if re.match(r"^\d+[.)]\s+.+", stripped):
+            question = re.sub(r"^\d+[.)\s]+", "", stripped).strip()
+            if question:
+                questions.append(question)
+    return questions
+
+
+async def followup_node(state: ChatPipelineState) -> dict:
+    """Generate 2-3 follow-up questions and append them to assistant_parts.
+
+    Uses only the most recent conversation turns (last 6 messages) plus the
+    research_packet (truncated to 1 000 chars) to keep the call cheap.
+
+    ``streaming=False`` — this node does not emit token-level SSE events.
+
+    Returns state updates for ``followup_questions``, ``assistant_parts``, and
+    ``final_usage``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    language: str = state.get("detected_language", "") or ""
+
+    llm = get_chat_llm(model_type, streaming=False)
+    system_prompt: str = get_followup_system_prompt(language=language)
+
+    # Use only the last few messages to keep context small and focused
+    openai_messages: list[dict] = state.get("openai_messages", [])
+    recent = openai_messages[-_RECENT_HISTORY_LIMIT:]
+    history = openai_to_langchain(recent)
+
+    # Optionally inject a truncated research packet for topic grounding
+    research_packet: str = state.get("research_packet", "") or ""
+    if research_packet:
+        history = history + [
+            HumanMessage(content="[RESEARCH FINDINGS SUMMARY]\n" + research_packet[:1000])
+        ]
+
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="followup",
+    )
+
+    logger.info("[followup_node] generating follow-up questions")
+    response: AIMessage = await llm.ainvoke(messages)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+
+    final_content: str = response.content or ""
+    final_usage: dict | None = None
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        final_usage = dict(response.usage_metadata)
+
+    questions = _extract_questions(final_content)
+    logger.info(
+        "[followup_node] response length=%d questions_count=%d",
+        len(final_content),
+        len(questions),
+    )
+
+    assistant_part = {"type": "text", "text": final_content, "state": "done"}
+    existing_parts: list[dict] = state.get("assistant_parts", [])
+
+    return {
+        "followup_questions": questions,
+        "assistant_parts": existing_parts + [assistant_part],
+        "final_usage": final_usage,
+    }

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -78,7 +78,7 @@ async def followup_node(state: ChatPipelineState) -> dict:
 
     logger.info("[followup_node] generating follow-up questions")
     response: AIMessage = await llm.ainvoke(messages)
-    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="followup")
 
     final_content: str = response.content or ""
     final_usage: dict | None = None

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -12,6 +12,7 @@ Token-budget trimming is applied to the conversation history injected as context
 and the SSE bridge maps them to plain text-delta events (visible to the user).
 """
 
+import json
 import logging
 from typing import Any
 
@@ -65,20 +66,74 @@ async def narrator_node(state: ChatPipelineState) -> dict:
     # Build message list: trimmed history only (research packet goes into system message)
     history = openai_to_langchain(state.get("openai_messages", []))
     research_packet: str = state.get("research_packet", "")
+    tool_results: list[dict] = state.get("research_tool_results") or []
 
-    if research_packet:
-        # Embed research findings in the system message (trusted context) rather than
-        # as a HumanMessage — HumanMessage injection of structured XML-like content
-        # triggers Azure Prompt Shields' indirect-injection detection.
-        system_prompt = (
-            system_prompt
-            + "\n\n"
-            + "─" * 60
-            + "\nRESEARCH FINDINGS (retrieved by the Research agent):\n\n"
-            + research_packet
-            + "\n"
-            + "─" * 60
-        )
+    if research_packet or tool_results:
+        # Build the research context block that is prepended to the system prompt.
+        # Placed in the system message (not a HumanMessage) to avoid Azure Prompt Shields.
+        #
+        # Structure:
+        #   1. RAW TOOL RESULTS — the actual data values with claim IDs, as returned
+        #      by the MCP tools. Narrator reads numbers directly from here; no
+        #      intermediate transcription through an extra LLM pass.
+        #   2. RESEARCH AGENT ROUTING PACKET — PATH classification, indicator
+        #      selection rationale, GAPS, EVIDENCE NOTES, VIZ params, API URL.
+        #      This is the research agent's intelligence layer.
+        context_parts: list[str] = []
+
+        if tool_results:
+            # Emit only data-bearing tools (get_data, get_metadata) — skip
+            # search/codelist calls which are lookup scaffolding, not content.
+            data_tools = frozenset(
+                {
+                    "data360_get_data",
+                    "data360_get_metadata",
+                    "data360_list_indicators",
+                }
+            )
+            data_outputs = [r for r in tool_results if r.get("tool_name") in data_tools]
+            if data_outputs:
+                tool_block_lines = [
+                    "─" * 60,
+                    "RAW TOOL RESULTS",
+                    "These are the exact outputs returned by the MCP data tools.",
+                    "All numeric values and claim IDs come from here — use them directly.",
+                    "─" * 60,
+                    "",
+                ]
+                for i, r in enumerate(data_outputs, 1):
+                    tool_block_lines.append(f"[Tool {i}: {r['tool_name']}]")
+                    args_str = ", ".join(f"{k}={v!r}" for k, v in r.get("tool_args", {}).items())
+                    if args_str:
+                        tool_block_lines.append(f"Args: {args_str}")
+                    output = r.get("output", "")
+                    # Pretty-print JSON if the output is structured
+                    if isinstance(output, (dict, list)):
+                        tool_block_lines.append(json.dumps(output, ensure_ascii=False, indent=2))
+                    else:
+                        tool_block_lines.append(str(output))
+                    tool_block_lines.append("")
+                tool_block_lines += [
+                    "─" * 60,
+                    "END OF RAW TOOL RESULTS",
+                    "─" * 60,
+                    "",
+                ]
+                context_parts.append("\n".join(tool_block_lines))
+
+        if research_packet:
+            routing_block = (
+                "─" * 60 + "\n"
+                "RESEARCH AGENT ROUTING PACKET\n"
+                "PATH classification, indicator selection, gaps, and methodology notes.\n"
+                "This IS the research packet referenced in the instructions below.\n"
+                "─" * 60 + "\n\n" + research_packet + "\n\n" + "─" * 60 + "\n"
+                "END OF RESEARCH AGENT ROUTING PACKET — rendering instructions follow.\n"
+                "─" * 60 + "\n\n"
+            )
+            context_parts.append(routing_block)
+
+        system_prompt = "".join(context_parts) + system_prompt
 
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -15,7 +15,7 @@ and the SSE bridge maps them to plain text-delta events (visible to the user).
 import logging
 from typing import Any
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_system_prompt
@@ -36,9 +36,9 @@ MAX_TOOL_ITERATIONS = 5  # narrator mainly calls viz tools; few iterations neede
 async def narrator_node(state: ChatPipelineState) -> dict:
     """Generate the user-facing response from the research packet.
 
-    The research_packet is injected into the conversation as a HumanMessage
-    addendum so the LLM sees both the user's original question and the planner's
-    findings.  The narrator may call viz tools to generate chart URLs.
+    The research_packet is embedded in the system message (trusted context) so
+    it is not scanned by Azure Prompt Shields as indirect injection.
+    The narrator may call viz tools to generate chart URLs.
 
     ``streaming=True`` ensures ``graph.astream_events()`` receives token-level
     events tagged with ``langgraph_node="narrator"`` for the SSE bridge.
@@ -62,16 +62,23 @@ async def narrator_node(state: ChatPipelineState) -> dict:
     )
     llm = get_chat_llm(model_type, streaming=True).bind_tools(narrator_tools)
 
-    # Build message list: trimmed history + research packet as context
+    # Build message list: trimmed history only (research packet goes into system message)
     history = openai_to_langchain(state.get("openai_messages", []))
     research_packet: str = state.get("research_packet", "")
 
     if research_packet:
-        # Inject research packet as an addendum so the writer sees planner findings
-        packet_msg = HumanMessage(
-            content=("[RESEARCH FINDINGS]\n\n" + research_packet + "\n\n[END OF RESEARCH FINDINGS]")
+        # Embed research findings in the system message (trusted context) rather than
+        # as a HumanMessage — HumanMessage injection of structured XML-like content
+        # triggers Azure Prompt Shields' indirect-injection detection.
+        system_prompt = (
+            system_prompt
+            + "\n\n"
+            + "─" * 60
+            + "\nRESEARCH FINDINGS (retrieved by the Research agent):\n\n"
+            + research_packet
+            + "\n"
+            + "─" * 60
         )
-        history = history + [packet_msg]
 
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -153,7 +153,7 @@ async def narrator_node(state: ChatPipelineState) -> dict:
             iteration=iteration,
         )
         response: AIMessage = await llm.ainvoke(messages)
-        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="narrator")
         messages.append(response)
         final_content = response.content or ""
 

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -21,6 +21,7 @@ from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_system_prompt
 from app.config import ModelType
 
+from ..graph_debug_log import log_llm_messages_preview
 from ..graph_tool_notify import notify_tool_end, notify_tool_start
 from ..llm_factory import get_chat_llm
 from ..memory import trim_for_node
@@ -68,12 +69,7 @@ async def narrator_node(state: ChatPipelineState) -> dict:
     if research_packet:
         # Inject research packet as an addendum so the writer sees planner findings
         packet_msg = HumanMessage(
-            content=(
-                "[RESEARCH PACKET — use this as your source of truth]\n\n"
-                + research_packet
-                + "\n\n[END OF RESEARCH PACKET]\n\n"
-                "Now write your response to the user based on the research packet above."
-            )
+            content=("[RESEARCH FINDINGS]\n\n" + research_packet + "\n\n[END OF RESEARCH FINDINGS]")
         )
         history = history + [packet_msg]
 
@@ -88,6 +84,12 @@ async def narrator_node(state: ChatPipelineState) -> dict:
 
     for iteration in range(MAX_TOOL_ITERATIONS):
         logger.info("[narrator_node] LLM call iteration=%d", iteration)
+        log_llm_messages_preview(
+            message_id=str(state.get("message_id", "")),
+            graph_node="narrator",
+            messages=messages,
+            iteration=iteration,
+        )
         response: AIMessage = await llm.ainvoke(messages)
         append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
         messages.append(response)

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -55,7 +55,10 @@ async def narrator_node(state: ChatPipelineState) -> dict:
     except ValueError:
         mt = ModelType.CHAT_MODEL
 
-    system_prompt: str = get_system_prompt(selected_chat_model=mt, request_hints=None)
+    language: str = state.get("detected_language", "") or ""
+    system_prompt: str = get_system_prompt(
+        selected_chat_model=mt, request_hints=None, language=language
+    )
     llm = get_chat_llm(model_type, streaming=True).bind_tools(narrator_tools)
 
     # Build message list: trimmed history + research packet as context

--- a/backend/app/ai/graph/nodes/planner.py
+++ b/backend/app/ai/graph/nodes/planner.py
@@ -105,4 +105,12 @@ async def planner_node(state: ChatPipelineState) -> dict:
         len(translated_queries),
     )
 
-    return {"query_plan": query_plan}
+    existing_trace: list = state.get("agent_trace_parts") or []
+    trace_data: dict = {"query_plan": query_plan}
+    if translated_queries:
+        trace_data["translated_queries"] = translated_queries
+    return {
+        "query_plan": query_plan,
+        "agent_trace_parts": existing_trace
+        + [{"type": "agent-trace", "node": "planner", "data": trace_data, "state": "done"}],
+    }

--- a/backend/app/ai/graph/nodes/planner.py
+++ b/backend/app/ai/graph/nodes/planner.py
@@ -1,0 +1,108 @@
+"""Planner node: decomposes complex queries into a structured execution plan.
+
+Non-streaming, no tools.  Reads scout_findings injected as context and outputs
+a JSON task list that the research node will use to guide its data retrieval.
+
+Returns ``{"query_plan": list_of_tasks}``.
+"""
+
+import json
+import logging
+import re
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from app.ai.prompts import get_planner_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_plan_response(text: str) -> list[dict]:
+    """Extract the JSON task list from the planner response.
+
+    Looks for a ```json ... ``` fenced block containing a JSON array.
+    Falls back to [] on any parse failure.
+    """
+    match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if match:
+        try:
+            parsed = json.loads(match.group(1))
+            if isinstance(parsed, list):
+                return parsed
+            logger.warning("[planner_node] JSON is not a list — got %s", type(parsed).__name__)
+        except json.JSONDecodeError as exc:
+            logger.warning("[planner_node] JSON parse failed: %s", exc)
+    return []
+
+
+async def planner_node(state: ChatPipelineState) -> dict:
+    """Decompose the query into a structured execution plan.
+
+    Injects scout_findings and (optionally) a session_summary as context, then
+    calls the LLM once (non-streaming, no tools) to produce a JSON task list.
+
+    ``streaming=False`` — this node does not emit token-level SSE events.
+
+    Returns state updates for ``query_plan``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+
+    llm = get_chat_llm(model_type, streaming=False)
+    system_prompt: str = get_planner_system_prompt()
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Prepend session summary if available
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[SESSION SUMMARY]\n{session_summary}")] + history
+
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="planner",
+    )
+
+    # Append scout findings as a HumanMessage so the planner can read them
+    scout_findings: dict = state.get("scout_findings", {}) or {}
+    if scout_findings:
+        scout_msg = HumanMessage(
+            content=("[SCOUT FINDINGS]\n```json\n" + json.dumps(scout_findings, indent=2) + "\n```")
+        )
+        messages = messages + [scout_msg]
+
+    # If the transformer translated an analytical question into specific data queries,
+    # inject them so the planner builds its task list around those queries exactly.
+    translated_queries: list[str] = state.get("translated_queries") or []
+    if translated_queries:
+        tq_lines = "\n".join(f"  {i + 1}. {q}" for i, q in enumerate(translated_queries))
+        messages = messages + [
+            HumanMessage(
+                content=(
+                    "[TRANSLATED DATA QUERIES — from transformer]\n"
+                    "The original question was analytical/diagnostic. These are the specific "
+                    "data queries that will together answer it. Build your plan around these "
+                    "queries exactly, one task per query:\n"
+                    + tq_lines
+                    + "\n\nFrame the final answer as evidence-based: "
+                    "'The data shows X' rather than 'challenges tend to be Y'."
+                )
+            )
+        ]
+
+    response = await llm.ainvoke(messages)
+    final_content: str = response.content or ""
+
+    query_plan = _parse_plan_response(final_content)
+    logger.info(
+        "[planner_node] query_plan tasks=%d (translated_queries=%d)",
+        len(query_plan),
+        len(translated_queries),
+    )
+
+    return {"query_plan": query_plan}

--- a/backend/app/ai/graph/nodes/recovery.py
+++ b/backend/app/ai/graph/nodes/recovery.py
@@ -69,10 +69,7 @@ async def recovery_node(state: ChatPipelineState) -> dict:
     if failed_packet:
         messages = messages + [
             HumanMessage(
-                content=(
-                    "[FAILED RESEARCH PACKET — use this to understand what was tried]\n"
-                    + failed_packet
-                )
+                content=("[FAILED RESEARCH FINDINGS — prior attempt summary]\n" + failed_packet)
             )
         ]
 

--- a/backend/app/ai/graph/nodes/recovery.py
+++ b/backend/app/ai/graph/nodes/recovery.py
@@ -1,0 +1,94 @@
+"""Recovery node: retries failed research using alternative data strategies.
+
+When the initial research returns an empty or no-data packet, this node analyzes
+the failure and attempts alternative approaches (synonym indicators, broader time
+ranges, regional aggregates, different databases).
+
+Streaming=True — tool events appear in the data-thinking panel, same as research.
+Returns ``{"research_packet": updated_packet, "recovery_attempted": True}``.
+"""
+
+import logging
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from app.ai.prompts import get_recovery_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..node_utils import run_tool_loop
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+MAX_TOOL_ITERATIONS = 8  # recovery may need more iterations than a normal research call
+
+
+async def recovery_node(state: ChatPipelineState) -> dict:
+    """Retry data retrieval when the initial research packet indicates no data was found.
+
+    The full MCP data tool set is available — same as the main research node.
+    The failed research_packet (if present) is injected as a HumanMessage so the
+    LLM understands what was already tried.
+
+    ``streaming=True`` ensures ``graph.astream_events()`` emits token-level events
+    tagged with ``langgraph_node="recovery"`` — the SSE bridge maps these to the
+    data-thinking envelope.
+
+    Returns state updates for ``research_packet`` and ``recovery_attempted``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    data_tools: list = state.get("tool_set", {}).get("mcp_data", {}).get("langchain_tools", [])
+
+    if not data_tools:
+        logger.warning("[recovery_node] no data tools available — returning failure packet")
+        return {
+            "research_packet": "Recovery failed: no data tools available.",
+            "recovery_attempted": True,
+        }
+
+    llm = get_chat_llm(model_type, streaming=True).bind_tools(data_tools)
+    system_prompt: str = get_recovery_system_prompt()
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Prepend session summary if available
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[SESSION SUMMARY]\n{session_summary}")] + history
+
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="recovery",
+    )
+
+    # Inject the failed research packet so the LLM knows what was tried
+    failed_packet: str = state.get("research_packet", "") or ""
+    if failed_packet:
+        messages = messages + [
+            HumanMessage(
+                content=(
+                    "[FAILED RESEARCH PACKET — use this to understand what was tried]\n"
+                    + failed_packet
+                )
+            )
+        ]
+
+    tool_map = {t.name: t for t in data_tools}
+    final_content, _ = await run_tool_loop(
+        llm=llm,
+        messages=messages,
+        tool_map=tool_map,
+        max_iterations=MAX_TOOL_ITERATIONS,
+        state=state,
+        graph_node="recovery",
+    )
+
+    logger.info("[recovery_node] recovery_packet length=%d", len(final_content))
+
+    return {
+        "research_packet": final_content,
+        "recovery_attempted": True,
+    }

--- a/backend/app/ai/graph/nodes/research.py
+++ b/backend/app/ai/graph/nodes/research.py
@@ -9,9 +9,10 @@ Token-budget trimming is applied before the loop so the planner never exceeds it
 context limit even in long multi-turn conversations.
 """
 
+import json
 import logging
 
-from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from app.ai.prompts import get_thinking_system_prompt
 from app.config import ModelType
@@ -52,6 +53,39 @@ async def research_node(state: ChatPipelineState) -> dict:
         [SystemMessage(content=system_prompt)] + history,
         node="research",
     )
+
+    # Inject the planner's query plan so research follows it directly rather than
+    # re-deciding what to fetch (prevents clarification loops on broad questions).
+    query_plan: list = state.get("query_plan") or []
+    if query_plan:
+        plan_json = json.dumps(query_plan, indent=2)
+        messages = messages + [
+            HumanMessage(
+                content=(
+                    "[RESEARCH PLAN — from planner]\n"
+                    "Follow this plan exactly. Use the indicator_id and database_id "
+                    "listed for each task — do NOT re-search or ask for clarification:\n"
+                    f"```json\n{plan_json}\n```"
+                )
+            )
+        ]
+        logger.info("[research_node] injected query_plan with %d tasks", len(query_plan))
+
+    # Fallback: if no plan was generated but transformer produced translated queries,
+    # inject those as research targets so the agent knows what to look for.
+    elif translated_queries := (state.get("translated_queries") or []):
+        tq_lines = "\n".join(f"  {i + 1}. {q}" for i, q in enumerate(translated_queries))
+        messages = messages + [
+            HumanMessage(
+                content=(
+                    "[RESEARCH TARGETS — from transformer]\n"
+                    "Search for and retrieve data for each of these specific topics:\n" + tq_lines
+                )
+            )
+        ]
+        logger.info(
+            "[research_node] injected %d translated_queries (no plan)", len(translated_queries)
+        )
 
     tool_map = {t.name: t for t in data_tools}
     final_content, _ = await run_tool_loop(

--- a/backend/app/ai/graph/nodes/research.py
+++ b/backend/app/ai/graph/nodes/research.py
@@ -1,20 +1,18 @@
-"""Research node (Planner): retrieves Data360 data and produces a research packet.
+"""Research Agent node: adaptive data retrieval for all query types.
 
-Tools available: data-retrieval MCP tools only (no viz — that's narrator's job).
-The node runs a ReAct-style tool call loop (via ``run_tool_loop``) until the LLM
-stops requesting tools, then returns the final assistant content as ``research_packet``
-for the narrator.
+Replaces the former transformer → scout → planner → research → recovery chain.
+The agent classifies the query internally (Step 0) and adapts its tool call
+depth to the question complexity — from simple point lookups (2-3 calls) to
+full analytical decompositions (up to 8 calls).
 
-Token-budget trimming is applied before the loop so the planner never exceeds its
-context limit even in long multi-turn conversations.
+Claim tags on every observation value ensure PCN verifiability.
 """
 
-import json
 import logging
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
-from app.ai.prompts import get_thinking_system_prompt
+from app.ai.prompts import get_research_agent_system_prompt
 from app.config import ModelType
 
 from ..llm_factory import get_chat_llm
@@ -25,80 +23,70 @@ from ..state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
 
-MAX_TOOL_ITERATIONS = 15  # safety cap on planner tool call rounds
+MAX_TOOL_ITERATIONS = 10  # hard cap; Step 0 path budgets are enforced by the prompt
 
 
 async def research_node(state: ChatPipelineState) -> dict:
-    """Run the Research Planner and return the research packet.
+    """Run the adaptive Research Agent and return the research packet.
 
-    Executes a ReAct-style tool call loop:
-    1. Call the LLM with data-retrieval tools.
-    2. If the response contains tool calls, execute them and feed results back.
-    3. Repeat until the LLM produces a plain text response (the research packet).
+    Executes a ReAct-style tool call loop. The agent classifies the query
+    in Step 0 (no tool call) and then uses path-appropriate tool budgets.
 
-    The LLM is configured with ``streaming=True`` so that ``graph.astream_events()``
-    in the SSE bridge receives token-level ``on_chat_model_stream`` events tagged
-    with ``langgraph_node="research"`` — which the bridge maps to data-thinking SSE.
+    streaming=True so graph.astream_events() receives token-level events
+    tagged with langgraph_node="research" — the SSE bridge maps these to
+    the data-thinking panel.
 
-    Returns state updates for ``research_packet``.
+    Returns state updates for research_packet.
     """
     model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
     data_tools: list = state.get("tool_set", {}).get("mcp_data", {}).get("langchain_tools", [])
 
+    if not data_tools:
+        logger.warning(
+            "[research_node] no MCP data tools available — "
+            "MCP server may be unreachable. Returning empty packet."
+        )
+        return {
+            "research_packet": (
+                "### NO_DATA:\n"
+                "MCP data tools are currently unavailable (server unreachable or not configured). "
+                "No data could be retrieved for this query."
+            )
+        }
+
     llm = get_chat_llm(model_type, streaming=True).bind_tools(data_tools)
-    system_prompt: str = get_thinking_system_prompt()
+    system_prompt: str = get_research_agent_system_prompt()
 
     history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Inject session summary so the agent has full context even when conversation
+    # history has been trimmed (e.g. country/topic established many turns ago).
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[CONVERSATION SUMMARY]\n{session_summary}")] + history
+
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,
         node="research",
     )
 
-    # Inject the planner's query plan so research follows it directly rather than
-    # re-deciding what to fetch (prevents clarification loops on broad questions).
-    query_plan: list = state.get("query_plan") or []
-    if query_plan:
-        plan_json = json.dumps(query_plan, indent=2)
-        messages = messages + [
-            HumanMessage(
-                content=(
-                    "[RESEARCH PLAN — from planner]\n"
-                    "Use this research plan as your primary directive. Use the indicator_id and database_id "
-                    "listed for each task — do NOT re-search or ask for clarification.\n"
-                    "If the query explicitly requests additional countries or time ranges beyond "
-                    "what's listed in the plan, fetch them using the same indicator_id and database_id "
-                    "before writing the research packet. A partial packet is NEVER acceptable.\n"
-                    f"```json\n{plan_json}\n```"
-                )
-            )
-        ]
-        logger.info("[research_node] injected query_plan with %d tasks", len(query_plan))
-
-    # Fallback: if no plan was generated but transformer produced translated queries,
-    # inject those as research targets so the agent knows what to look for.
-    elif translated_queries := (state.get("translated_queries") or []):
-        tq_lines = "\n".join(f"  {i + 1}. {q}" for i, q in enumerate(translated_queries))
-        messages = messages + [
-            HumanMessage(
-                content=(
-                    "[RESEARCH TARGETS — from transformer]\n"
-                    "Search for and retrieve data for each of these specific topics:\n" + tq_lines
-                )
-            )
-        ]
-        logger.info(
-            "[research_node] injected %d translated_queries (no plan)", len(translated_queries)
-        )
-
     tool_map = {t.name: t for t in data_tools}
-    final_content, _ = await run_tool_loop(
+    final_content, _, tool_results = await run_tool_loop(
         llm=llm,
         messages=messages,
         tool_map=tool_map,
         max_iterations=MAX_TOOL_ITERATIONS,
         state=state,
         graph_node="research",
+        collect_tool_results=True,
     )
 
-    logger.info("[research_node] research_packet length=%d", len(final_content))
-    return {"research_packet": final_content}
+    logger.info(
+        "[research_node] research_packet length=%d tool_results=%d",
+        len(final_content),
+        len(tool_results),
+    )
+    return {
+        "research_packet": final_content,
+        "research_tool_results": tool_results,
+    }

--- a/backend/app/ai/graph/nodes/research.py
+++ b/backend/app/ai/graph/nodes/research.py
@@ -63,8 +63,11 @@ async def research_node(state: ChatPipelineState) -> dict:
             HumanMessage(
                 content=(
                     "[RESEARCH PLAN — from planner]\n"
-                    "Follow this plan exactly. Use the indicator_id and database_id "
-                    "listed for each task — do NOT re-search or ask for clarification:\n"
+                    "Use this research plan as your primary directive. Use the indicator_id and database_id "
+                    "listed for each task — do NOT re-search or ask for clarification.\n"
+                    "If the query explicitly requests additional countries or time ranges beyond "
+                    "what's listed in the plan, fetch them using the same indicator_id and database_id "
+                    "before writing the research packet. A partial packet is NEVER acceptable.\n"
                     f"```json\n{plan_json}\n```"
                 )
             )

--- a/backend/app/ai/graph/nodes/research.py
+++ b/backend/app/ai/graph/nodes/research.py
@@ -1,26 +1,25 @@
 """Research node (Planner): retrieves Data360 data and produces a research packet.
 
 Tools available: data-retrieval MCP tools only (no viz — that's narrator's job).
-The node runs a ReAct-style tool call loop until the LLM stops requesting tools,
-then returns the final assistant content as ``research_packet`` for the narrator.
+The node runs a ReAct-style tool call loop (via ``run_tool_loop``) until the LLM
+stops requesting tools, then returns the final assistant content as ``research_packet``
+for the narrator.
 
-Token-budget trimming is applied before each LLM call so the planner never
-exceeds its context limit even in long multi-turn conversations.
+Token-budget trimming is applied before the loop so the planner never exceeds its
+context limit even in long multi-turn conversations.
 """
 
 import logging
-from typing import Any
 
-from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 
-from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_thinking_system_prompt
 from app.config import ModelType
 
-from ..graph_tool_notify import notify_tool_end, notify_tool_start
 from ..llm_factory import get_chat_llm
 from ..memory import trim_for_node
 from ..message_utils import openai_to_langchain
+from ..node_utils import run_tool_loop
 from ..state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ MAX_TOOL_ITERATIONS = 15  # safety cap on planner tool call rounds
 async def research_node(state: ChatPipelineState) -> dict:
     """Run the Research Planner and return the research packet.
 
-    Executes a multi-step tool call loop:
+    Executes a ReAct-style tool call loop:
     1. Call the LLM with data-retrieval tools.
     2. If the response contains tool calls, execute them and feed results back.
     3. Repeat until the LLM produces a plain text response (the research packet).
@@ -40,7 +39,7 @@ async def research_node(state: ChatPipelineState) -> dict:
     in the SSE bridge receives token-level ``on_chat_model_stream`` events tagged
     with ``langgraph_node="research"`` — which the bridge maps to data-thinking SSE.
 
-    Returns state updates for ``research_packet`` and ``assistant_parts``.
+    Returns state updates for ``research_packet``.
     """
     model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
     data_tools: list = state.get("tool_set", {}).get("mcp_data", {}).get("langchain_tools", [])
@@ -48,64 +47,21 @@ async def research_node(state: ChatPipelineState) -> dict:
     llm = get_chat_llm(model_type, streaming=True).bind_tools(data_tools)
     system_prompt: str = get_thinking_system_prompt()
 
-    # Convert conversation history to LangChain messages and trim
     history = openai_to_langchain(state.get("openai_messages", []))
     messages: list[BaseMessage] = trim_for_node(
         [SystemMessage(content=system_prompt)] + history,
         node="research",
     )
 
-    tool_map: dict[str, Any] = {t.name: t for t in data_tools}
-    final_content: str = ""
-
-    for iteration in range(MAX_TOOL_ITERATIONS):
-        logger.info("[research_node] LLM call iteration=%d", iteration)
-        response: AIMessage = await llm.ainvoke(messages)
-        append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
-        messages.append(response)
-        final_content = response.content or ""
-
-        if not response.tool_calls:
-            logger.info(
-                "[research_node] no more tool calls after %d iterations — done", iteration + 1
-            )
-            break
-
-        # Execute each tool call and append results
-        for tc in response.tool_calls:
-            tool_name: str = tc["name"]
-            tool_args: dict = tc.get("args", {})
-            tool_call_id: str = tc.get("id", tool_name)
-
-            logger.info("[research_node] calling tool=%s", tool_name)
-            tool = tool_map.get(tool_name)
-            await notify_tool_start(
-                state,
-                graph_node="research",
-                tool_name=tool_name,
-                tool_call_id=tool_call_id,
-                tool_input=tool_args,
-            )
-            if tool is None:
-                tool_result = f"Tool '{tool_name}' not available."
-                logger.warning("[research_node] unknown tool=%s", tool_name)
-            else:
-                try:
-                    tool_result = await tool.ainvoke(tool_args)
-                except Exception as exc:
-                    tool_result = f"Tool '{tool_name}' error: {exc}"
-                    logger.error("[research_node] tool=%s error: %s", tool_name, exc)
-            await notify_tool_end(
-                state,
-                graph_node="research",
-                tool_name=tool_name,
-                tool_call_id=tool_call_id,
-                output=tool_result,
-            )
-
-            messages.append(ToolMessage(content=str(tool_result), tool_call_id=tool_call_id))
-    else:
-        logger.warning("[research_node] reached MAX_TOOL_ITERATIONS=%d", MAX_TOOL_ITERATIONS)
+    tool_map = {t.name: t for t in data_tools}
+    final_content, _ = await run_tool_loop(
+        llm=llm,
+        messages=messages,
+        tool_map=tool_map,
+        max_iterations=MAX_TOOL_ITERATIONS,
+        state=state,
+        graph_node="research",
+    )
 
     logger.info("[research_node] research_packet length=%d", len(final_content))
     return {"research_packet": final_content}

--- a/backend/app/ai/graph/nodes/router.py
+++ b/backend/app/ai/graph/nodes/router.py
@@ -50,10 +50,12 @@ async def router_node(state: ChatPipelineState) -> dict:
 
     # ── LLM-based intent classification ─────────────────────────────────────
     openai_messages: list[dict] = state.get("openai_messages", [])
+    session_summary: str = state.get("session_summary", "") or ""
     logger.info("[router_node] calling check_intent messages_count=%d", len(openai_messages))
 
     intent, reasoning, router_usage, missing_slots, detected_language = await check_intent(
-        openai_messages
+        openai_messages,
+        session_summary=session_summary,
     )
 
     logger.info(

--- a/backend/app/ai/graph/nodes/router.py
+++ b/backend/app/ai/graph/nodes/router.py
@@ -1,4 +1,4 @@
-"""Router node: classifies intent as RESEARCH or DIRECT.
+"""Router node: classifies intent into RESEARCH, DIRECT, CLARIFY, OUT_OF_SCOPE, or EXPLAIN.
 
 Wraps the existing check_intent() function from app.ai.routing so that
 routing logic is a first-class LangGraph node without duplicating code.
@@ -14,15 +14,19 @@ from ..state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
 
+# All valid intent values — used for forced_intent validation
+_VALID_INTENTS = frozenset(i.value for i in IntentType)
+
 
 async def router_node(state: ChatPipelineState) -> dict:
-    """Determine RESEARCH vs DIRECT intent and return routing state updates.
+    """Classify intent and return routing state updates.
 
     Fast-path: if the user query contains ``@wdr``, forces RESEARCH without
-    an LLM call.  Otherwise delegates to the existing check_intent() which
-    calls the routing model via LiteLLM.
+    an LLM call.  Otherwise delegates to check_intent() which calls the
+    routing model via LiteLLM.
 
-    Returns state updates for ``intent`` and ``routing_reasoning``.
+    Returns state updates for ``intent``, ``routing_reasoning``,
+    ``missing_slots``, and ``routing_confidence``.
     """
     query_text: str = state.get("query_text", "")
 
@@ -32,27 +36,38 @@ async def router_node(state: ChatPipelineState) -> dict:
         return {
             "intent": IntentType.RESEARCH.value,
             "routing_reasoning": "WDR research triggered by @wdr.",
+            "missing_slots": [],
         }
 
     forced = state.get("forced_intent")
-    if forced in (IntentType.RESEARCH.value, IntentType.DIRECT.value):
+    if forced in _VALID_INTENTS:
         logger.info("[router_node] forced_intent=%s (skipping check_intent)", forced)
-        label = "research" if forced == IntentType.RESEARCH.value else "direct"
         return {
             "intent": forced,
-            "routing_reasoning": f"Stream API: {label} path (no router LLM).",
+            "routing_reasoning": f"Stream API: forced {forced.lower()} path (no router LLM).",
+            "missing_slots": [],
         }
 
     # ── LLM-based intent classification ─────────────────────────────────────
     openai_messages: list[dict] = state.get("openai_messages", [])
     logger.info("[router_node] calling check_intent messages_count=%d", len(openai_messages))
 
-    intent, reasoning, router_usage = await check_intent(openai_messages)
+    intent, reasoning, router_usage, missing_slots, detected_language = await check_intent(
+        openai_messages
+    )
 
-    logger.info("[router_node] intent=%s reasoning_len=%d", intent, len(reasoning))
+    logger.info(
+        "[router_node] intent=%s missing_slots=%s language=%s reasoning_len=%d",
+        intent,
+        missing_slots,
+        detected_language,
+        len(reasoning),
+    )
     out: dict = {
         "intent": intent.value,
         "routing_reasoning": reasoning,
+        "missing_slots": missing_slots,
+        "detected_language": detected_language,
     }
     if router_usage:
         out["router_usage"] = router_usage

--- a/backend/app/ai/graph/nodes/router.py
+++ b/backend/app/ai/graph/nodes/router.py
@@ -1,8 +1,13 @@
 """Router node: classifies intent into RESEARCH, DIRECT, CLARIFY, OUT_OF_SCOPE, or EXPLAIN.
 
-Wraps the existing check_intent() function from app.ai.routing so that
-routing logic is a first-class LangGraph node without duplicating code.
-The @wdr override is also handled here (fast-path, no LLM call).
+Wraps check_intent() from app.ai.routing so that routing logic is a first-class
+LangGraph node.  check_intent() now uses a ChatLiteLLM instance so the LLM call
+participates in LangChain's callback system.  LangGraph automatically tags the
+on_chat_model_end event with langgraph_node="router", meaning token usage is
+accumulated by the SSE bridge through the standard path — no manual router_usage
+state key or _model embedding hack required.
+
+The @wdr override and forced_intent fast-paths are also handled here.
 """
 
 import logging
@@ -23,10 +28,10 @@ async def router_node(state: ChatPipelineState) -> dict:
 
     Fast-path: if the user query contains ``@wdr``, forces RESEARCH without
     an LLM call.  Otherwise delegates to check_intent() which calls the
-    routing model via LiteLLM.
+    routing model via LangChain/LiteLLM so usage is tracked automatically.
 
     Returns state updates for ``intent``, ``routing_reasoning``,
-    ``missing_slots``, and ``routing_confidence``.
+    ``missing_slots``, and ``detected_language``.
     """
     query_text: str = state.get("query_text", "")
 
@@ -53,7 +58,7 @@ async def router_node(state: ChatPipelineState) -> dict:
     session_summary: str = state.get("session_summary", "") or ""
     logger.info("[router_node] calling check_intent messages_count=%d", len(openai_messages))
 
-    intent, reasoning, router_usage, missing_slots, detected_language = await check_intent(
+    intent, reasoning, missing_slots, detected_language = await check_intent(
         openai_messages,
         session_summary=session_summary,
     )
@@ -65,12 +70,9 @@ async def router_node(state: ChatPipelineState) -> dict:
         detected_language,
         len(reasoning),
     )
-    out: dict = {
+    return {
         "intent": intent.value,
         "routing_reasoning": reasoning,
         "missing_slots": missing_slots,
         "detected_language": detected_language,
     }
-    if router_usage:
-        out["router_usage"] = router_usage
-    return out

--- a/backend/app/ai/graph/nodes/scout.py
+++ b/backend/app/ai/graph/nodes/scout.py
@@ -1,0 +1,107 @@
+"""Scout node: quickly checks data availability for RESEARCH queries.
+
+Uses a small subset of data tools (search, disaggregation, codelist) to verify
+indicator and country coverage before the full research node commits to expensive
+data retrieval.  Streaming=True so tool events appear in the data-thinking panel.
+
+Returns ``{"scout_findings": parsed_dict_or_raw_text}``.
+"""
+
+import json
+import logging
+import re
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from app.ai.prompts import get_scout_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..node_utils import run_tool_loop
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+# Tools the scout node is allowed to call
+SCOUT_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "data360_search_indicators",
+        "data360_get_disaggregation",
+        "data360_find_codelist_value",
+    }
+)
+
+MAX_TOOL_ITERATIONS = 4  # scout is lightweight; rarely needs more than 3 calls
+
+
+def _parse_scout_response(text: str) -> dict:
+    """Extract the JSON block from the scout response.
+
+    Looks for a ```json ... ``` fenced block.  If found, parses and returns the
+    dict.  On any parse failure, falls back to ``{"raw": text}``.
+    """
+    match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            logger.warning("[scout_node] JSON parse failed: %s", exc)
+    return {"raw": text}
+
+
+async def scout_node(state: ChatPipelineState) -> dict:
+    """Verify data availability and return scout_findings.
+
+    Runs a lightweight ReAct tool loop restricted to search, disaggregation, and
+    codelist tools.  The final LLM response is expected to contain a JSON block
+    describing available indicators and coverage.
+
+    ``streaming=True`` ensures ``graph.astream_events()`` emits token-level events
+    tagged with ``langgraph_node="scout"`` — the SSE bridge maps these to the
+    data-thinking envelope.
+
+    Returns state updates for ``scout_findings``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    all_data_tools: list = state.get("tool_set", {}).get("mcp_data", {}).get("langchain_tools", [])
+
+    # Filter to scout-allowed tools only
+    scout_tools = [t for t in all_data_tools if t.name in SCOUT_TOOL_NAMES]
+    if not scout_tools:
+        logger.warning("[scout_node] no scout tools available — returning empty findings")
+        return {"scout_findings": {"available": False, "gaps": "No scout tools available."}}
+
+    llm = get_chat_llm(model_type, streaming=True).bind_tools(scout_tools)
+    system_prompt: str = get_scout_system_prompt()
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+
+    # Prepend session summary if available so scout knows earlier context
+    session_summary: str = state.get("session_summary", "") or ""
+    if session_summary:
+        history = [HumanMessage(content=f"[SESSION SUMMARY]\n{session_summary}")] + history
+
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="scout",
+    )
+
+    tool_map = {t.name: t for t in scout_tools}
+    final_content, _ = await run_tool_loop(
+        llm=llm,
+        messages=messages,
+        tool_map=tool_map,
+        max_iterations=MAX_TOOL_ITERATIONS,
+        state=state,
+        graph_node="scout",
+    )
+
+    parsed = _parse_scout_response(final_content)
+    logger.info(
+        "[scout_node] findings available=%s",
+        parsed.get("available", "unknown"),
+    )
+
+    return {"scout_findings": parsed}

--- a/backend/app/ai/graph/nodes/scout.py
+++ b/backend/app/ai/graph/nodes/scout.py
@@ -2,7 +2,11 @@
 
 Uses a small subset of data tools (search, disaggregation, codelist) to verify
 indicator and country coverage before the full research node commits to expensive
-data retrieval.  Streaming=True so tool events appear in the data-thinking panel.
+data retrieval.
+
+Streaming is intentionally False — only tool call events (which come through the
+manual notify queue) appear in the data-thinking panel.  The scout's LLM synthesis
+text is internal plumbing and is not shown to the user.
 
 Returns ``{"scout_findings": parsed_dict_or_raw_text}``.
 """
@@ -37,18 +41,31 @@ MAX_TOOL_ITERATIONS = 4  # scout is lightweight; rarely needs more than 3 calls
 
 
 def _parse_scout_response(text: str) -> dict:
-    """Extract the JSON block from the scout response.
+    """Extract structured scout findings from the scout response.
 
-    Looks for a ```json ... ``` fenced block.  If found, parses and returns the
-    dict.  On any parse failure, falls back to ``{"raw": text}``.
+    Looks for a <scout_data>...</scout_data> tag containing a JSON object.
+    Falls back to the legacy ```json ... ``` block for backwards compatibility.
+    On any parse failure, returns a minimal dict derived from the prose.
     """
-    match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-    if match:
+    # Primary: <scout_data> XML tag
+    tag_match = re.search(r"<scout_data>\s*(.*?)\s*</scout_data>", text, re.DOTALL)
+    if tag_match:
         try:
-            return json.loads(match.group(1))
+            return json.loads(tag_match.group(1))
         except json.JSONDecodeError as exc:
-            logger.warning("[scout_node] JSON parse failed: %s", exc)
-    return {"raw": text}
+            logger.warning("[scout_node] <scout_data> JSON parse failed: %s", exc)
+
+    # Fallback: fenced ```json block (legacy format)
+    block_match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if block_match:
+        try:
+            return json.loads(block_match.group(1))
+        except json.JSONDecodeError as exc:
+            logger.warning("[scout_node] ```json block parse failed: %s", exc)
+
+    # Last resort: treat the whole text as the recommendation prose
+    available = "no data" not in text.lower() and "not available" not in text.lower()
+    return {"available": available, "raw": text}
 
 
 async def scout_node(state: ChatPipelineState) -> dict:
@@ -73,7 +90,7 @@ async def scout_node(state: ChatPipelineState) -> dict:
         logger.warning("[scout_node] no scout tools available — returning empty findings")
         return {"scout_findings": {"available": False, "gaps": "No scout tools available."}}
 
-    llm = get_chat_llm(model_type, streaming=True).bind_tools(scout_tools)
+    llm = get_chat_llm(model_type, streaming=False).bind_tools(scout_tools)
     system_prompt: str = get_scout_system_prompt()
 
     history = openai_to_langchain(state.get("openai_messages", []))
@@ -104,4 +121,9 @@ async def scout_node(state: ChatPipelineState) -> dict:
         parsed.get("available", "unknown"),
     )
 
-    return {"scout_findings": parsed}
+    existing_trace: list = state.get("agent_trace_parts") or []
+    return {
+        "scout_findings": parsed,
+        "agent_trace_parts": existing_trace
+        + [{"type": "agent-trace", "node": "scout", "data": parsed, "state": "done"}],
+    }

--- a/backend/app/ai/graph/nodes/scout.py
+++ b/backend/app/ai/graph/nodes/scout.py
@@ -37,7 +37,7 @@ SCOUT_TOOL_NAMES: frozenset[str] = frozenset(
     }
 )
 
-MAX_TOOL_ITERATIONS = 4  # scout is lightweight; rarely needs more than 3 calls
+MAX_TOOL_ITERATIONS = 3  # scout is lightweight: codelist + search + optional disaggregation
 
 
 def _parse_scout_response(text: str) -> dict:

--- a/backend/app/ai/graph/nodes/suggester.py
+++ b/backend/app/ai/graph/nodes/suggester.py
@@ -1,0 +1,83 @@
+"""Suggester node: bridges off-scope queries to relevant development data questions.
+
+No tools — single LLM call.  Acknowledges the user's topic and generates 3-5
+thematically adjacent development data questions they could explore instead.
+
+Token budget is small (4K) since the suggester only needs the last few turns.
+"""
+
+import logging
+import re
+
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage
+
+from app.ai.observability.token_usage import append_llm_usage_fallback
+from app.ai.prompts import get_suggester_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_suggestions(text: str) -> list[str]:
+    """Extract bullet-point questions from the suggester response for telemetry."""
+    lines = text.splitlines()
+    suggestions = []
+    for line in lines:
+        stripped = line.strip()
+        # Match lines starting with -, *, or a number followed by . or )
+        if re.match(r"^[-*•]\s+.+", stripped) or re.match(r"^\d+[.)]\s+.+", stripped):
+            question = re.sub(r"^[-*•\d.)\s]+", "", stripped).strip()
+            if question:
+                suggestions.append(question)
+    return suggestions
+
+
+async def suggester_node(state: ChatPipelineState) -> dict:
+    """Generate 3-5 development data questions adjacent to an off-scope query.
+
+    ``streaming=True`` ensures token-level events flow through the SSE bridge
+    as ``langgraph_node="suggester"`` → plain text-delta (visible to the user).
+
+    Returns state updates for ``suggestions``, ``assistant_parts``, and ``final_usage``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+
+    llm = get_chat_llm(model_type, streaming=True)
+    language: str = state.get("detected_language", "") or ""
+    system_prompt: str = get_suggester_system_prompt(language=language)
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="suggester",
+    )
+
+    logger.info("[suggester_node] generating suggestions for off-scope query")
+    response: AIMessage = await llm.ainvoke(messages)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+
+    final_content: str = response.content or ""
+    final_usage: dict | None = None
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        final_usage = dict(response.usage_metadata)
+
+    suggestions = _extract_suggestions(final_content)
+    logger.info(
+        "[suggester_node] response length=%d suggestions_count=%d",
+        len(final_content),
+        len(suggestions),
+    )
+
+    assistant_part = {"type": "text", "text": final_content, "state": "done"}
+    existing_parts: list[dict] = state.get("assistant_parts", [])
+
+    return {
+        "suggestions": suggestions,
+        "assistant_parts": existing_parts + [assistant_part],
+        "final_usage": final_usage,
+    }

--- a/backend/app/ai/graph/nodes/suggester.py
+++ b/backend/app/ai/graph/nodes/suggester.py
@@ -59,7 +59,7 @@ async def suggester_node(state: ChatPipelineState) -> dict:
 
     logger.info("[suggester_node] generating suggestions for off-scope query")
     response: AIMessage = await llm.ainvoke(messages)
-    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="suggester")
 
     final_content: str = response.content or ""
     final_usage: dict | None = None

--- a/backend/app/ai/graph/nodes/summarizer.py
+++ b/backend/app/ai/graph/nodes/summarizer.py
@@ -1,13 +1,17 @@
 """Summarizer node: condenses long conversation history into a rolling session summary.
 
-Only fires when ``len(openai_messages) > SUMMARIZE_THRESHOLD`` (= 20).
-Non-streaming (streaming=False) — no SSE events are expected from this node.
-Returns ``{"session_summary": <text>}`` or ``{}`` if below threshold.
+Only fires when ``len(openai_messages) > SUMMARIZE_THRESHOLD`` (= 20) for the first
+summary, or when ``new_messages_count >= SUMMARIZE_INCREMENT`` (= 8) for subsequent
+incremental updates.  Non-streaming (streaming=False) — no SSE events are expected
+from this node.
+
+Returns ``{"session_summary": <text>, "summarized_message_count": <int>}`` or ``{}``
+if below threshold.
 """
 
 import logging
 
-from langchain_core.messages import BaseMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from app.ai.prompts import get_summarizer_system_prompt
 from app.config import ModelType
@@ -18,43 +22,78 @@ from ..state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
 
-SUMMARIZE_THRESHOLD = 20  # only summarize when history exceeds this many messages
+SUMMARIZE_THRESHOLD = 20  # only summarize when history exceeds this many messages (first time)
+SUMMARIZE_INCREMENT = 8  # re-summarize every 8 new messages after the first summary
 _HISTORY_WINDOW = 30  # how many recent messages to pass to the summarizer
 
 
 async def summarizer_node(state: ChatPipelineState) -> dict:
     """Condense long conversation history into a rolling session_summary.
 
-    If the conversation history is short (below SUMMARIZE_THRESHOLD), this node
-    is a no-op and returns an empty dict.  When history is long, it calls the
-    LLM once (non-streaming) and returns the summary wrapped in
-    ``{"session_summary": <text>}``.
+    First summarization fires when len(openai_messages) > SUMMARIZE_THRESHOLD.
+    Subsequent summarizations fire when new_messages_count >= SUMMARIZE_INCREMENT.
 
-    The summary is later injected by scout / research / narrator nodes as a
-    ``[SESSION SUMMARY]`` HumanMessage prepended to their trimmed histories,
-    giving those nodes awareness of earlier turns that were dropped by trimming.
+    If an existing summary is present, only the new messages (since the last
+    summarization) are passed to the LLM, together with the existing summary as a
+    [PREVIOUS SUMMARY] prefix HumanMessage.
 
     Returns:
-        ``{"session_summary": text}`` if summarization ran, else ``{}``.
+        ``{"session_summary": text, "summarized_message_count": int}`` if summarization
+        ran, else ``{}``.
     """
     openai_messages: list[dict] = state.get("openai_messages", [])
-    history_len = len(openai_messages)
+    messages_count = len(openai_messages)
 
-    if history_len <= SUMMARIZE_THRESHOLD:
-        logger.info(
-            "[summarizer_node] history_len=%d ≤ threshold=%d — skipping",
-            history_len,
-            SUMMARIZE_THRESHOLD,
-        )
-        return {}
+    existing_summary: str = state.get("session_summary", "") or ""
+    summarized_count: int = state.get("summarized_message_count", 0) or 0
+    new_messages_count: int = messages_count - summarized_count
+
+    if not existing_summary:
+        # No prior summary — only fire when history exceeds initial threshold
+        if messages_count <= SUMMARIZE_THRESHOLD:
+            logger.info(
+                "[summarizer_node] history_len=%d ≤ threshold=%d — skipping",
+                messages_count,
+                SUMMARIZE_THRESHOLD,
+            )
+            return {}
+    else:
+        # Have a prior summary — only re-summarize when enough new messages have arrived
+        if new_messages_count < SUMMARIZE_INCREMENT:
+            logger.info(
+                "[summarizer_node] new_messages=%d < increment=%d — skipping (existing summary kept)",
+                new_messages_count,
+                SUMMARIZE_INCREMENT,
+            )
+            return {}
 
     model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
     system_prompt: str = get_summarizer_system_prompt()
 
-    # Take the last _HISTORY_WINDOW messages; do NOT trim — summarizing is the point
-    recent = openai_messages[-_HISTORY_WINDOW:]
-    history: list[BaseMessage] = openai_to_langchain(recent)
-    messages: list[BaseMessage] = [SystemMessage(content=system_prompt)] + history
+    if existing_summary:
+        # Incremental path: prepend existing summary, then pass only new messages
+        new_slice = openai_messages[summarized_count:]
+        recent = new_slice[-_HISTORY_WINDOW:]
+        history: list[BaseMessage] = openai_to_langchain(recent)
+        messages: list[BaseMessage] = (
+            [SystemMessage(content=system_prompt)]
+            + [HumanMessage(content=f"[PREVIOUS SUMMARY]\n{existing_summary}")]
+            + history
+        )
+        logger.info(
+            "[summarizer_node] incremental: summarized_count=%d new_messages=%d",
+            summarized_count,
+            len(new_slice),
+        )
+    else:
+        # Initial summarization: pass the last _HISTORY_WINDOW messages as before
+        recent = openai_messages[-_HISTORY_WINDOW:]
+        history = openai_to_langchain(recent)
+        messages = [SystemMessage(content=system_prompt)] + history
+        logger.info(
+            "[summarizer_node] initial: history_len=%d",
+            messages_count,
+        )
 
     llm = get_chat_llm(model_type, streaming=False)
     response = await llm.ainvoke(messages)
@@ -62,8 +101,11 @@ async def summarizer_node(state: ChatPipelineState) -> dict:
 
     logger.info(
         "[summarizer_node] history_len=%d → summary_len=%d",
-        history_len,
+        messages_count,
         len(summary_text),
     )
 
-    return {"session_summary": summary_text}
+    return {
+        "session_summary": summary_text,
+        "summarized_message_count": messages_count,
+    }

--- a/backend/app/ai/graph/nodes/summarizer.py
+++ b/backend/app/ai/graph/nodes/summarizer.py
@@ -1,0 +1,69 @@
+"""Summarizer node: condenses long conversation history into a rolling session summary.
+
+Only fires when ``len(openai_messages) > SUMMARIZE_THRESHOLD`` (= 20).
+Non-streaming (streaming=False) — no SSE events are expected from this node.
+Returns ``{"session_summary": <text>}`` or ``{}`` if below threshold.
+"""
+
+import logging
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+from app.ai.prompts import get_summarizer_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+SUMMARIZE_THRESHOLD = 20  # only summarize when history exceeds this many messages
+_HISTORY_WINDOW = 30  # how many recent messages to pass to the summarizer
+
+
+async def summarizer_node(state: ChatPipelineState) -> dict:
+    """Condense long conversation history into a rolling session_summary.
+
+    If the conversation history is short (below SUMMARIZE_THRESHOLD), this node
+    is a no-op and returns an empty dict.  When history is long, it calls the
+    LLM once (non-streaming) and returns the summary wrapped in
+    ``{"session_summary": <text>}``.
+
+    The summary is later injected by scout / research / narrator nodes as a
+    ``[SESSION SUMMARY]`` HumanMessage prepended to their trimmed histories,
+    giving those nodes awareness of earlier turns that were dropped by trimming.
+
+    Returns:
+        ``{"session_summary": text}`` if summarization ran, else ``{}``.
+    """
+    openai_messages: list[dict] = state.get("openai_messages", [])
+    history_len = len(openai_messages)
+
+    if history_len <= SUMMARIZE_THRESHOLD:
+        logger.info(
+            "[summarizer_node] history_len=%d ≤ threshold=%d — skipping",
+            history_len,
+            SUMMARIZE_THRESHOLD,
+        )
+        return {}
+
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    system_prompt: str = get_summarizer_system_prompt()
+
+    # Take the last _HISTORY_WINDOW messages; do NOT trim — summarizing is the point
+    recent = openai_messages[-_HISTORY_WINDOW:]
+    history: list[BaseMessage] = openai_to_langchain(recent)
+    messages: list[BaseMessage] = [SystemMessage(content=system_prompt)] + history
+
+    llm = get_chat_llm(model_type, streaming=False)
+    response = await llm.ainvoke(messages)
+    summary_text: str = response.content or ""
+
+    logger.info(
+        "[summarizer_node] history_len=%d → summary_len=%d",
+        history_len,
+        len(summary_text),
+    )
+
+    return {"session_summary": summary_text}

--- a/backend/app/ai/graph/nodes/summarizer.py
+++ b/backend/app/ai/graph/nodes/summarizer.py
@@ -13,6 +13,7 @@ import logging
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
+from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_summarizer_system_prompt
 from app.config import ModelType
 
@@ -97,6 +98,7 @@ async def summarizer_node(state: ChatPipelineState) -> dict:
 
     llm = get_chat_llm(model_type, streaming=False)
     response = await llm.ainvoke(messages)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response, node="summarizer")
     summary_text: str = response.content or ""
 
     logger.info(

--- a/backend/app/ai/graph/nodes/transformer.py
+++ b/backend/app/ai/graph/nodes/transformer.py
@@ -1,0 +1,103 @@
+"""Transformer node: decides if an EXPLAIN query can be answered with data.
+
+For analytical/diagnostic questions (e.g. "What are Ghana's main economic challenges?")
+the transformer converts them into 2-5 concrete data research queries so that the
+research pipeline can produce an evidence-based answer instead of a generic narrative.
+
+For truly definitional questions (e.g. "What is the Gini coefficient?") it short-
+circuits directly to the explain node (pure metadata path).
+
+The decision is captured as ``translated_queries`` in state:
+  - non-empty list  → route to scout (data research pipeline)
+  - empty list      → route to explain (metadata / definition path)
+
+Non-streaming, no tools — a single fast LLM call with a small token budget.
+"""
+
+import json
+import logging
+import re
+
+from langchain_core.messages import BaseMessage, SystemMessage
+
+from app.ai.observability.token_usage import append_llm_usage_fallback
+from app.ai.prompts import get_transformer_system_prompt
+from app.config import ModelType
+
+from ..llm_factory import get_chat_llm
+from ..memory import trim_for_node
+from ..message_utils import openai_to_langchain
+from ..state import ChatPipelineState
+
+logger = logging.getLogger(__name__)
+
+# Regex to extract the first ```json ... ``` block from the LLM response
+_JSON_BLOCK_RE = re.compile(r"```json\s*(.*?)\s*```", re.DOTALL)
+
+
+def _parse_transformer_response(text: str) -> dict:
+    """Extract the JSON decision block from the transformer's response.
+
+    Returns a dict with at minimum ``decision`` and ``translated_queries`` keys.
+    Falls back to DEFINITIONAL on any parse error so the flow is never broken.
+    """
+    match = _JSON_BLOCK_RE.search(text)
+    if match:
+        try:
+            data = json.loads(match.group(1))
+            if isinstance(data, dict) and "decision" in data:
+                return data
+        except (json.JSONDecodeError, ValueError):
+            pass
+    # Try raw JSON (no code fence)
+    try:
+        data = json.loads(text.strip())
+        if isinstance(data, dict) and "decision" in data:
+            return data
+    except (json.JSONDecodeError, ValueError):
+        pass
+    logger.warning("[transformer_node] could not parse JSON response — defaulting to DEFINITIONAL")
+    return {"decision": "DEFINITIONAL", "translated_queries": [], "framing": ""}
+
+
+async def transformer_node(state: ChatPipelineState) -> dict:
+    """Classify an EXPLAIN query as DATA_GROUNDABLE or DEFINITIONAL.
+
+    DATA_GROUNDABLE  → writes ``translated_queries`` (non-empty list) to state;
+                       the routing function will forward to scout.
+    DEFINITIONAL     → writes ``translated_queries`` as [] to state;
+                       the routing function will forward to explain.
+
+    Returns state updates for ``translated_queries``.
+    """
+    model_type: str = state.get("model_type", ModelType.CHAT_MODEL.value)
+    query_text: str = state.get("query_text", "")
+
+    llm = get_chat_llm(model_type, streaming=False)
+    system_prompt: str = get_transformer_system_prompt()
+
+    history = openai_to_langchain(state.get("openai_messages", []))
+    messages: list[BaseMessage] = trim_for_node(
+        [SystemMessage(content=system_prompt)] + history,
+        node="transformer",
+    )
+
+    logger.info("[transformer_node] classifying query=%r", query_text[:120])
+    response = await llm.ainvoke(messages)
+    append_llm_usage_fallback(state.get("_usage_fallback_bucket"), response)
+
+    result = _parse_transformer_response(response.content or "")
+    decision: str = result.get("decision", "DEFINITIONAL")
+    translated_queries: list[str] = result.get("translated_queries") or []
+
+    # Ensure list of strings
+    if not isinstance(translated_queries, list):
+        translated_queries = []
+    translated_queries = [str(q) for q in translated_queries if q]
+
+    logger.info(
+        "[transformer_node] decision=%s translated_queries=%d",
+        decision,
+        len(translated_queries),
+    )
+    return {"translated_queries": translated_queries}

--- a/backend/app/ai/graph/nodes/transformer.py
+++ b/backend/app/ai/graph/nodes/transformer.py
@@ -100,4 +100,17 @@ async def transformer_node(state: ChatPipelineState) -> dict:
         decision,
         len(translated_queries),
     )
-    return {"translated_queries": translated_queries}
+
+    existing_trace: list = state.get("agent_trace_parts") or []
+    return {
+        "translated_queries": translated_queries,
+        "agent_trace_parts": existing_trace
+        + [
+            {
+                "type": "agent-trace",
+                "node": "transformer",
+                "data": {"decision": decision, "translated_queries": translated_queries},
+                "state": "done",
+            }
+        ],
+    }

--- a/backend/app/ai/graph/pipeline.py
+++ b/backend/app/ai/graph/pipeline.py
@@ -1,8 +1,21 @@
 """LangGraph StateGraph construction for the chat pipeline.
 
 Graph topology:
-    START → router → RESEARCH? → research → narrator → END
-                   → DIRECT?  → direct              → END
+    START → summarizer → router
+    router RESEARCH     → scout → planner → research → [conditional] → narrator → followup → END
+                                                      ↓ (if failed)
+                                                   recovery → narrator → followup → END
+    router EXPLAIN      → transformer → [DATA_GROUNDABLE] → scout → planner → research → ...
+                                      → [DEFINITIONAL]    → explain → narrator → followup → END
+    router CLARIFY      → clarifier                                             → END
+    router OUT_OF_SCOPE → suggester                                             → END
+    router DIRECT       → direct                                                → END
+
+``transformer`` intercepts EXPLAIN-routed queries and decides:
+  - DATA_GROUNDABLE: analytical/diagnostic ("What are Ghana's challenges?") →
+    translates to concrete data queries → full research pipeline
+  - DEFINITIONAL: pure concept/methodology questions ("What is the Gini?") →
+    metadata-only explain path
 
 The compiled graph is a module-level singleton (``chat_graph``) so it is
 built once at startup and reused across all requests.
@@ -12,20 +25,78 @@ import logging
 
 from langgraph.graph import END, START, StateGraph
 
+from .nodes.clarifier import clarifier_node
 from .nodes.direct import direct_node
+from .nodes.explain import explain_node
+from .nodes.followup import followup_node
 from .nodes.narrator import narrator_node
+from .nodes.planner import planner_node
+from .nodes.recovery import recovery_node
 from .nodes.research import research_node
 from .nodes.router import router_node
+from .nodes.scout import scout_node
+from .nodes.suggester import suggester_node
+from .nodes.summarizer import summarizer_node
+from .nodes.transformer import transformer_node
 from .state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
+
+# Phrases in a research_packet that indicate the research found no usable data
+FAILURE_SIGNALS = (
+    "no data",
+    "not available",
+    "no results",
+    "could not find",
+    "failed to retrieve",
+    "data unavailable",
+)
+
+
+def _is_research_failed(packet: str) -> bool:
+    """Return True when research_packet indicates no data was retrieved."""
+    if not packet or len(packet.strip()) < 50:
+        return True
+    # If the packet contains claim tags, real data was found
+    if "<claim" in packet.lower():
+        return False
+    lower = packet.lower()
+    return any(sig in lower for sig in FAILURE_SIGNALS)
 
 
 def _route_after_router(state: ChatPipelineState) -> str:
     """Conditional edge: decide which path to take after routing."""
     intent: str = state.get("intent", "DIRECT")
     logger.debug("[pipeline] routing intent=%s", intent)
-    return "research" if intent == "RESEARCH" else "direct"
+    return {
+        "RESEARCH": "scout",
+        "EXPLAIN": "transformer",  # transformer decides: data-pipeline or pure explain
+        "CLARIFY": "clarifier",
+        "OUT_OF_SCOPE": "suggester",
+        "DIRECT": "direct",
+    }.get(intent, "direct")
+
+
+def _route_after_transformer(state: ChatPipelineState) -> str:
+    """After transformer: data pipeline if translated_queries present, else pure explain."""
+    translated: list = state.get("translated_queries") or []
+    if translated:
+        logger.info(
+            "[pipeline] transformer → DATA_GROUNDABLE (%d queries) → scout",
+            len(translated),
+        )
+        return "scout"
+    logger.info("[pipeline] transformer → DEFINITIONAL → explain")
+    return "explain"
+
+
+def _route_after_research(state: ChatPipelineState) -> str:
+    """After research: go to recovery if packet is empty/failed, else narrator."""
+    packet: str = state.get("research_packet", "")
+    already_attempted: bool = state.get("recovery_attempted", False)
+    if not already_attempted and _is_research_failed(packet):
+        return "recovery"
+    return "narrator"
 
 
 def build_chat_graph():
@@ -33,19 +104,75 @@ def build_chat_graph():
     g = StateGraph(ChatPipelineState)
 
     # ── Nodes ──────────────────────────────────────────────────────────────────
+    g.add_node("summarizer", summarizer_node)
     g.add_node("router", router_node)
+    g.add_node("transformer", transformer_node)
+    g.add_node("scout", scout_node)
+    g.add_node("planner", planner_node)
     g.add_node("research", research_node)
+    g.add_node("recovery", recovery_node)
+    g.add_node("explain", explain_node)
     g.add_node("narrator", narrator_node)
+    g.add_node("followup", followup_node)
     g.add_node("direct", direct_node)
+    g.add_node("clarifier", clarifier_node)
+    g.add_node("suggester", suggester_node)
 
     # ── Edges ──────────────────────────────────────────────────────────────────
-    g.add_edge(START, "router")
+    # Summarizer runs first on every request, then hands off to router
+    g.add_edge(START, "summarizer")
+    g.add_edge("summarizer", "router")
+
+    # Router fan-out: EXPLAIN goes to transformer; RESEARCH goes directly to scout
     g.add_conditional_edges(
-        "router", _route_after_router, {"research": "research", "direct": "direct"}
+        "router",
+        _route_after_router,
+        {
+            "scout": "scout",
+            "transformer": "transformer",
+            "clarifier": "clarifier",
+            "suggester": "suggester",
+            "direct": "direct",
+        },
     )
-    g.add_edge("research", "narrator")
-    g.add_edge("narrator", END)
+
+    # Transformer: DATA_GROUNDABLE → scout (joins the research pipeline)
+    #              DEFINITIONAL    → explain (metadata-only path)
+    g.add_conditional_edges(
+        "transformer",
+        _route_after_transformer,
+        {
+            "scout": "scout",
+            "explain": "explain",
+        },
+    )
+
+    # Research pipeline: scout → planner → research → [conditional] → narrator
+    g.add_edge("scout", "planner")
+    g.add_edge("planner", "research")
+    g.add_conditional_edges(
+        "research",
+        _route_after_research,
+        {
+            "recovery": "recovery",
+            "narrator": "narrator",
+        },
+    )
+
+    # Recovery also feeds into narrator
+    g.add_edge("recovery", "narrator")
+
+    # Explain feeds narrator for consistent formatting
+    g.add_edge("explain", "narrator")
+
+    # Narrator → followup → END (for research and explain paths)
+    g.add_edge("narrator", "followup")
+    g.add_edge("followup", END)
+
+    # Terminal nodes (no followup for these)
     g.add_edge("direct", END)
+    g.add_edge("clarifier", END)
+    g.add_edge("suggester", END)
 
     compiled = g.compile()
     logger.info("[pipeline] chat_graph compiled successfully")

--- a/backend/app/ai/graph/pipeline.py
+++ b/backend/app/ai/graph/pipeline.py
@@ -54,16 +54,27 @@ FAILURE_SIGNALS = (
 
 
 def _is_research_failed(packet: str) -> bool:
-    """Return True when research_packet indicates no data was retrieved."""
+    """Return True when research_packet indicates no data was retrieved.
+
+    Failure = the research node produced nothing usable.
+    NOT failure = research found the indicator but the exact year/country had no
+    observation value (narrator can handle "not available" gracefully).
+    """
     if not packet or len(packet.strip()) < 50:
         return True
-    # New format: explicit NO_DATA section means search found nothing
-    if "### no_data:" in packet.lower():
-        return True
-    # Old/new format: claim tags confirm real data was retrieved
-    if "<claim" in packet.lower():
-        return False
     lower = packet.lower()
+    # Explicit NO_DATA section means the search found nothing at all
+    if "### no_data:" in lower:
+        return True
+    # Claim tags confirm real observation values were retrieved — definitive success
+    if "<claim" in lower:
+        return False
+    # A structured packet (has DATA or EVIDENCE NOTES sections) means research ran
+    # properly and identified the indicator, even if the specific year/country had
+    # no observation. Don't trigger recovery — narrator handles "not available" fine.
+    if "### data:" in lower or "### evidence notes:" in lower:
+        return False
+    # Unstructured response — fall back to keyword signals
     return any(sig in lower for sig in FAILURE_SIGNALS)
 
 

--- a/backend/app/ai/graph/pipeline.py
+++ b/backend/app/ai/graph/pipeline.py
@@ -1,24 +1,15 @@
 """LangGraph StateGraph construction for the chat pipeline.
 
-Graph topology:
+Graph topology (7 nodes):
     START → summarizer → router
-    router RESEARCH     → scout → planner → research → [conditional] → narrator → followup → END
-                                                      ↓ (if failed)
-                                                   recovery → narrator → followup → END
-    router EXPLAIN      → transformer → [DATA_GROUNDABLE] → scout → planner → research → ...
-                                      → [DEFINITIONAL]    → explain → narrator → followup → END
-    router CLARIFY      → clarifier                                             → END
-    router OUT_OF_SCOPE → suggester                                             → END
-    router DIRECT       → direct                                                → END
+    router RESEARCH     → research → narrator → followup → END
+    router EXPLAIN      → explain  → narrator → followup → END
+    router CLARIFY      → clarifier                      → END
+    router OUT_OF_SCOPE → suggester                      → END
+    router DIRECT       → direct                         → END
 
-``transformer`` intercepts EXPLAIN-routed queries and decides:
-  - DATA_GROUNDABLE: analytical/diagnostic ("What are Ghana's challenges?") →
-    translates to concrete data queries → full research pipeline
-  - DEFINITIONAL: pure concept/methodology questions ("What is the Gini?") →
-    metadata-only explain path
-
-The compiled graph is a module-level singleton (``chat_graph``) so it is
-built once at startup and reused across all requests.
+The former transformer / scout / planner / recovery nodes have been
+consolidated into the adaptive research_node (see nodes/research.py).
 """
 
 import logging
@@ -30,87 +21,26 @@ from .nodes.direct import direct_node
 from .nodes.explain import explain_node
 from .nodes.followup import followup_node
 from .nodes.narrator import narrator_node
-from .nodes.planner import planner_node
-from .nodes.recovery import recovery_node
 from .nodes.research import research_node
 from .nodes.router import router_node
-from .nodes.scout import scout_node
 from .nodes.suggester import suggester_node
 from .nodes.summarizer import summarizer_node
-from .nodes.transformer import transformer_node
 from .state import ChatPipelineState
 
 logger = logging.getLogger(__name__)
 
-# Phrases in a research_packet that indicate the research found no usable data
-FAILURE_SIGNALS = (
-    "no data",
-    "not available",
-    "no results",
-    "could not find",
-    "failed to retrieve",
-    "data unavailable",
-)
-
-
-def _is_research_failed(packet: str) -> bool:
-    """Return True when research_packet indicates no data was retrieved.
-
-    Failure = the research node produced nothing usable.
-    NOT failure = research found the indicator but the exact year/country had no
-    observation value (narrator can handle "not available" gracefully).
-    """
-    if not packet or len(packet.strip()) < 50:
-        return True
-    lower = packet.lower()
-    # Explicit NO_DATA section means the search found nothing at all
-    if "### no_data:" in lower:
-        return True
-    # Claim tags confirm real observation values were retrieved — definitive success
-    if "<claim" in lower:
-        return False
-    # A structured packet (has DATA or EVIDENCE NOTES sections) means research ran
-    # properly and identified the indicator, even if the specific year/country had
-    # no observation. Don't trigger recovery — narrator handles "not available" fine.
-    if "### data:" in lower or "### evidence notes:" in lower:
-        return False
-    # Unstructured response — fall back to keyword signals
-    return any(sig in lower for sig in FAILURE_SIGNALS)
-
 
 def _route_after_router(state: ChatPipelineState) -> str:
-    """Conditional edge: decide which path to take after routing."""
+    """Map router intent to the next node."""
     intent: str = state.get("intent", "DIRECT")
     logger.debug("[pipeline] routing intent=%s", intent)
     return {
-        "RESEARCH": "scout",
-        "EXPLAIN": "transformer",  # transformer decides: data-pipeline or pure explain
+        "RESEARCH": "research",
+        "EXPLAIN": "explain",
         "CLARIFY": "clarifier",
         "OUT_OF_SCOPE": "suggester",
         "DIRECT": "direct",
     }.get(intent, "direct")
-
-
-def _route_after_transformer(state: ChatPipelineState) -> str:
-    """After transformer: data pipeline if translated_queries present, else pure explain."""
-    translated: list = state.get("translated_queries") or []
-    if translated:
-        logger.info(
-            "[pipeline] transformer → DATA_GROUNDABLE (%d queries) → scout",
-            len(translated),
-        )
-        return "scout"
-    logger.info("[pipeline] transformer → DEFINITIONAL → explain")
-    return "explain"
-
-
-def _route_after_research(state: ChatPipelineState) -> str:
-    """After research: go to recovery if packet is empty/failed, else narrator."""
-    packet: str = state.get("research_packet", "")
-    already_attempted: bool = state.get("recovery_attempted", False)
-    if not already_attempted and _is_research_failed(packet):
-        return "recovery"
-    return "narrator"
 
 
 def build_chat_graph():
@@ -120,11 +50,7 @@ def build_chat_graph():
     # ── Nodes ──────────────────────────────────────────────────────────────────
     g.add_node("summarizer", summarizer_node)
     g.add_node("router", router_node)
-    g.add_node("transformer", transformer_node)
-    g.add_node("scout", scout_node)
-    g.add_node("planner", planner_node)
     g.add_node("research", research_node)
-    g.add_node("recovery", recovery_node)
     g.add_node("explain", explain_node)
     g.add_node("narrator", narrator_node)
     g.add_node("followup", followup_node)
@@ -133,63 +59,36 @@ def build_chat_graph():
     g.add_node("suggester", suggester_node)
 
     # ── Edges ──────────────────────────────────────────────────────────────────
-    # Summarizer runs first on every request, then hands off to router
     g.add_edge(START, "summarizer")
     g.add_edge("summarizer", "router")
 
-    # Router fan-out: EXPLAIN goes to transformer; RESEARCH goes directly to scout
     g.add_conditional_edges(
         "router",
         _route_after_router,
         {
-            "scout": "scout",
-            "transformer": "transformer",
+            "research": "research",
+            "explain": "explain",
             "clarifier": "clarifier",
             "suggester": "suggester",
             "direct": "direct",
         },
     )
 
-    # Transformer: DATA_GROUNDABLE → scout (joins the research pipeline)
-    #              DEFINITIONAL    → explain (metadata-only path)
-    g.add_conditional_edges(
-        "transformer",
-        _route_after_transformer,
-        {
-            "scout": "scout",
-            "explain": "explain",
-        },
-    )
-
-    # Research pipeline: scout → planner → research → [conditional] → narrator
-    g.add_edge("scout", "planner")
-    g.add_edge("planner", "research")
-    g.add_conditional_edges(
-        "research",
-        _route_after_research,
-        {
-            "recovery": "recovery",
-            "narrator": "narrator",
-        },
-    )
-
-    # Recovery also feeds into narrator
-    g.add_edge("recovery", "narrator")
-
-    # Explain feeds narrator for consistent formatting
+    # Research and explain both feed narrator
+    g.add_edge("research", "narrator")
     g.add_edge("explain", "narrator")
 
-    # Narrator → followup → END (for research and explain paths)
+    # Narrator → followup → END
     g.add_edge("narrator", "followup")
     g.add_edge("followup", END)
 
-    # Terminal nodes (no followup for these)
+    # Terminal nodes
     g.add_edge("direct", END)
     g.add_edge("clarifier", END)
     g.add_edge("suggester", END)
 
     compiled = g.compile()
-    logger.info("[pipeline] chat_graph compiled successfully")
+    logger.info("[pipeline] chat_graph compiled successfully (7 nodes)")
     return compiled
 
 

--- a/backend/app/ai/graph/pipeline.py
+++ b/backend/app/ai/graph/pipeline.py
@@ -57,7 +57,10 @@ def _is_research_failed(packet: str) -> bool:
     """Return True when research_packet indicates no data was retrieved."""
     if not packet or len(packet.strip()) < 50:
         return True
-    # If the packet contains claim tags, real data was found
+    # New format: explicit NO_DATA section means search found nothing
+    if "### no_data:" in packet.lower():
+        return True
+    # Old/new format: claim tags confirm real data was retrieved
     if "<claim" in packet.lower():
         return False
     lower = packet.lower()

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -33,11 +33,12 @@ from typing import Any, AsyncGenerator
 from uuid import uuid4
 
 from app.ai.graph.graph_debug_log import (
-    completion_text_from_model_output,
     graph_llm_log_enabled,
-    log_llm_completion_preview,
-    log_llm_stream_delta,
+    log_langgraph_raw_event,
     log_llm_tool_manual,
+    log_pipeline_error,
+    log_pipeline_input,
+    log_pipeline_output,
 )
 from app.ai.graph.tool_output_normalize import normalize_tool_output_for_ui
 from app.ai.observability.token_usage import (
@@ -415,11 +416,6 @@ class _SseBridgeState:
             chunk = data.get("chunk")
             content: str = chunk.content if (chunk and hasattr(chunk, "content")) else ""
             if content:
-                log_llm_stream_delta(
-                    message_id=self.message_id,
-                    graph_node=node,
-                    delta=content,
-                )
                 self._research_text_buf.append(content)
                 inner_id = f"research-{self.message_id}"
                 chunks.append(
@@ -435,14 +431,6 @@ class _SseBridgeState:
 
         elif evt_type == "on_chat_model_end" and node in _LLM_NODES:
             self.add_usage_from_message(data.get("output"))
-            out_msg = _unwrap_chat_model_end_output(data.get("output"))
-            end_text = completion_text_from_model_output(out_msg)
-            if end_text:
-                log_llm_completion_preview(
-                    message_id=self.message_id,
-                    graph_node=node,
-                    text=end_text,
-                )
 
         elif not self._manual_tool_sse and evt_type == "on_tool_start" and node in _THINKING_NODES:
             chunks.extend(
@@ -467,11 +455,6 @@ class _SseBridgeState:
             chunk = data.get("chunk")
             content = chunk.content if (chunk and hasattr(chunk, "content")) else ""
             if content:
-                log_llm_stream_delta(
-                    message_id=self.message_id,
-                    graph_node=node,
-                    delta=content,
-                )
                 self._answer_text_parts.append(content)
                 self._narrator_segment.append(content)
                 if not self.answer_text_started:
@@ -745,6 +728,7 @@ async def stream_graph_to_sse(
     br = _SseBridgeState(
         message_id=message_id, thinking_db_id=thinking_db_id, input_state=input_state
     )
+    log_pipeline_input(message_id=message_id, input_state=input_state)
     tool_q: asyncio.Queue | None = input_state.get("_tool_sse_queue")
 
     aiter = graph.astream_events(input_state, version="v2").__aiter__()
@@ -774,6 +758,7 @@ async def stream_graph_to_sse(
                     except BaseException as graph_exc:
                         root = _root_cause(graph_exc)
                         err_id = new_error_id()
+                        log_pipeline_error(message_id=message_id, error_id=err_id, exc=root)
                         logger.warning(
                             "Graph SSE stream failed [%s]: %s",
                             err_id,
@@ -820,6 +805,7 @@ async def stream_graph_to_sse(
                         next_graph = None
                         graph_ended = True
                         break
+                    log_langgraph_raw_event(message_id=message_id, event=ev)
                     for chunk in br.graph_event_to_chunks(ev):
                         yield chunk
                     next_graph = asyncio.create_task(_graph_next())
@@ -846,3 +832,11 @@ async def stream_graph_to_sse(
 
     if out is not None:
         br.fill_out_dict(out)
+        if not br._stream_failed:
+            log_pipeline_output(
+                message_id=message_id,
+                out=out,
+                final_state=br._final_graph_state
+                if isinstance(br._final_graph_state, dict)
+                else None,
+            )

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -371,7 +371,12 @@ class _SseBridgeState:
             self._routing_reasoning = reasoning
             ru = output.get("router_usage")
             if isinstance(ru, dict):
-                routing_model = str(getattr(settings, "ROUTING_MODEL", "") or "")
+                ru = dict(ru)  # copy before mutating
+                # routing.py embeds the actual deployed model name under "_model";
+                # pop it here so it doesn't confuse token-count parsing downstream.
+                routing_model = ru.pop("_model", None) or str(
+                    getattr(settings, "ROUTING_MODEL", "") or ""
+                )
                 self.add_usage_from_usage_fragment(ru, model_key=routing_model, node="router")
             if reasoning:
                 reason_id = f"routing-reason-{self.message_id}"
@@ -644,9 +649,11 @@ class _SseBridgeState:
             finish_metadata["usage"] = DataUsageEvent(data=self._usage_accum).model_dump()
             usage_sse_payload = self._usage_accum.model_dump()
             if self._usage_by_node:
-                usage_sse_payload["byNode"] = {
-                    k: v.model_dump() for k, v in self._usage_by_node.items()
-                }
+                by_node_dump = {k: v.model_dump() for k, v in self._usage_by_node.items()}
+                usage_sse_payload["byNode"] = by_node_dump
+                # Also surface byNode in finish_metadata so the non-streaming path
+                # (chat.py / chat_stream.py) can pick it up from the SSE finish event.
+                finish_metadata["usageByNode"] = by_node_dump
             chunks.append(
                 DataPart(type="data-usage", data=usage_sse_payload).to_sse().encode("utf-8")
             )

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -137,11 +137,14 @@ _THINKING_NODES = frozenset({"research", "explain", "recovery"})
 # Nodes whose LLM tokens are emitted as plain visible text
 _ANSWER_NODES = frozenset({"narrator", "direct", "clarifier", "suggester", "followup"})
 
+# Non-streaming background nodes (no SSE text emitted, but tokens must be counted)
+_BACKGROUND_NODES: frozenset[str] = frozenset({"summarizer"})
+
 # Non-streaming pre-research nodes — transformer/scout/planner removed in refactor
 _PREPROCESSING_NODES: frozenset[str] = frozenset()  # transformer/scout/planner removed
 _PREPROCESSING_STATUS: dict[str, str] = {}
 
-_LLM_NODES = _THINKING_NODES | _ANSWER_NODES
+_LLM_NODES = _THINKING_NODES | _ANSWER_NODES | _BACKGROUND_NODES
 
 
 def _unwrap_chat_model_end_output(output: Any) -> Any:
@@ -152,6 +155,26 @@ def _unwrap_chat_model_end_output(output: Any) -> Any:
     if msg is not None:
         return msg
     return output
+
+
+def _extract_model_id_from_message(msg: Any) -> str | None:
+    """Try to read the real deployed model name from an AIMessage's response_metadata.
+
+    LangChain stores the model name returned by the API in ``response_metadata``
+    under ``model_name`` (OpenAI) or ``model`` (Anthropic / Azure).  Using this
+    avoids storing the internal enum value (e.g. ``"chat-model-reasoning"``) as
+    the model ID in usage records.
+    """
+    if msg is None:
+        return None
+    rm = getattr(msg, "response_metadata", None)
+    if not isinstance(rm, dict):
+        return None
+    for key in ("model_name", "model", "model_id"):
+        value = rm.get(key)
+        if value and isinstance(value, str):
+            return value
+    return None
 
 
 class _SseBridgeState:
@@ -166,6 +189,7 @@ class _SseBridgeState:
         "_routing_reasoning",
         "_answer_text_parts",
         "_usage_accum",
+        "_usage_by_node",
         "_db_parts",
         "_research_text_buf",
         "_research_tool_parts",
@@ -195,6 +219,7 @@ class _SseBridgeState:
         self._routing_reasoning: str = ""
         self._answer_text_parts: list[str] = []
         self._usage_accum: DataUsageData | None = None
+        self._usage_by_node: dict[str, DataUsageData] = {}
         self._db_parts: list[dict] = []
         self._research_text_buf: list[str] = []
         self._research_tool_parts: dict[str, dict] = {}
@@ -272,27 +297,39 @@ class _SseBridgeState:
         }
         self._db_parts.append(inner)
 
-    def add_usage_from_usage_fragment(self, raw: dict[str, Any], *, model_key: str) -> None:
+    def _accumulate_node_usage(self, node: str, piece: DataUsageData) -> None:
+        """Add piece to both the total accumulator and the per-node accumulator."""
+        if self._usage_accum is None:
+            self._usage_accum = piece
+        else:
+            self._usage_accum = self._usage_accum + piece
+        if node:
+            if node not in self._usage_by_node:
+                self._usage_by_node[node] = piece
+            else:
+                self._usage_by_node[node] = self._usage_by_node[node] + piece
+
+    def add_usage_from_usage_fragment(
+        self, raw: dict[str, Any], *, model_key: str, node: str = ""
+    ) -> None:
         """Merge one usage blob (OpenAI or LangChain-shaped) into the accumulator."""
         if not raw or not usage_dict_is_nonzero(raw):
             return
         mk = model_key or str(self.input_state.get("model_type") or "")
         piece = coerce_graph_final_usage_to_data_usage(raw, model=mk)
-        if self._usage_accum is None:
-            self._usage_accum = piece
-            return
-        try:
-            self._usage_accum = self._usage_accum + piece
-        except ValueError as exc:
-            logger.warning("Skipping additive usage merge: %s", exc)
+        self._accumulate_node_usage(node, piece)
 
-    def add_usage_from_message(self, output_msg: Any) -> None:
+    def add_usage_from_message(self, output_msg: Any, *, node: str = "") -> None:
         unwrapped = _unwrap_chat_model_end_output(output_msg)
         raw = usage_dict_from_langchain_message(unwrapped)
         if not raw:
             return
-        model_key = str(self.input_state.get("model_type") or "")
-        self.add_usage_from_usage_fragment(raw, model_key=model_key)
+        # Prefer the actual model name from the API response over the internal
+        # enum value stored in model_type (e.g. "chat-model-reasoning").
+        model_key = _extract_model_id_from_message(unwrapped) or str(
+            self.input_state.get("model_type") or ""
+        )
+        self.add_usage_from_usage_fragment(raw, model_key=model_key, node=node)
 
     def make_stage_sse(self, stage: str) -> bytes | None:
         if stage in self._stages_emitted:
@@ -335,7 +372,7 @@ class _SseBridgeState:
             ru = output.get("router_usage")
             if isinstance(ru, dict):
                 routing_model = str(getattr(settings, "ROUTING_MODEL", "") or "")
-                self.add_usage_from_usage_fragment(ru, model_key=routing_model)
+                self.add_usage_from_usage_fragment(ru, model_key=routing_model, node="router")
             if reasoning:
                 reason_id = f"routing-reason-{self.message_id}"
                 for part in (
@@ -370,7 +407,7 @@ class _SseBridgeState:
                 )
 
         elif evt_type == "on_chat_model_end" and node in _LLM_NODES:
-            self.add_usage_from_message(data.get("output"))
+            self.add_usage_from_message(data.get("output"), node=node)
 
         elif not self._manual_tool_sse and evt_type == "on_tool_start" and node in _THINKING_NODES:
             chunks.extend(
@@ -605,10 +642,13 @@ class _SseBridgeState:
         finish_metadata: dict = {}
         if self._usage_accum:
             finish_metadata["usage"] = DataUsageEvent(data=self._usage_accum).model_dump()
+            usage_sse_payload = self._usage_accum.model_dump()
+            if self._usage_by_node:
+                usage_sse_payload["byNode"] = {
+                    k: v.model_dump() for k, v in self._usage_by_node.items()
+                }
             chunks.append(
-                DataPart(type="data-usage", data=self._usage_accum.model_dump())
-                .to_sse()
-                .encode("utf-8")
+                DataPart(type="data-usage", data=usage_sse_payload).to_sse().encode("utf-8")
             )
         chunks.append(
             FinishMessagePart(
@@ -629,18 +669,27 @@ class _SseBridgeState:
                 list(bucket.parts) if bucket is not None and hasattr(bucket, "parts") else []
             )
             model_key = str(self.input_state.get("model_type") or "")
-            merged: DataUsageData | None = None
-            for raw in fallback_parts:
+            for entry in fallback_parts:
+                # New format: {"node": str, "raw": dict}
+                if isinstance(entry, dict) and "raw" in entry:
+                    raw = entry["raw"]
+                    entry_node = entry.get("node") or ""
+                else:
+                    # Legacy bare dict fallback
+                    raw = entry
+                    entry_node = ""
                 if not isinstance(raw, dict) or not usage_dict_is_nonzero(raw):
                     continue
                 try:
                     piece = coerce_graph_final_usage_to_data_usage(raw, model=model_key)
-                    merged = piece if merged is None else merged + piece
-                except (ValueError, TypeError) as exc:
+                except TypeError as exc:
                     logger.debug("LLM usage fallback piece skipped: %s", exc)
                     continue
-            self._usage_accum = merged
-        out["final_usage"] = self._usage_accum.model_dump() if self._usage_accum else None
+                self._accumulate_node_usage(entry_node, piece)
+        usage_dict = self._usage_accum.model_dump() if self._usage_accum else None
+        if usage_dict and self._usage_by_node:
+            usage_dict["byNode"] = {k: v.model_dump() for k, v in self._usage_by_node.items()}
+        out["final_usage"] = usage_dict
         out["assistant_parts_for_db"] = self._db_parts
         out["stream_failed"] = self._stream_failed
         # Expose session summary for persistence by chat.py

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -121,11 +121,12 @@ def _terminal_error_chunks(br: _SseBridgeState, root: BaseException, error_id: s
     return chunks
 
 
-# Nodes whose LLM tokens go into the data-thinking envelope
-_THINKING_NODES = frozenset({"research"})
+# Nodes whose LLM tokens go into the data-thinking envelope (hidden in collapsible panel)
+# summarizer and planner are non-streaming → they don't appear in either set
+_THINKING_NODES = frozenset({"research", "explain", "scout", "recovery"})
 
 # Nodes whose LLM tokens are emitted as plain visible text
-_ANSWER_NODES = frozenset({"narrator", "direct"})
+_ANSWER_NODES = frozenset({"narrator", "direct", "clarifier", "suggester", "followup"})
 
 _LLM_NODES = _THINKING_NODES | _ANSWER_NODES
 
@@ -254,12 +255,12 @@ class _SseBridgeState:
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
 
-        if evt_type == "on_chain_start" and evt_name == "research":
+        if evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
             stage_bytes = self.make_stage_sse("interpreting")
             if stage_bytes:
                 chunks.append(stage_bytes)
 
-        elif evt_type == "on_chain_start" and evt_name in ("narrator", "direct"):
+        elif evt_type == "on_chain_start" and evt_name in _ANSWER_NODES:
             self.flush_research_text_to_db()
             stage_bytes = self.make_stage_sse("generating")
             if stage_bytes:
@@ -368,7 +369,7 @@ class _SseBridgeState:
         tool_name = str(payload.get("tool_name") or "tool")
         tool_call_id = str(payload.get("tool_call_id") or tool_name)
         if phase == "start":
-            if graph_node == "research":
+            if graph_node in _THINKING_NODES:
                 return self._chunks_research_tool_start(
                     tool_call_id=tool_call_id,
                     tool_name=tool_name,
@@ -382,7 +383,7 @@ class _SseBridgeState:
                 )
         elif phase == "end":
             raw_out = payload.get("output", "")
-            if graph_node == "research":
+            if graph_node in _THINKING_NODES:
                 return self._chunks_research_tool_end(tool_call_id=tool_call_id, output=raw_out)
             if graph_node in _ANSWER_NODES:
                 return self._chunks_answer_tool_end(tool_call_id=tool_call_id, output=raw_out)

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -137,15 +137,9 @@ _THINKING_NODES = frozenset({"research", "explain", "recovery"})
 # Nodes whose LLM tokens are emitted as plain visible text
 _ANSWER_NODES = frozenset({"narrator", "direct", "clarifier", "suggester", "followup"})
 
-# Non-streaming pre-research nodes — we emit stage/status text on their lifecycle events
-_PREPROCESSING_NODES = frozenset({"transformer", "scout", "planner"})
-
-# Human-readable status shown in the thinking panel when each preprocessing node starts
-_PREPROCESSING_STATUS: dict[str, str] = {
-    "transformer": "Analyzing question…",
-    "scout": "Checking data availability…",
-    "planner": "Building research plan…",
-}
+# Non-streaming pre-research nodes — transformer/scout/planner removed in refactor
+_PREPROCESSING_NODES: frozenset[str] = frozenset()  # transformer/scout/planner removed
+_PREPROCESSING_STATUS: dict[str, str] = {}
 
 _LLM_NODES = _THINKING_NODES | _ANSWER_NODES
 
@@ -315,61 +309,7 @@ class _SseBridgeState:
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
 
-        if evt_type == "on_chain_start" and evt_name in _PREPROCESSING_NODES:
-            # Emit "interpreting" stage (once) + animated node-progress "running" event
-            stage_bytes = self.make_stage_sse("interpreting")
-            if stage_bytes:
-                chunks.append(stage_bytes)
-            status_msg = _PREPROCESSING_STATUS.get(evt_name, "")
-            if status_msg:
-                chunks.extend(self._node_progress_chunks(evt_name, "running", status_msg))
-
-        elif evt_type == "on_chain_end" and evt_name == "transformer":
-            output: dict = data.get("output", {}) or {}
-            translated: list = output.get("translated_queries") or []
-            if translated:
-                lines = " · ".join(translated[:4])  # compact inline list
-                done_msg = f"Queries identified: {lines}"
-                if len(translated) > 4:
-                    done_msg += f" (+{len(translated) - 4} more)"
-            else:
-                done_msg = "Routing to definition lookup"
-            chunks.extend(self._node_progress_chunks("transformer", "done", done_msg))
-
-        elif evt_type == "on_chain_end" and evt_name == "scout":
-            output = data.get("output", {}) or {}
-            findings: dict = output.get("scout_findings") or {}
-            available = findings.get("available", True)
-            indicators = findings.get("indicators") or []
-            if available and indicators:
-                names = ", ".join(i.get("name", "") for i in indicators[:3] if i.get("name"))
-                done_msg = f"Data found: {names}" if names else "Data available"
-            elif available:
-                done_msg = "Data available"
-            else:
-                done_msg = "No matching data — will try alternatives"
-            chunks.extend(self._node_progress_chunks("scout", "done", done_msg))
-
-        elif evt_type == "on_chain_end" and evt_name == "planner":
-            output = data.get("output", {}) or {}
-            plan: list = output.get("query_plan") or []
-            if plan:
-                purposes = [
-                    t.get("purpose") or t.get("indicator_id", "")
-                    for t in plan[:3]
-                    if t.get("purpose") or t.get("indicator_id")
-                ]
-                summary = "; ".join(p for p in purposes if p)
-                done_msg = (
-                    f"{len(plan)} task{'s' if len(plan) != 1 else ''}: {summary}"
-                    if summary
-                    else f"{len(plan)} tasks planned"
-                )
-            else:
-                done_msg = "Plan ready"
-            chunks.extend(self._node_progress_chunks("planner", "done", done_msg))
-
-        elif evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
+        if evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
             stage_bytes = self.make_stage_sse("interpreting")
             if stage_bytes:
                 chunks.append(stage_bytes)

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -64,8 +64,9 @@ from app.ai.protocols.stream import (
     ToolInputStartPart,
     ToolOutputAvailablePart,
 )
-from app.config import settings
 from app.utils.error_id import USER_MESSAGE_GENERIC, new_error_id
+
+from .llm_invoke import LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT
 
 try:
     from litellm.exceptions import ContentPolicyViolationError
@@ -137,8 +138,10 @@ _THINKING_NODES = frozenset({"research", "explain", "recovery"})
 # Nodes whose LLM tokens are emitted as plain visible text
 _ANSWER_NODES = frozenset({"narrator", "direct", "clarifier", "suggester", "followup"})
 
-# Non-streaming background nodes (no SSE text emitted, but tokens must be counted)
-_BACKGROUND_NODES: frozenset[str] = frozenset({"summarizer"})
+# Non-streaming background nodes (no SSE text emitted, but tokens must be counted).
+# "router" uses ChatLiteLLM via check_intent() so its on_chat_model_end fires here;
+# "summarizer" compresses history in the background.
+_BACKGROUND_NODES: frozenset[str] = frozenset({"router", "summarizer"})
 
 # Non-streaming pre-research nodes — transformer/scout/planner removed in refactor
 _PREPROCESSING_NODES: frozenset[str] = frozenset()  # transformer/scout/planner removed
@@ -366,18 +369,11 @@ class _SseBridgeState:
             self._final_graph_state = data["output"]
 
         elif evt_type == "on_chain_end" and evt_name == "router":
+            # Usage is now tracked automatically via on_chat_model_end (router is in
+            # _BACKGROUND_NODES) — no manual router_usage extraction needed here.
             output: dict = data.get("output", {}) or {}
             reasoning: str = output.get("routing_reasoning", "")
             self._routing_reasoning = reasoning
-            ru = output.get("router_usage")
-            if isinstance(ru, dict):
-                ru = dict(ru)  # copy before mutating
-                # routing.py embeds the actual deployed model name under "_model";
-                # pop it here so it doesn't confuse token-count parsing downstream.
-                routing_model = ru.pop("_model", None) or str(
-                    getattr(settings, "ROUTING_MODEL", "") or ""
-                )
-                self.add_usage_from_usage_fragment(ru, model_key=routing_model, node="router")
             if reasoning:
                 reason_id = f"routing-reason-{self.message_id}"
                 for part in (
@@ -644,6 +640,16 @@ class _SseBridgeState:
         self.flush_narrator_segment_to_db()
         if self.answer_text_started:
             chunks.append(TextEndPart(id=self.text_part_id).to_sse().encode("utf-8"))
+        if isinstance(self._final_graph_state, dict) and self._final_graph_state.get(
+            "content_policy_blocked"
+        ):
+            blocked_id = f"followup-blocked-{self.message_id}"
+            for part in (
+                TextStartPart(id=blocked_id),
+                TextDeltaPart(id=blocked_id, delta=LLM_POLICY_BLOCKED_TEXT),
+                TextEndPart(id=blocked_id),
+            ):
+                chunks.append(part.to_sse().encode("utf-8"))
         finish_metadata: dict = {}
         if self._usage_accum:
             finish_metadata["usage"] = DataUsageEvent(data=self._usage_accum).model_dump()
@@ -709,6 +715,22 @@ class _SseBridgeState:
             trace_parts = self._final_graph_state.get("agent_trace_parts") or []
             if trace_parts:
                 self._db_parts.extend(trace_parts)
+            # Non-streaming follow-up may only exist on graph state — persist short markers
+            assistant_tail = self._final_graph_state.get("assistant_parts") or []
+            for p in assistant_tail:
+                if not isinstance(p, dict) or p.get("type") != "text":
+                    continue
+                tx = (p.get("text") or "").strip()
+                if tx not in (LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT):
+                    continue
+                if any(
+                    isinstance(x, dict)
+                    and x.get("type") == "text"
+                    and (x.get("text") or "").strip() == tx
+                    for x in self._db_parts
+                ):
+                    continue
+                self._db_parts.append(dict(p))
 
 
 async def stream_graph_to_sse(

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -32,6 +32,13 @@ import logging
 from typing import Any, AsyncGenerator
 from uuid import uuid4
 
+from app.ai.graph.graph_debug_log import (
+    completion_text_from_model_output,
+    graph_llm_log_enabled,
+    log_llm_completion_preview,
+    log_llm_stream_delta,
+    log_llm_tool_manual,
+)
 from app.ai.graph.tool_output_normalize import normalize_tool_output_for_ui
 from app.ai.observability.token_usage import (
     DataUsageData,
@@ -122,11 +129,22 @@ def _terminal_error_chunks(br: _SseBridgeState, root: BaseException, error_id: s
 
 
 # Nodes whose LLM tokens go into the data-thinking envelope (hidden in collapsible panel)
-# summarizer and planner are non-streaming → they don't appear in either set
-_THINKING_NODES = frozenset({"research", "explain", "scout", "recovery"})
+# summarizer, planner, scout, transformer are non-streaming → LLM text not emitted;
+# scout tool events still appear via the manual notify queue
+_THINKING_NODES = frozenset({"research", "explain", "recovery"})
 
 # Nodes whose LLM tokens are emitted as plain visible text
 _ANSWER_NODES = frozenset({"narrator", "direct", "clarifier", "suggester", "followup"})
+
+# Non-streaming pre-research nodes — we emit stage/status text on their lifecycle events
+_PREPROCESSING_NODES = frozenset({"transformer", "scout", "planner"})
+
+# Human-readable status shown in the thinking panel when each preprocessing node starts
+_PREPROCESSING_STATUS: dict[str, str] = {
+    "transformer": "Analyzing question…",
+    "scout": "Checking data availability…",
+    "planner": "Building research plan…",
+}
 
 _LLM_NODES = _THINKING_NODES | _ANSWER_NODES
 
@@ -161,6 +179,8 @@ class _SseBridgeState:
         "_stages_emitted",
         "_manual_tool_sse",
         "_stream_failed",
+        "_final_graph_state",
+        "_preprocessing_run_ids",
     )
 
     def __init__(
@@ -187,6 +207,45 @@ class _SseBridgeState:
         self._answer_tool_parts: dict[str, dict] = {}
         self._stages_emitted: set[str] = set()
         self._stream_failed = False
+        self._final_graph_state: dict = {}
+        # Stable run-id per preprocessing node — shared between start and end events
+        # so the frontend can match them and animate running → done in place.
+        self._preprocessing_run_ids: dict[str, str] = {}
+
+    def _node_progress_chunks(
+        self,
+        node: str,
+        status: str,
+        message: str,
+    ) -> list[bytes]:
+        """Emit a node-progress event into the data-thinking panel.
+
+        status="running" → frontend shows animated spinner + message text.
+        status="done"    → frontend replaces spinner with checkmark + result text.
+
+        Both events share the same stable ``id`` keyed by node name so the
+        frontend Map entry is overwritten in-place (running → done transition).
+        """
+        if status == "running":
+            run_id = f"np-{node}-{uuid4().hex[:8]}"
+            self._preprocessing_run_ids[node] = run_id
+        else:
+            run_id = self._preprocessing_run_ids.get(node, f"np-{node}-{uuid4().hex[:8]}")
+
+        return [
+            DataThinkingPart(
+                id=self.message_id,
+                data={
+                    "type": "node-progress",
+                    "id": run_id,
+                    "node": node,
+                    "status": status,
+                    "message": message,
+                },
+            )
+            .to_sse()
+            .encode("utf-8")
+        ]
 
     def flush_research_text_to_db(self) -> None:
         if not self._research_text_buf:
@@ -255,7 +314,61 @@ class _SseBridgeState:
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
 
-        if evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
+        if evt_type == "on_chain_start" and evt_name in _PREPROCESSING_NODES:
+            # Emit "interpreting" stage (once) + animated node-progress "running" event
+            stage_bytes = self.make_stage_sse("interpreting")
+            if stage_bytes:
+                chunks.append(stage_bytes)
+            status_msg = _PREPROCESSING_STATUS.get(evt_name, "")
+            if status_msg:
+                chunks.extend(self._node_progress_chunks(evt_name, "running", status_msg))
+
+        elif evt_type == "on_chain_end" and evt_name == "transformer":
+            output: dict = data.get("output", {}) or {}
+            translated: list = output.get("translated_queries") or []
+            if translated:
+                lines = " · ".join(translated[:4])  # compact inline list
+                done_msg = f"Queries identified: {lines}"
+                if len(translated) > 4:
+                    done_msg += f" (+{len(translated) - 4} more)"
+            else:
+                done_msg = "Routing to definition lookup"
+            chunks.extend(self._node_progress_chunks("transformer", "done", done_msg))
+
+        elif evt_type == "on_chain_end" and evt_name == "scout":
+            output = data.get("output", {}) or {}
+            findings: dict = output.get("scout_findings") or {}
+            available = findings.get("available", True)
+            indicators = findings.get("indicators") or []
+            if available and indicators:
+                names = ", ".join(i.get("name", "") for i in indicators[:3] if i.get("name"))
+                done_msg = f"Data found: {names}" if names else "Data available"
+            elif available:
+                done_msg = "Data available"
+            else:
+                done_msg = "No matching data — will try alternatives"
+            chunks.extend(self._node_progress_chunks("scout", "done", done_msg))
+
+        elif evt_type == "on_chain_end" and evt_name == "planner":
+            output = data.get("output", {}) or {}
+            plan: list = output.get("query_plan") or []
+            if plan:
+                purposes = [
+                    t.get("purpose") or t.get("indicator_id", "")
+                    for t in plan[:3]
+                    if t.get("purpose") or t.get("indicator_id")
+                ]
+                summary = "; ".join(p for p in purposes if p)
+                done_msg = (
+                    f"{len(plan)} task{'s' if len(plan) != 1 else ''}: {summary}"
+                    if summary
+                    else f"{len(plan)} tasks planned"
+                )
+            else:
+                done_msg = "Plan ready"
+            chunks.extend(self._node_progress_chunks("planner", "done", done_msg))
+
+        elif evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
             stage_bytes = self.make_stage_sse("interpreting")
             if stage_bytes:
                 chunks.append(stage_bytes)
@@ -265,6 +378,14 @@ class _SseBridgeState:
             stage_bytes = self.make_stage_sse("generating")
             if stage_bytes:
                 chunks.append(stage_bytes)
+
+        elif (
+            evt_type == "on_chain_end"
+            and not metadata.get("langgraph_node")
+            and isinstance(data.get("output"), dict)
+        ):
+            # Top-level graph on_chain_end — capture final state for persistence
+            self._final_graph_state = data["output"]
 
         elif evt_type == "on_chain_end" and evt_name == "router":
             output: dict = data.get("output", {}) or {}
@@ -294,6 +415,11 @@ class _SseBridgeState:
             chunk = data.get("chunk")
             content: str = chunk.content if (chunk and hasattr(chunk, "content")) else ""
             if content:
+                log_llm_stream_delta(
+                    message_id=self.message_id,
+                    graph_node=node,
+                    delta=content,
+                )
                 self._research_text_buf.append(content)
                 inner_id = f"research-{self.message_id}"
                 chunks.append(
@@ -309,6 +435,14 @@ class _SseBridgeState:
 
         elif evt_type == "on_chat_model_end" and node in _LLM_NODES:
             self.add_usage_from_message(data.get("output"))
+            out_msg = _unwrap_chat_model_end_output(data.get("output"))
+            end_text = completion_text_from_model_output(out_msg)
+            if end_text:
+                log_llm_completion_preview(
+                    message_id=self.message_id,
+                    graph_node=node,
+                    text=end_text,
+                )
 
         elif not self._manual_tool_sse and evt_type == "on_tool_start" and node in _THINKING_NODES:
             chunks.extend(
@@ -333,6 +467,11 @@ class _SseBridgeState:
             chunk = data.get("chunk")
             content = chunk.content if (chunk and hasattr(chunk, "content")) else ""
             if content:
+                log_llm_stream_delta(
+                    message_id=self.message_id,
+                    graph_node=node,
+                    delta=content,
+                )
                 self._answer_text_parts.append(content)
                 self._narrator_segment.append(content)
                 if not self.answer_text_started:
@@ -368,6 +507,23 @@ class _SseBridgeState:
         graph_node = payload.get("graph_node", "")
         tool_name = str(payload.get("tool_name") or "tool")
         tool_call_id = str(payload.get("tool_call_id") or tool_name)
+        if graph_llm_log_enabled():
+            if phase == "start":
+                log_llm_tool_manual(
+                    message_id=self.message_id,
+                    graph_node=str(graph_node),
+                    tool_name=tool_name,
+                    phase="start",
+                    payload_summary=f"input={payload.get('input', {})!r}",
+                )
+            elif phase == "end":
+                log_llm_tool_manual(
+                    message_id=self.message_id,
+                    graph_node=str(graph_node),
+                    tool_name=tool_name,
+                    phase="end",
+                    payload_summary=f"output={payload.get('output', '')!r}",
+                )
         if phase == "start":
             if graph_node in _THINKING_NODES:
                 return self._chunks_research_tool_start(
@@ -564,6 +720,16 @@ class _SseBridgeState:
         out["final_usage"] = self._usage_accum.model_dump() if self._usage_accum else None
         out["assistant_parts_for_db"] = self._db_parts
         out["stream_failed"] = self._stream_failed
+        # Expose session summary for persistence by chat.py
+        if self._final_graph_state:
+            out["session_summary"] = self._final_graph_state.get("session_summary") or ""
+            out["summarized_message_count"] = (
+                self._final_graph_state.get("summarized_message_count") or 0
+            )
+            # Merge agent trace parts into db_parts for persistence
+            trace_parts = self._final_graph_state.get("agent_trace_parts") or []
+            if trace_parts:
+                self._db_parts.extend(trace_parts)
 
 
 async def stream_graph_to_sse(

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -16,13 +16,26 @@ class ChatPipelineState(TypedDict):
     tool_set: dict[str, Any]
 
     # ── Router output ──────────────────────────────────────────────────────────
-    intent: str  # "RESEARCH" | "DIRECT"
+    intent: str  # "RESEARCH" | "DIRECT" | "CLARIFY" | "OUT_OF_SCOPE" | "EXPLAIN"
     routing_reasoning: str  # brief explanation for the SSE thinking panel
-    # When set ("RESEARCH" | "DIRECT"), router_node skips LLM classification (e.g. v1 chat stream).
+    # When set, router_node skips LLM classification (e.g. v1 chat stream).
     forced_intent: NotRequired[str | None]
+    # Missing slots populated by router when intent == CLARIFY
+    missing_slots: NotRequired[list[str]]
+    # Confidence score from the routing LLM (0.0–1.0), for diagnostics/telemetry
+    routing_confidence: NotRequired[float]
+    # Detected language of the user's message (e.g. "French", "Spanish", "English")
+    # Used to instruct all response nodes to reply in the same language.
+    detected_language: NotRequired[str]
 
-    # ── Research node output ───────────────────────────────────────────────────
+    # ── Research / Explain node output ────────────────────────────────────────
     research_packet: str  # Planner's notes / data summary for the Writer
+
+    # ── Clarifier node output ─────────────────────────────────────────────────
+    clarification_question: NotRequired[str]  # the single question emitted to the user
+
+    # ── Suggester node output ─────────────────────────────────────────────────
+    suggestions: NotRequired[list[str]]  # 3-5 bridging questions (for telemetry)
 
     # ── Final output (consumed by chat.py for DB save) ────────────────────────
     assistant_parts: list[dict]  # assembled message parts (thinking + chat)
@@ -32,3 +45,18 @@ class ChatPipelineState(TypedDict):
     _tool_sse_queue: NotRequired[Any]  # asyncio.Queue of manual tool payloads
     # Same object as graph input; nodes append usage if stream events omit token counts
     _usage_fallback_bucket: NotRequired[Any]
+
+    # ── Multi-agent expansion fields ──────────────────────────────────────────
+    # Rolling summary of compressed older turns; injected as context by research/narrator/explain
+    session_summary: NotRequired[str]
+    # Data availability check results from scout node
+    scout_findings: NotRequired[dict]
+    # Structured execution plan from planner node
+    query_plan: NotRequired[list[dict]]
+    # Follow-up questions generated post-narrator
+    followup_questions: NotRequired[list[str]]
+    # Flag to prevent double recovery loops
+    recovery_attempted: NotRequired[bool]
+    # Translated data queries produced by the transformer node for analytical questions
+    # (e.g. "What are Ghana's economic challenges?" → ["Ghana GDP growth 2014-2024", ...])
+    translated_queries: NotRequired[list[str]]

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -29,7 +29,10 @@ class ChatPipelineState(TypedDict):
     detected_language: NotRequired[str]
 
     # ── Research / Explain node output ────────────────────────────────────────
-    research_packet: str  # Planner's notes / data summary for the Writer
+    research_packet: str  # Routing metadata packet from the Research Agent
+    # Raw tool outputs from the research loop — injected into narrator directly
+    # so numbers never have to be re-transcribed through an extra LLM pass.
+    research_tool_results: NotRequired[list[dict]]
 
     # ── Clarifier node output ─────────────────────────────────────────────────
     clarification_question: NotRequired[str]  # the single question emitted to the user
@@ -46,21 +49,12 @@ class ChatPipelineState(TypedDict):
     # Same object as graph input; nodes append usage if stream events omit token counts
     _usage_fallback_bucket: NotRequired[Any]
 
-    # ── Multi-agent expansion fields ──────────────────────────────────────────
-    # Rolling summary of compressed older turns; injected as context by research/narrator/explain
+    # ── Session memory ────────────────────────────────────────────────────────
+    # Rolling summary of compressed older turns; injected as context by nodes
     session_summary: NotRequired[str]
-    # Data availability check results from scout node
-    scout_findings: NotRequired[dict]
-    # Structured execution plan from planner node
-    query_plan: NotRequired[list[dict]]
+    # How many openai_messages were captured in the current session_summary
+    summarized_message_count: NotRequired[int]
     # Follow-up questions generated post-narrator
     followup_questions: NotRequired[list[str]]
-    # Flag to prevent double recovery loops
-    recovery_attempted: NotRequired[bool]
-    # Translated data queries produced by the transformer node for analytical questions
-    # (e.g. "What are Ghana's economic challenges?" → ["Ghana GDP growth 2014-2024", ...])
-    translated_queries: NotRequired[list[str]]
-    # How many openai_messages were captured in the current session_summary (for incremental re-summarization)
-    summarized_message_count: NotRequired[int]
-    # Internal agent outputs from scout/planner/transformer nodes for debugging/analytics
+    # Internal agent outputs for debugging/analytics
     agent_trace_parts: NotRequired[list[dict]]

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -56,5 +56,7 @@ class ChatPipelineState(TypedDict):
     summarized_message_count: NotRequired[int]
     # Follow-up questions generated post-narrator
     followup_questions: NotRequired[list[str]]
+    # Set when followup (or another node) surfaces LLM_POLICY_BLOCKED_TEXT under policy
+    content_policy_blocked: NotRequired[bool]
     # Internal agent outputs for debugging/analytics
     agent_trace_parts: NotRequired[list[dict]]

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -60,3 +60,7 @@ class ChatPipelineState(TypedDict):
     # Translated data queries produced by the transformer node for analytical questions
     # (e.g. "What are Ghana's economic challenges?" → ["Ghana GDP growth 2014-2024", ...])
     translated_queries: NotRequired[list[str]]
+    # How many openai_messages were captured in the current session_summary (for incremental re-summarization)
+    summarized_message_count: NotRequired[int]
+    # Internal agent outputs from scout/planner/transformer nodes for debugging/analytics
+    agent_trace_parts: NotRequired[list[dict]]

--- a/backend/app/ai/observability/token_usage.py
+++ b/backend/app/ai/observability/token_usage.py
@@ -12,32 +12,26 @@ logger = logging.getLogger(__name__)
 
 
 class CostUSD(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     inputUSD: NonNegativeFloat = 0.0
     outputUSD: NonNegativeFloat = 0.0
     cacheReadUSD: NonNegativeFloat = 0.0
-
-    # keep aliases if you truly need them; otherwise consider dropping them
-    inputTokenUSD: NonNegativeFloat = 0.0
-    outputTokenUSD: NonNegativeFloat = 0.0
-    cacheReadsUSD: NonNegativeFloat = 0.0
-
+    reasoningUSD: NonNegativeFloat = 0.0
     totalUSD: NonNegativeFloat = 0.0
 
     def __add__(self, other: "CostUSD") -> "CostUSD":
         input_usd = self.inputUSD + other.inputUSD
         output_usd = self.outputUSD + other.outputUSD
         cache_usd = self.cacheReadUSD + other.cacheReadUSD
+        reasoning_usd = self.reasoningUSD + other.reasoningUSD
 
         return CostUSD(
             inputUSD=input_usd,
             outputUSD=output_usd,
             cacheReadUSD=cache_usd,
-            totalUSD=input_usd + output_usd + cache_usd,
-            inputTokenUSD=self.inputTokenUSD + other.inputTokenUSD,
-            outputTokenUSD=self.outputTokenUSD + other.outputTokenUSD,
-            cacheReadsUSD=self.cacheReadsUSD + other.cacheReadsUSD,
+            reasoningUSD=reasoning_usd,
+            totalUSD=input_usd + output_usd + cache_usd + reasoning_usd,
         )
 
 
@@ -75,8 +69,18 @@ class DataUsageData(BaseModel):
     modelId: str
 
     def __add__(self, other: "DataUsageData") -> "DataUsageData":
+        # When models differ (e.g. routing model + chat model), combine IDs and
+        # sum tokens/costs.  Costs are pre-computed per-model before accumulation
+        # so the summed costUSD is still accurate despite the model mismatch.
+        # Use an ordered-dict trick to deduplicate while preserving insertion order,
+        # so repeated additions of the same model don't grow the string unboundedly.
         if self.modelId != other.modelId:
-            raise ValueError(f"Cannot add usage across models: {self.modelId} vs {other.modelId}")
+            seen: dict[str, None] = dict.fromkeys(
+                self.modelId.split(" + ") + other.modelId.split(" + ")
+            )
+            combined_id = " + ".join(seen)
+        else:
+            combined_id = self.modelId
 
         return DataUsageData(
             inputTokens=self.inputTokens + other.inputTokens,
@@ -86,7 +90,7 @@ class DataUsageData(BaseModel):
             cachedInputTokens=self.cachedInputTokens + other.cachedInputTokens,
             context=self.context + other.context,
             costUSD=self.costUSD + other.costUSD,
-            modelId=self.modelId,
+            modelId=combined_id,
         )
 
 
@@ -308,6 +312,13 @@ def usage_dict_from_langchain_message(msg: Any) -> dict[str, Any] | None:
 
     Prefers ``AIMessage.usage_metadata``; falls back to LiteLLM-style fields inside
     ``response_metadata`` (``token_usage``, ``usage``).
+
+    LangChain stores cache/reasoning detail under ``input_token_details.cache_read``
+    and ``output_token_details.reasoning`` — different from the raw OpenAI API shape
+    that ``extract_usage`` was written for.  We normalise them here into the nested
+    keys ``extract_usage`` already knows (``prompt_tokens_details.cached_tokens`` and
+    ``completion_tokens_details.reasoning_tokens``) so the rest of the pipeline just
+    works without needing a second code path.
     """
     if msg is None:
         return None
@@ -315,6 +326,18 @@ def usage_dict_from_langchain_message(msg: Any) -> dict[str, Any] | None:
     um = getattr(msg, "usage_metadata", None)
     flat = _usage_mapping_to_dict(um)
     if flat and usage_dict_is_nonzero(flat):
+        # Translate LangChain detail dicts → OpenAI-style nested keys so
+        # extract_usage can find cached and reasoning token counts.
+        in_details = flat.get("input_token_details")
+        out_details = flat.get("output_token_details")
+        if isinstance(in_details, dict):
+            cache_read = _int_or_zero(in_details.get("cache_read"))
+            if cache_read:
+                flat.setdefault("prompt_tokens_details", {})["cached_tokens"] = cache_read
+        if isinstance(out_details, dict):
+            reasoning = _int_or_zero(out_details.get("reasoning"))
+            if reasoning:
+                flat.setdefault("completion_tokens_details", {})["reasoning_tokens"] = reasoning
         return flat
 
     rm = getattr(msg, "response_metadata", None)
@@ -348,15 +371,16 @@ class UsageFallbackBucket:
 
     def __init__(self) -> None:
         self.parts: list[dict[str, Any]] = []
+        # Each entry: {"node": str, "raw": dict}
 
 
-def append_llm_usage_fallback(bucket: Any, msg: Any) -> None:
+def append_llm_usage_fallback(bucket: Any, msg: Any, *, node: str = "") -> None:
     """Append non-empty usage from an ``AIMessage`` into a :class:`UsageFallbackBucket`."""
     if bucket is None or not hasattr(bucket, "parts"):
         return
     raw = usage_dict_from_langchain_message(msg)
     if raw and usage_dict_is_nonzero(raw):
-        bucket.parts.append(raw)
+        bucket.parts.append({"node": node, "raw": raw})
 
 
 def coerce_graph_final_usage_to_data_usage(raw: Dict[str, Any], *, model: str) -> DataUsageData:
@@ -409,6 +433,10 @@ def build_data_usage_event(
     input_usd = cache_miss_tokens * p.input_per_token
     output_usd = u.completion_tokens * p.output_per_token
     cache_read_usd = u.cached_tokens * p.cache_read_per_token
+    # Reasoning tokens are a subset of completion_tokens; price at the output rate.
+    # LiteLLM doesn't expose a dedicated reasoning_cost_per_token yet, so this is
+    # the best available approximation.
+    reasoning_usd = u.reasoning_tokens * p.output_per_token
     total_usd = input_usd + output_usd + cache_read_usd
 
     return DataUsageEvent(
@@ -424,11 +452,8 @@ def build_data_usage_event(
                 inputUSD=input_usd,
                 outputUSD=output_usd,
                 cacheReadUSD=cache_read_usd,
+                reasoningUSD=reasoning_usd,
                 totalUSD=total_usd,
-                # aliases
-                inputTokenUSD=input_usd,
-                outputTokenUSD=output_usd,
-                cacheReadsUSD=cache_read_usd,
             ),
             modelId=model_id,
         ),

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -499,7 +499,7 @@ Document tools are not available. When asked to write code, provide it in markdo
 # ---------------------------------------------------------------------------
 def get_routing_system_prompt() -> str:
     """Intent router: classifies user message into one of five intent types."""
-    return """You are an intent router for the Data360 Chat assistant. Classify the user's message into exactly one of five intents. Respond in the user's language. Push back politely on stereotypes, bias, or unfounded generalizations.
+    return """You are an intent router for the Data360 Chat assistant. Classify the user's message into exactly one of five intents. Push back politely on stereotypes, bias, or unfounded generalizations.
 
 INTENT DEFINITIONS:
 
@@ -541,13 +541,14 @@ CLASSIFICATION PRIORITY (apply in this order):
 Return ONLY this JSON:
 {
   "intent": "RESEARCH" | "EXPLAIN" | "CLARIFY" | "OUT_OF_SCOPE" | "DIRECT",
-  "reasoning": "brief explanation in the user's language",
+  "reasoning": "brief explanation in English",
   "missing_slots": [],
   "confidence": 0.95,
   "detected_language": "English"
 }
 
 Notes:
+- "reasoning" must ALWAYS be written in English, regardless of the user's language. It is an internal log field shown to developers, not to end users.
 - "missing_slots" is an array: include slot names ["country", "indicator", "time_period"] only when intent is CLARIFY; otherwise leave as empty array [].
 - "confidence" is a float 0.0–1.0 representing your certainty.
 - "detected_language" is the full English name of the language the user wrote in (e.g., "French", "Spanish", "Arabic", "Portuguese", "English"). Always include this field. Default to "English" if uncertain.

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -94,21 +94,54 @@ You are restricted to World Bank, economics, and international development topic
 If the query is clearly unrelated (e.g., recipes, creative writing, entertainment), NEVER attempt research. Set CLARIFYING QUESTION to a polite refusal explaining that Data360 Chat covers development and economics data only, and suggest a relevant alternative topic.
 
 ─── DISAMBIGUATION ────────────────────────────────────────────────
-If the user's query is ambiguous (country name, indicator name, or time period unclear), ask ONE short, focused CLARIFYING QUESTION before fetching data. NEVER assume — clarify first.
-If a country or region is specified, use `data360_find_codelist_value("REF_AREA", "country name")` to verify there is no ambiguity in the name.
+DEFAULT BEHAVIOR: Always attempt to retrieve data. Broad questions are NOT ambiguous.
+For broad or multi-angle questions (e.g., "climate change impact on Bangladesh",
+"labor market challenges in Morocco", "economic development in Vietnam"), choose the
+3-5 most diagnostic indicators and fetch them WITHOUT asking for clarification.
+
+When a [RESEARCH PLAN] block is present in this conversation, follow it directly —
+use the indicator_ids listed. Do NOT re-search or ask for clarification.
+
+Only ask a clarifying question when ALL of the following are true:
+  1. No country is named AND conversation history provides no country context.
+  2. OR the topic is so vague that no useful search query is possible at all
+     (e.g., "show me the data" with no prior context).
+
+NEVER ask for clarification when:
+  - A country is named (even if the topic is broad)
+  - The question asks about "challenges", "trends", "performance", "impact",
+    "situation", or "development" — these always warrant a search
+  - The time period is unspecified (use the last 10 years as the default)
+  - You are unsure which indicator is best (search for it, pick the top result)
+
+If a country or region is specified, use `data360_find_codelist_value("REF_AREA",
+"country name")` to verify the code. Do NOT ask the user to confirm country names.
 
 ─── CONVERSATION CONTEXT ──────────────────────────────────────────
-When the user asks a follow-up question about data that was already retrieved:
+When the user uses pronouns ("these", "those", "that", "them", "the indicators",
+"it") or confirms a previous suggestion ("those sound good", "yes please", "go
+ahead"), they are referring to data or indicators from the most recent assistant
+turn. NEVER ask which indicators they mean — extract them from history.
 
-**For visualization requests** (e.g., "Can you visualize the data for me?", "Show me a chart"):
-- Extract the `database_id`, `indicator_id`, and relevant filters from the previous `data360_get_data` tool call in conversation history
-- Note these details in the research packet under "Visualization readiness" so the Writer can call the viz tools
-- Do NOT call `data360_get_viz_spec` yourself — visualization is handled by the Writer phase
+**For visualization requests** ("can you visualize these in a chart?", "show those
+as a trend", "plot that for the last decade", "chart the indicators above"):
+- DO NOT fetch new data. Scan the conversation history for the most recent
+  `data360_get_data` tool calls and extract their `database_id`, `indicator_id`,
+  and `disaggregation_filters` (country codes, year range).
+- If multiple indicators were fetched in the previous turn, include ALL of them
+  in the ### VIZ: section — the Writer will pass them to the viz tool.
+- DO NOT call `data360_get_viz_spec` yourself — the Writer handles that.
+- DO NOT ask for clarification about which indicators to use.
 
-**For other follow-ups** (e.g., "What does that mean?" or "Is that good?"):
-- Check conversation history for context
-- Reuse previously retrieved data instead of re-fetching with `data360_get_data`
-- Only call `data360_get_data` again if you need NEW data or different parameters
+**For confirmatory follow-ups** ("those sound good", "yes please", "go ahead"):
+- Treat this as confirmation of the most recent question or suggestion in the
+  conversation (e.g., if the previous assistant turn suggested a visualization,
+  proceed with it).
+- Proceed with the action implied by context; do NOT ask for clarification.
+
+**For other follow-ups** ("What does that mean?", "Is that good?"):
+- Reuse previously retrieved data. Only call `data360_get_data` again if you
+  genuinely need NEW data or different parameters.
 
 ───  DATA RETRIEVAL WORKFLOW ───────────────────────────────────────
 Follow this sequence strictly:
@@ -141,7 +174,8 @@ Step 7 — Assess visualization readiness (if user requested a chart):
 Step 8 — Generate API URL (optional):
   If the user wants to access the data directly, call `data360_get_data_api_url` to generate a shareable URL.
 
-If no suitable indicator is found, do not fetch data. Set CLARIFYING QUESTION to explain the gap and suggest a development-related alternative.
+If no suitable indicator is found after a genuine search attempt, note the gap and
+suggest what the user could ask instead. Do NOT use this as an excuse to skip searching.
 
 ─── DATA INTEGRITY ────────────────────────────────────────────────
 - If a requested country (`REF_AREA`) or year (`TIME_PERIOD`) is missing from the tool output, state "Data not available" for that entity.
@@ -150,7 +184,7 @@ If no suitable indicator is found, do not fetch data. Set CLARIFYING QUESTION to
 - Cross-check that each `claim_id` belongs to the correct `REF_AREA` and `TIME_PERIOD`.
 
 ─── CLAIM TAGGING ─────────────────────────────────────────────────
-When you provide any numerical data from the tools, enclose the number in a claim tag: `<claim id="claim_id" policy="policy">value</claim>`.
+When you provide any numerical data from the tools, enclose the number in a claim tag: `<claim id="claim_id">value</claim>`.
 Never invent a claim_id. Always use the `claim_id` from the tool output.
 Numeric values inside claim tags must NOT be quoted (e.g., <claim id="x">1234.5</claim>, not <claim id="x">"1234.5"</claim>).
 
@@ -163,39 +197,42 @@ When the user does not specify a time period, use the latest available data and 
 If comparing series that differ in time coverage, methodology, or definitions, note this clearly in the research packet so the Writer can add a comparability warning. Use `data360_get_metadata` to check methodology differences when relevant.
 
 GENERAL RULES:
-- You MAY ask at most ONE clarifying question per turn.
+- NEVER ask a clarifying question when a country is named. Search and retrieve.
+- You may ask at most ONE clarifying question per turn, and only when truly blocked.
 - Use tools as needed, but avoid unnecessary calls.
 - Never invent tool outputs, indicator IDs, or numbers.
 
 ─── OUTPUT FORMAT ─────────────────────────────────────────────────
+Write ONLY the sections below — nothing else. Keep it concise: the Writer will
+compose the user-facing answer; your job is to hand over the data faithfully.
 
-### RESEARCH PACKET:
-- User intent: <one sentence>
-- Key assumptions (optional): <0-2 bullets>
-- Data360 indicators selected (if any):
-  - <indicator_id> (<database_id>) — <indicator_title> (why selected)
-- Data retrieved (if any):
-  - Describe the dataset briefly (dimensions, coverage).
-  - Provide results in a compact table or bullets (include units, dates, geography).
-- Data Sources:
-  - List the providers or datasets cited in tool outputs (e.g., "World Bank - WDI").
-- Evidence notes:
-  - Caveats, missing coverage, or quality flags.
-  - If coverage is limited (missing countries, years, breakdowns), list them.
-  - If comparing series with different methodology/definitions, note this.
-- Visualization readiness (when user asked for a chart/visualization):
-  - State whether data is suitable for visualization (coverage OK / sparse).
-  - Include: `database_id`, `indicator_id`, `country_code` (or filter), `start_year`/`end_year`.
-  - The Writer will call `data360_get_viz_spec` using these details.
-- API URL (if generated):
-  - If you called `data360_get_data_api_url`, include the URL.
-- Recommended response plan (for Writer):
-  - <1-3 bullets on how to present findings>
-  - Suggest the Writer end with 2-3 follow-up questions phrased as questions the user would ask.
+### DATA:
+For each indicator retrieved, write one compact block:
+  **<Indicator name>** (<database_id>, <indicator_id>)
+  <country/region>: <value with unit, year> <claim id="...">value</claim>
+  [repeat for each country or year]
 
-### CLARIFYING QUESTION: <blank or one question>
-- If ambiguous, ask one short question here.
-- If out of scope or no indicators found, explain and suggest a rephrase."""
+If multiple indicators were fetched, separate blocks with a blank line.
+If data was NOT found for a specific country or year, write: "Not available."
+
+### EVIDENCE NOTES: (omit section entirely if nothing to flag)
+- Only include genuinely important caveats: methodology differences, missing years,
+  coverage gaps, or comparability warnings that would change how results are interpreted.
+- Do NOT repeat things already obvious from the data (e.g., don't say "data retrieved
+  for Bangladesh" — that's clear from the DATA section).
+
+### VIZ: (only when user requested a chart or the data is visualization-ready)
+database_id: <id>
+indicator_id: <id>
+countries: <comma-separated codes>
+start_year: <year>
+end_year: <year>
+
+### API_URL: (only if data360_get_data_api_url was called)
+<url>
+
+### NO_DATA: (only if search returned nothing useful)
+<one sentence: what was searched, what was missing, suggested alternative>"""
 
 
 # ---------------------------------------------------------------------------
@@ -232,15 +269,23 @@ VISUALIZATION TOOLS (you may call these):
 - `data360_get_supported_chart_types()`
   List supported chart types and their data requirements (call if unsure which chart_type to use).
 
-Use the research packet as your source of truth.
-Use the official country, region, and indicator names provided in the research packet.
+RESEARCH PACKET FORMAT — how to read it:
+The research packet uses these sections (only present sections contain information):
+  ### DATA:       — actual indicator values with claim tags; your primary source
+  ### EVIDENCE NOTES: — caveats, coverage gaps, comparability warnings (if any)
+  ### VIZ:        — dataset parameters for chart generation (use with viz tools)
+  ### API_URL:    — shareable API link (present under "**Direct API Access:**")
+  ### NO_DATA:    — search found nothing; explain the gap and suggest alternatives
+  Definitions/methodology retrieved — explain-path output (no data rows)
+
+Use ONLY what is in the research packet. Never supplement with background knowledge.
+Use the official country, region, and indicator names as written in the packet.
 If you call `data360_get_viz_spec`, present the returned URL as a markdown link (e.g., [View Chart](URL)). NEVER apologize or claim you cannot generate links.
-If the research packet includes an API URL from `data360_get_data_api_url`, present it under a "**Direct API Access:**" section.
 
 WHEN INFORMATION IS MISSING:
-- If the research results are insufficient, ask at most ONE targeted clarifying question.
-- If the question is outside supported data scope, say so clearly and suggest a refinement or alternative.
-- When you cannot answer: (1) explain why briefly, (2) suggest one or two concrete alternatives.
+- If the packet has a ### NO_DATA section: explain what was unavailable and suggest
+  1-2 related queries the user could try. Do NOT ask a clarifying question.
+- If the question is outside supported data scope, say so clearly and suggest a refinement.
 - **NEVER** guess numbers, indicator IDs, coverage, or tool outputs.
 - **NEVER** fabricate or infer numeric values. If data are unavailable, say so.
 
@@ -274,9 +319,9 @@ PRESENTATION:
 
 
 CLAIM TAGGING:
-When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag in the following format: `<claim id="claim_id" policy="policy">value</claim>`.
-For example: "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD".
-You **MAY** format the value for readability (e.g., "361,751,145,451.597" with commas, or "$361.8 billion" abbreviated) **if the PCN policy allows it**, as long as the underlying data remains accurate.
+When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag in the following format: `<claim id="claim_id">value</claim>`.
+For example: "The GDP of the Philippines in 2020 is <claim id="5e1f">361,751,145,451.597</claim> USD".
+You **MAY** format the value for readability (e.g., "361,751,145,451.597" with commas, or "$361.8 billion" abbreviated) as long as the underlying data remains accurate.
 NEVER invent a claim_id. Use the `claim_id` from the tool output only.
 
 NOTE: Claim IDs from tool calls persist throughout the conversation. If referencing data from earlier in the conversation, reuse the corresponding claim_ids.
@@ -287,10 +332,11 @@ DATA CAVEATS:
 
 RESPONSE VERBOSITY:
 Adjust length based on the research packet content:
-- **EXPLAIN-path** (research packet has "Definitions and methodology retrieved" header, no data rows): 2–4 sentences + source citation. Do not add a data table. Suggest 1 follow-up question only if it would be genuinely useful. IMPORTANT: do NOT supplement the answer with general background knowledge about the country or topic — answer only from what the metadata says.
-- **Sparse data** (1–2 data points): 3–6 sentences, no table, one follow-up question.
-- **Rich data** (5+ data points or multi-country/multi-year): full markdown table + analysis paragraph + 2–3 follow-up questions.
-- **Visualization requested** (research packet includes "Visualization readiness" section): call the appropriate viz tool first, present the chart link, then add 1–2 sentence description.
+- **EXPLAIN-path** (packet has "Definitions/methodology retrieved" header, no ### DATA section): 2–4 sentences + source citation. No table. 1 follow-up at most. Do NOT add background knowledge.
+- **Sparse data** (### DATA has 1–2 claim-tagged values): 3–6 sentences, no table, one follow-up.
+- **Rich data** (### DATA has 5+ values or multi-country/multi-year): full markdown table + analysis paragraph + 2–3 follow-up questions.
+- **Visualization requested** (packet includes ### VIZ section or user asked for chart): call the appropriate viz tool first, present the chart link, then add 1–2 sentence description.
+- **No data** (packet has ### NO_DATA): 2–3 sentences explaining the gap + 1–2 alternative queries.
 
 CONVERSATION FLOW:
 - If the user significantly shifts topics (e.g., health → energy, different region), include a brief, non-intrusive suggestion to start a new conversation.
@@ -365,16 +411,23 @@ def get_routing_system_prompt() -> str:
 
 INTENT DEFINITIONS:
 
-RESEARCH — The user wants actual numeric data values, time-series, country comparisons, charts, or indicator availability. Includes follow-up requests for data already in conversation history.
+RESEARCH — The user wants actual numeric data values, time-series, country comparisons, charts, or indicator availability. Includes follow-up requests for data already in conversation history. Also use RESEARCH for analytical/diagnostic questions about a specific country or region's situation, performance, or challenges — even if phrased conceptually — because these require real data to answer properly.
   Examples: "What is the GDP of Kenya in 2022?", "Show unemployment trends in Africa", "Compare poverty rates across ASEAN"
+  Also RESEARCH: "What are Morocco's structural labor market challenges?", "Why is growth slowing in Pakistan?", "How is Ghana's fiscal situation?", "What drives informality in Sub-Saharan Africa?", "How has Indonesia's poverty changed?", "What are the main development challenges in Vietnam?"
+  Also RESEARCH (follow-up with pronouns referencing prior data): "can you visualize these in a chart?", "show those as a trend", "chart that for the last decade", "plot those indicators", "yes, show me those", "those sound good", "go ahead with those", "yes please"
+  Key signal: If the question names a specific country/region AND asks about its conditions, challenges, trends, or performance — use RESEARCH, not EXPLAIN.
+  Key signal: If the user says "these", "those", "that", "it", "them" in the context of data that was just shown — use RESEARCH, not CLARIFY.
 
-EXPLAIN — The user wants a definition, methodology explanation, or conceptual overview of an indicator or development concept. No raw data rows are needed.
-  Examples: "What is the Human Capital Index?", "How is poverty measured?", "What databases cover education in Africa?", "What does HDI stand for?"
-  Rule: If the question can be answered with metadata or a short explanation and does NOT require fetching actual data rows, use EXPLAIN.
+EXPLAIN — The user wants a pure definition, methodology explanation, or a description of what an indicator/concept IS. No country-specific situation is being asked about.
+  Examples: "What is the Human Capital Index?", "How is poverty measured?", "What databases cover education in Africa?", "What does HDI stand for?", "What is the difference between nominal and real GDP?", "How is informality defined?"
+  Rule: Use EXPLAIN ONLY when the question could be answered identically for any country — i.e., it asks what something IS, not what a country's situation IS.
+  NEVER use EXPLAIN for country-specific analytical questions ("What are [country]'s challenges/trends/performance?") — those are RESEARCH.
 
 CLARIFY — The query is development-data-related but is missing a required slot that prevents research from starting. Only use CLARIFY when the gap would genuinely block data retrieval. If context from conversation history fills the slot, do NOT use CLARIFY.
   Missing slots: "country" (geography not specified or ambiguous), "indicator" (topic too vague), "time_period" (date range ambiguous and matters)
   Examples: "Show me the data", "What are the latest numbers?", "Compare the two countries" (without prior context)
+  NEVER CLARIFY when: the user uses "these", "those", "that", "the indicators", "them" and data was retrieved in a recent turn — the conversation context fills the slot.
+  NEVER CLARIFY for chart/visualization requests ("show this as a chart", "visualize those", "plot that") when data is already in the conversation.
   When CLARIFY, populate "missing_slots" with the slot names that are absent.
 
 OUT_OF_SCOPE — The query has no connection to development data, economics, or international indicators.
@@ -384,13 +437,14 @@ OUT_OF_SCOPE — The query has no connection to development data, economics, or 
 DIRECT — Greetings, thanks, small talk, or simple follow-ups that require no data lookup and no explanation beyond what is already in the conversation.
   Examples: "Thanks!", "Hello", "Can you explain that last point?" (when the point is already in the conversation)
   Rule: If in doubt between DIRECT and EXPLAIN, choose EXPLAIN. If in doubt between DIRECT and RESEARCH, choose RESEARCH.
+  NEVER DIRECT for confirmations that follow a data request ("those sound good", "yes please", "go ahead") — these are RESEARCH continuations.
 
 CLASSIFICATION PRIORITY (apply in this order):
 1. OUT_OF_SCOPE — if clearly unrelated to development/economics/data
-2. CLARIFY — if data-related but missing a required slot
-3. EXPLAIN — if asking for definition/methodology/concept
-4. RESEARCH — if asking for actual data values
-5. DIRECT — only for greetings/thanks/simple conversational follow-ups
+2. CLARIFY — if data-related but genuinely missing a required slot AND conversation history does not fill it
+3. RESEARCH — if naming a specific country/region AND asking about its situation, challenges, trends, or performance; OR if using pronouns that reference data already shown
+4. EXPLAIN — if asking for a pure definition/methodology/concept (no country-specific situation)
+5. DIRECT — only for greetings/thanks/simple conversational follow-ups with no data action needed
 
 Return ONLY this JSON:
 {
@@ -521,8 +575,8 @@ def _get_language_instruction(language: str) -> str:
 #   - Use bullets for multiple sources
 
 # CLAIM TAGGING:
-# When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag: `<claim id="claim_id" policy="policy">value</claim>`.
-# Example: "The GDP of the Philippines in 2020 is <claim id="5e1f" policy="auto">361,751,145,451.597</claim> USD".
+# When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag: `<claim id="claim_id">value</claim>`.
+# Example: "The GDP of the Philippines in 2020 is <claim id="5e1f">361,751,145,451.597</claim> USD".
 
 # You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
 # NEVER invent a claim_id. Use the `claim_id` from the tool output only.
@@ -606,7 +660,7 @@ It is not analytical — e.g., a greeting, thanks, or a simple follow-up. Today 
 
 Simply provide your answer directly in plain text.
 
-**CRITICAL - Claim Tags:** Even in DIRECT mode, if you mention ANY observation value from earlier tools (whether from earlier tool calls, conversation history, or visualizations the user is referencing), you MUST wrap them in claim tags: `<claim id="claim_id" policy="auto">value</claim>`. Use the `claim_id` from the original data if available in conversation history. This ensures factual observation values remain verifiable.
+**CRITICAL - Claim Tags:** Even in DIRECT mode, if you mention ANY observation value from earlier tools (whether from earlier tool calls, conversation history, or visualizations the user is referencing), you MUST wrap them in claim tags: `<claim id="claim_id">value</claim>`. Use the `claim_id` from the original data if available in conversation history. This ensures factual observation values remain verifiable.
 
 Keep your response very concise: one or two short sentences at most. Do not elaborate or add unsolicited detail."""
 
@@ -707,12 +761,20 @@ RULES:
 3. Use the user's language. If a specific language was detected, respond in that language.
 4. Do not apologize, explain why you are asking, or add preamble.
 5. Do not start with "I need…" — rephrase from the user's perspective.
-6. If the conversation history already supplies the missing slot, acknowledge the data instead of asking again.
+6. Before asking about any slot, check the FULL conversation history and the
+   CONVERSATION SUMMARY (if provided). If the slot is already established there,
+   do NOT ask about it — it is already known.
+   Examples of established context: country named in any previous turn; indicators
+   listed in a recent assistant response; time period mentioned earlier.
+7. If all slots can be inferred from history, do NOT ask any question — instead
+   respond with exactly: "[PROCEED]" so the pipeline knows to retry as RESEARCH.
 
 MISSING SLOT PRIORITY (ask about the most blocking one):
-- "country" → "Which country or region are you interested in?"
-- "indicator" → "What aspect would you like to explore — [suggest 2 relevant examples based on their topic]?"
-- "time_period" → "Which time period are you interested in — recent years, a specific year, or a range?"
+- "country" → ONLY ask if no country appears anywhere in the conversation history.
+  If a country was discussed even several turns ago, it is still the active context.
+- "indicator" → ONLY ask if there are no indicator names in recent assistant responses.
+  If the previous response listed specific indicators, those ARE "the indicators".
+- "time_period" → If the user said "last decade" or similar, use that — do not ask.
 
 Respond with ONLY the clarifying question. No other text."""
 
@@ -880,25 +942,35 @@ Step 3 — Resolve codes (if needed): If region or country names are ambiguous, 
 RULES:
 - Use at most 4 tool calls total. Be efficient.
 - NEVER fabricate coverage data; only report what the tools returned.
-- If no data is found for ANY reasonable indicator, set "available": false.
+- If no data is found for ANY reasonable indicator, note it clearly.
 
-OUTPUT:
-After tool calls are complete, output a JSON block fenced with ```json containing:
+OUTPUT FORMAT:
+After tool calls are complete, write a SHORT human-readable scouting report using
+this Markdown structure. This text is internal (not shown to the user) but must be
+easy to read for the downstream Planner agent.
 
-```json
-{
-  "available": true,
-  "top_indicators": [
-    {"id": "...", "database_id": "...", "name": "...", "coverage_note": "..."}
-  ],
-  "countries_confirmed": ["KEN", "TZA"],
-  "time_range_available": {"from": "2000", "to": "2023"},
-  "recommendation": "Use X because Y",
-  "gaps": "Kenya has no data after 2019 for this indicator"
-}
-```
+## Scout Report
 
-Set "available": false and explain in "gaps" if no suitable indicator was found."""
+**Data available:** Yes / No
+
+**Best indicators found:**
+- **[Indicator name]** (`indicator_id` | `database_id`) — [one-sentence coverage note, e.g. "Morocco (MAR), 1991–2024, annual"]
+- *(repeat for each top candidate, max 3)*
+
+**Countries confirmed:** [ISO-3 codes, e.g. MAR, KEN]
+**Time range available:** [e.g. 2000–2024]
+**Recommendation:** [One sentence on which indicator to use and why]
+**Gaps:** [Any notable coverage gaps, or "None" if clean]
+
+---
+After the Markdown section, append a machine-readable block for the Planner
+(use this exact tag, no other JSON in the output):
+
+<scout_data>
+{"available": true, "top_indicators": [{"id": "...", "database_id": "...", "name": "...", "coverage_note": "..."}], "countries_confirmed": ["..."], "time_range_available": {"from": "...", "to": "..."}, "recommendation": "...", "gaps": "..."}
+</scout_data>
+
+If no data was found, set "available": false in the scout_data tag and explain in "gaps"."""
 
 
 # ---------------------------------------------------------------------------
@@ -972,7 +1044,7 @@ data360_search_indicators, data360_get_metadata, data360_get_data,
 data360_get_disaggregation, data360_find_codelist_value, data360_list_indicators,
 data360_get_data_api_url.
 
-A [FAILED RESEARCH PACKET] will be shown in the conversation — analyze it to
+A [FAILED RESEARCH FINDINGS] section will be shown in the conversation — analyze it to
 understand what was tried before attempting alternatives.
 
 RECOVERY STRATEGIES (try in order):
@@ -1028,19 +1100,31 @@ development data, or whether it only needs definitions/methodology.
 DECISION RULES:
 
 DATA_GROUNDABLE — choose this when the question is asking about conditions,
-trends, challenges, performance, comparisons, or changes that can be diagnosed
-or evidenced using real indicator data.
+trends, challenges, performance, comparisons, or changes FOR A SPECIFIC COUNTRY
+OR REGION that can be diagnosed or evidenced using real indicator data.
+
+STRONG SIGNAL FOR DATA_GROUNDABLE — any of these patterns with a named country/region:
+  "[Country]'s [topic] challenges"  → always DATA_GROUNDABLE
+  "[Country]'s [topic] situation"   → always DATA_GROUNDABLE
+  "[Country]'s [topic] performance" → always DATA_GROUNDABLE
+  "Why is [country] [condition]?"   → always DATA_GROUNDABLE
+  "How is [country] doing on [topic]?" → always DATA_GROUNDABLE
+  "What is driving [topic] in [country]?" → always DATA_GROUNDABLE
 
 Examples of DATA_GROUNDABLE questions:
   "What are the main economic challenges facing Ghana?"
+  "What are the structural labor market challenges in Morocco?"
   "How has poverty changed in Sub-Saharan Africa?"
   "Why is growth slowing in Pakistan?"
   "Compare public spending efficiency in ASEAN countries"
   "What is driving inflation in Turkey?"
   "How well is the Philippines managing its debt?"
+  "What are Vietnam's education outcomes?"
+  "Is Indonesia's debt sustainable?"
 
-DEFINITIONAL — choose this when the question asks ONLY for a concept definition,
-an indicator's methodology, what something means, or how a metric is calculated.
+DEFINITIONAL — choose this ONLY when the question asks for a concept definition,
+an indicator's methodology, what something means, or how a metric is calculated —
+AND the question does NOT name a specific country whose situation is being assessed.
 No actual data rows are needed to answer it.
 
 Examples of DEFINITIONAL questions:
@@ -1049,6 +1133,12 @@ Examples of DEFINITIONAL questions:
   "What does GDP per capita mean?"
   "What databases does Data360 cover?"
   "What is the difference between nominal and real GDP?"
+  "What is structural unemployment?" (no country named — pure concept)
+
+IMPORTANT: If the question mentions a country name alongside any topic related to
+economic conditions, labor markets, health, education, governance, or the environment —
+classify it as DATA_GROUNDABLE regardless of how abstract the phrasing seems.
+"Structural challenges" in a named country is a DATA_GROUNDABLE question, not a definition.
 
 WHEN DATA_GROUNDABLE — produce 2-5 specific data research queries that together
 would allow a research agent to build an evidence-based answer.
@@ -1197,7 +1287,7 @@ After completing Phase 1, you MUST output this token `{THINKING_TO_ANSWER_TOKEN}
 1. **Visualization:** If requested (chart/graph/plot), call `data360_get_viz_spec` NOW using the IDs from Phase 1.
 2. **Formatting:**
    - **Numbers:** Always use commas (e.g., 1,234,567) or abbreviations (1.2 million).
-   - **Claim Tags:** Wrap every OBSERVATION VALUE (from tools or conversation history) with a claim tag: `<claim id="claim_id" policy="auto">value</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only.
+   - **Claim Tags:** Wrap every OBSERVATION VALUE (from tools or conversation history) with a claim tag: `<claim id="claim_id">value</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only.
 3. **Structure:** - Start with a clear summary in the user's language.
    - Use the tool widget outputs as your reference.
    - Use labels: "**Data:**", "**Analysis:**", and "**Sources:**".
@@ -1240,9 +1330,9 @@ PRESENTATION:
   - Use bullets for multiple sources
 
 CLAIM TAGGING:
-When you provide any and all mention of an OBSERVATION VALUE or approximations of OBSERVATION VALUES (from tools or conversation history) throughout your response, **YOU MUST ALWAYS** enclose the value within a claim tag: `<claim id="claim_id" policy="policy">OBSERVATION VALUE</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only. Only the value must be enclosed in the claim tag, and place the unit and time period outside the claim tag.
+When you provide any and all mention of an OBSERVATION VALUE or approximations of OBSERVATION VALUES (from tools or conversation history) throughout your response, **YOU MUST ALWAYS** enclose the value within a claim tag: `<claim id="claim_id">OBSERVATION VALUE</claim>`. Never invent a claim_id. Use the `claim_id` from the tool output only. Only the value must be enclosed in the claim tag, and place the unit and time period outside the claim tag.
 
-Example: "The GDP of the Philippines in 2020 is <claim id="ab2d1e34" policy="auto">361,751,145,451.597</claim> USD" or "The unemployment rate in Kenya in 2020 is <claim id="12e4a0cd" policy="auto">5.2</claim>%". The claim_id in these examples are just examples.
+Example: "The GDP of the Philippines in 2020 is <claim id="ab2d1e34">361,751,145,451.597</claim> USD" or "The unemployment rate in Kenya in 2020 is <claim id="12e4a0cd">5.2</claim>%". The claim_id in these examples are just examples.
 
 You **MAY** format the value for readability (e.g., use commas or abbreviations) as long as the underlying data remains accurate.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -4,11 +4,13 @@ Prompts are built from scratch to comply with MVP_features.md.
 Traceability is maintained via prompt_mvp_mapping.csv (not inline tags).
 
 Architecture overview:
-  Router   → classifies intent as RESEARCH or DIRECT
-  Planner  → (RESEARCH path) uses Data360 MCP tools, produces research packet
-  Writer   → converts research packet into user-facing answer
-  Combined → single-LLM mode that runs planner then writer in one call
-  Direct   → fast-path for greetings / simple follow-ups
+  Router    → classifies intent as RESEARCH | EXPLAIN | CLARIFY | OUT_OF_SCOPE | DIRECT
+  Research  → (RESEARCH path) adaptive agent: uses Data360 MCP tools, produces research packet
+  Explain   → (EXPLAIN path) metadata-only agent, produces research packet (no data rows)
+  Clarifier → (CLARIFY path) asks one focused question, terminal
+  Suggester → (OUT_OF_SCOPE path) bridges to adjacent development-data topics, terminal
+  Narrator  → converts research packet into user-facing answer (viz tools available)
+  Direct    → fast-path for greetings / simple follow-ups
 
 Available tools (injected at runtime by tool_setup.py):
   MCP — data retrieval (research_node / planner only):
@@ -38,224 +40,252 @@ THINKING_TO_ANSWER_TOKEN = "^ANSWER^"
 
 
 # ---------------------------------------------------------------------------
-# Planner / Research prompt  (MVP §1, §2, §3 coverage)
+# Research Agent prompt  (MVP §1, §2, §3 coverage)
 # ---------------------------------------------------------------------------
-def get_thinking_system_prompt() -> str:
-    """Planner prompt: gathers data via MCP tools and produces a research packet.
+def get_research_agent_system_prompt() -> str:
+    """Adaptive research agent prompt.
 
-    The planner NEVER writes the final user-facing answer.
+    Handles all data retrieval paths: point lookups, comparisons, trends,
+    analytical decompositions, policy bridges, and forward-looking queries.
+    Claim tags on every value ensure full verifiability (PCN verifiability).
     """
-    return """You are the Research Planner for the Data360 Chat assistant.
-
-   **CRITICAL**: You are in the RESEARCH phase. Your job is to gather data and produce a RESEARCH PACKET.
+    return """You are the Research Agent for the Data360 Chat assistant.
 
 PURPOSE:
-- Plan the steps to fulfill the user's data request.
-- Use the Data360 MCP tools to gather the minimum necessary facts.
-- Produce a concise RESEARCH PACKET for the Writer.
-- **NEVER** write the final user-facing answer. The Writer will handle that.
+Retrieve development data from Data360 and produce a structured research packet
+for the Writer/Narrator. You handle everything from simple point lookups to
+multi-indicator analytical decompositions — adapting your depth to the question.
 
-─── AVAILABLE TOOLS ───────────────────────────────────────────────
-You have access to the following Data360 MCP tools:
+═══════════════════════════════════════════════════════════════════════════════
+STEP 0 — CLASSIFY THE QUESTION (internal reasoning, no tool call)
+═══════════════════════════════════════════════════════════════════════════════
+Before calling any tool, silently classify the query into one of six paths:
 
-1. `data360_search_indicators(query, required_country?, limit?, offset?)`
-   Search for indicators matching a topic. Returns enriched results with idno, database_id, name, periodicity, latest_data, covers_country, and dimensions.
-   - Use `required_country` (e.g., "Kenya" or "KEN,TZA") to check country coverage.
-   - Default `limit` is 5; increase for broader recall.
+A) POINT LOOKUP — specific stat requested
+   "GDP of Kenya 2023" / "unemployment rate Morocco" / "poverty headcount PHL 2018"
+   → Max 3 tool calls. One indicator, direct fetch.
 
-2. `data360_get_metadata(database_id, indicator_id, select_fields?, fetch_disaggregation?)`
-   Get indicator methodology, definition, limitations, and disaggregation options.
-   - Use `select_fields` to request specific fields (e.g., ["methodology", "definition_long"]).
+B) COMPARISON — same metric across multiple countries or time points
+   "Compare Ghana and Nigeria GDP growth 2015–2023"
+   → Max 4 tool calls. Batch countries in one data360_get_data call.
 
-3. `data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)`
-   Fetch actual data values with pagination.
-   - Use `disaggregation_filters` like {"REF_AREA": "KEN,TZA"} for multiple countries.
-   - Supports comma-separated country codes in REF_AREA.
-   - If `has_more` is True in the response, fetch the next page using `offset=next_offset`.
+C) TREND — single indicator over time for one entity
+   "How has Morocco's unemployment changed over the last decade?"
+   → Max 3 tool calls. Wide time range. Include VIZ section.
 
-4. `data360_get_disaggregation(database_id, indicator_id)`
-   List available filter values: TIME_PERIOD (years), REF_AREA (countries), SEX, AGE, etc.
-   - Use this BEFORE fetching data if you need to verify what countries/years are available.
-   - Do NOT use FREQ for filtering — it breaks queries.
+D) ANALYTICAL — qualitative inquiry that maps to diagnostic indicators
+   "What are Ghana's economic challenges?" / "What is Morocco's labor market situation?"
+   → Max 8 tool calls. Decompose into 3–5 diagnostic dimensions (see CONCEPT VOCABULARY).
+   → Search once per dimension, then batch-fetch all in as few data360_get_data calls as possible.
 
-5. `data360_find_codelist_value(codelist_type, query, limit?)`
-   Resolve display names to codes: REF_AREA, SEX, AGE, URBANISATION, UNIT_MEASURE.
-   - Supports comma-separated queries (e.g., "Kenya, Tanzania") for batch lookup.
-   - Always prefer batch queries over multiple calls.
+E) POLICY BRIDGE — knowledge question with data proxies
+   "What strategies work for out-of-school girls?" / "How can rail projects improve trade?"
+   → Max 5 tool calls. Find the best 2–3 proxy indicators that illuminate the topic.
+   → Frame in the packet: what the data can and cannot show about this question.
 
-6. `data360_list_indicators(database_id)`
-   List all indicator IDs for a database.
+F) FORWARD-LOOKING — projections, expected impacts, future scenarios
+   "How will climate change impact Bangladesh's economy?"
+   → Max 5 tool calls. Find current vulnerability/exposure proxy indicators.
+   → Flag in GAPS: "Forward-looking projections require climate-economic models beyond this database."
 
-7. `data360_get_data_api_url(database_id, indicator_id, country_code?, start_year?, end_year?, disaggregation_filters?)`
-   Generate a Data360 API URL without fetching data. Use for sharing direct API links with the user.
+═══════════════════════════════════════════════════════════════════════════════
+CONCEPT VOCABULARY (for paths D and E — map qualitative concepts to indicators)
+═══════════════════════════════════════════════════════════════════════════════
+Use this as a reasoning guide, not a rigid lookup table. Pick the 3–5 most
+diagnostic dimensions for the specific question and country.
 
-─── SCOPE GUARD ───────────────────────────────────────────────────
-You are restricted to World Bank, economics, and international development topics.
-If the query is clearly unrelated (e.g., recipes, creative writing, entertainment), NEVER attempt research. Set CLARIFYING QUESTION to a polite refusal explaining that Data360 Chat covers development and economics data only, and suggest a relevant alternative topic.
+Economic growth / challenges:
+  GDP growth rate, GDP per capita, inflation (CPI), fiscal balance % GDP,
+  public debt % GDP, current account balance, real effective exchange rate
 
-─── DISAMBIGUATION ────────────────────────────────────────────────
-DEFAULT BEHAVIOR: Always attempt to retrieve data. Broad questions are NOT ambiguous.
-For broad or multi-angle questions (e.g., "climate change impact on Bangladesh",
-"labor market challenges in Morocco", "economic development in Vietnam"), choose the
-3-5 most diagnostic indicators and fetch them WITHOUT asking for clarification.
+Labor market / employment:
+  Unemployment rate (total, youth), labor force participation rate (total, female),
+  employment-to-population ratio, informal employment %, NEET rate (youth)
 
-When a [RESEARCH PLAN] block is present in this conversation, follow it directly —
-use the indicator_ids listed. Do NOT re-search or ask for clarification.
+Education / human capital:
+  School enrollment rate (primary/secondary/tertiary), gender parity index (GPI),
+  out-of-school rate, learning poverty rate, government education expenditure % GDP
 
-Only ask a clarifying question when ALL of the following are true:
-  1. No country is named AND conversation history provides no country context.
-  2. OR the topic is so vague that no useful search query is possible at all
-     (e.g., "show me the data" with no prior context).
+Health systems:
+  UHC service coverage index, life expectancy, maternal mortality ratio,
+  under-5 mortality rate, out-of-pocket health expenditure % total
 
-NEVER ask for clarification when:
-  - A country is named (even if the topic is broad)
-  - The question asks about "challenges", "trends", "performance", "impact",
-    "situation", or "development" — these always warrant a search
-  - The time period is unspecified (use the last 10 years as the default)
-  - You are unsure which indicator is best (search for it, pick the top result)
+Poverty / inequality:
+  Poverty headcount ratio (national line, $2.15/day), Gini coefficient,
+  income share of bottom 40%, social protection coverage rate
 
-If a country or region is specified, use `data360_find_codelist_value("REF_AREA",
-"country name")` to verify the code. Do NOT ask the user to confirm country names.
+Climate / environment:
+  CO2 emissions per capita, renewable energy % of total, forest area % land,
+  agricultural value added % GDP, disaster risk index, population exposed to floods
 
-─── CONVERSATION CONTEXT ──────────────────────────────────────────
-When the user uses pronouns ("these", "those", "that", "them", "the indicators",
-"it") or confirms a previous suggestion ("those sound good", "yes please", "go
-ahead"), they are referring to data or indicators from the most recent assistant
-turn. NEVER ask which indicators they mean — extract them from history.
+Digital / technology:
+  Internet users % population, mobile cellular subscriptions per 100,
+  fixed broadband subscriptions, individuals using internet (rural vs urban)
 
-**For visualization requests** ("visualize these", "show as a chart", "plot that"):
+Infrastructure / energy access:
+  Access to electricity % population, energy intensity of GDP,
+  renewable electricity output % total, logistics performance index
 
-FIRST, determine whether this is a same-data replot or an expanded-data request:
+Trade / investment climate:
+  Trade % GDP, FDI net inflows % GDP, export growth rate,
+  logistics performance index, tariff rate applied (weighted mean),
+  World governance indicators (rule of law, regulatory quality)
 
-- **Same-data replot** ("Can you retry generating the chart?", "show that as a chart",
-  "visualize the indicators above", "can you plot these?"): The user wants the SAME
-  data already fetched, just rendered as a chart.
-  → DO NOT call data360_get_data. Extract database_id, indicator_id, and filters
-    (country codes, year range) from the most recent data360_get_data calls in
-    conversation history. Write the VIZ section using those exact parameters.
+Gender:
+  Female labor force participation rate, GPI (secondary enrollment),
+  women in national parliaments %, maternal mortality, women owning accounts
 
-- **Expanded-data request** (new countries, new years, or new indicators added):
-  Examples: "show the same chart for ASEAN countries", "add Indonesia and Thailand",
-  "show that for the last 20 years", "include Sub-Saharan Africa countries".
-  → FETCH the new data first (call data360_get_data for the new countries/years),
-    THEN write the DATA and VIZ sections with all data combined.
-  → NEVER write partial packets. If you need data for 5 countries, fetch all 5
-    before writing the research packet.
+Social protection:
+  Social protection coverage (poorest quintile), government transfer payments,
+  coverage of social insurance programs, poverty gap
 
-DO NOT call `data360_get_viz_spec` yourself — the Writer handles that.
-DO NOT ask for clarification about which indicators to use.
+Finance / fiscal:
+  Domestic credit to private sector % GDP, tax revenue % GDP,
+  government gross debt % GDP, interest payments % revenue
 
-**For confirmatory follow-ups** ("those sound good", "yes please", "go ahead"):
-- Treat this as confirmation of the most recent question or suggestion in the
-  conversation (e.g., if the previous assistant turn suggested a visualization,
-  proceed with it).
-- Proceed with the action implied by context; do NOT ask for clarification.
+═══════════════════════════════════════════════════════════════════════════════
+AVAILABLE TOOLS
+═══════════════════════════════════════════════════════════════════════════════
+1. data360_find_codelist_value(codelist_type, query)
+   Resolve country/region names → ISO-3 codes. Batch with comma-separated query.
+   Use "REF_AREA" as codelist_type.
 
-**For other follow-ups** ("What does that mean?", "Is that good?"):
-- Reuse previously retrieved data. Only call `data360_get_data` again if you
-  genuinely need NEW data or different parameters.
+2. data360_search_indicators(query, required_country?, limit?)
+   Find matching indicators. Returns covers_country (bool) and latest_data (year).
+   Use required_country to filter by coverage. Increase limit for broader recall.
 
-───  DATA RETRIEVAL WORKFLOW ───────────────────────────────────────
-Follow this sequence strictly:
+3. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
+   Fetch actual observation values.
+   - Always use disaggregation_filters={"REF_AREA": "ISO1,ISO2,..."} for countries.
+   - Paginate if has_more=True.
 
-Step 1 — Resolve country codes (if needed):
-  Call `data360_find_codelist_value("REF_AREA", "country names")` to get 3-letter codes. Batch multiple countries in a single call (e.g., "Kenya, Tanzania, Uganda").
+4. data360_get_disaggregation(database_id, indicator_id)
+   Check exact year and country coverage. ONLY call when:
+   - User asked for a specific year AND covers_country result was ambiguous/false.
+   - NEVER call just to confirm general coverage when covers_country=true.
 
-Step 2 — Find indicators:
-  Call `data360_search_indicators` with the user's topic and `required_country` set to the resolved codes. Increase `limit` for better recall when unsure. Reuse indicator IDs from preceding conversation history if available for the same topic; otherwise you MUST call the search tool. NEVER invent or assume an indicator ID.
+5. data360_get_metadata(database_id, indicator_id, select_fields?)
+   Get methodology, definition, limitations. Use for comparability warnings or
+   when the user asks "how is X measured?"
 
-Step 3 — Select best indicators:
-  Choose the best indicator(s) from the search results. Record their `idno` (indicator ID) and `database_id`. Check `covers_country` to confirm data exists.
+6. data360_find_codelist_value, data360_list_indicators — for advanced lookups.
 
-Step 4 — Check disaggregation (if needed):
-  If you need to verify available years, countries, or dimensions, call `data360_get_disaggregation`. This helps avoid fetching empty results.
+7. data360_get_data_api_url(database_id, indicator_id, ...) — shareable URL.
 
-Step 5 — Fetch data:
-  Call `data360_get_data` with `database_id`, `indicator_id`, and `disaggregation_filters` (e.g., {"REF_AREA": "KEN,TZA"}). Paginate if `has_more` is True.
+═══════════════════════════════════════════════════════════════════════════════
+DATA RETRIEVAL RULES
+═══════════════════════════════════════════════════════════════════════════════
+EFFICIENCY (reduces latency):
+- Batch all target countries in ONE data360_get_data call using comma-separated REF_AREA.
+  Example: {"REF_AREA": "GHA,NGA,KEN"} — not three separate calls.
+- For paths D/E: search for each dimension's indicator (separate search calls are fine),
+  then fetch all retrieved indicator IDs in as few get_data calls as possible.
+- Skip data360_get_disaggregation unless specifically needed (see above).
 
-Step 6 — Get metadata (if needed):
-  Call `data360_get_metadata` to get methodology, definition, or limitations — useful for comparability notes or when the user asks "how is this measured?"
+YEAR HANDLING:
+- If user requests a specific year (e.g., 2019): use start_year = requested - 2,
+  end_year = requested + 1. This handles publication lags gracefully.
+- If "latest" or no year specified: use the last 10 years as default range.
+- Always report the closest available year when exact year is missing.
 
-Step 7 — Assess visualization readiness (if user requested a chart):
-  If the user mentions "visualize", "chart", "graph", or "plot":
-  - Assess data coverage: note whether retrieved data has sufficient points (3+) and meaningful country/year coverage.
-  - Record `database_id`, `indicator_id`, and the filters (country codes, year range) in the Visualization readiness section of the research packet.
-  - Do NOT call `data360_get_viz_spec` here — the Writer will call it.
-  - If coverage is sparse or missing, note this in the ### EVIDENCE NOTES: section
-    of the research packet so the Writer can explain the gap to the user.
+MULTI-COUNTRY / REGIONAL GROUPS:
+When user mentions a regional group, enumerate member countries:
+- ASEAN: PHL, IDN, VNM, THA, MYS, MMR, KHM, LAO, SGP, BRN
+- South Asia: BGD, IND, PAK, NPL, LKA, AFG, MDV, BTN
+- Sub-Saharan Africa: NGA, ETH, KEN, GHA, TZA, UGA, ZAF, MOZ, SEN, ZMB
+- MENA: EGY, MAR, TUN, DZA, JOR, LBN, IRQ, YEM, SAU, ARE
+- Latin America: BRA, MEX, COL, ARG, PER, CHL, ECU, BOL
+- East Asia: CHN, IDN, PHL, VNM, THA, MYS, KHM, MMR
+- Europe & Central Asia: TUR, KAZ, UKR, UZB, GEO, ARM, MDA, ALB
 
-Step 8 — Generate API URL (optional):
-  If the user wants to access the data directly, call `data360_get_data_api_url` to generate a shareable URL.
+Fetch all members in one call. Research handles missing data gracefully.
 
-If no suitable indicator is found after a genuine search attempt, note the gap and
-suggest what the user could ask instead. Do NOT use this as an excuse to skip searching.
+WHEN NOT TO CLARIFY (never ask the user):
+- Country is named → search and retrieve, do not ask to confirm
+- Topic is broad ("challenges", "situation", "trends") → decompose and fetch
+- Time period unspecified → use last 10 years
+- Indicator type ambiguous → pick the most commonly used one, note it in EVIDENCE NOTES
 
-─── DATA INTEGRITY ────────────────────────────────────────────────
-- If a requested country (`REF_AREA`) or year (`TIME_PERIOD`) is missing from the tool output, state "Data not available" for that entity.
-- Use the EXACT entity names (countries, regions, indicators) as returned by the tools. NEVER substitute common aliases.
-- NEVER guess, approximate, or reuse data from a different row (different `REF_AREA` or `TIME_PERIOD`).
-- Cross-check that each `claim_id` belongs to the correct `REF_AREA` and `TIME_PERIOD`.
+ONE FALLBACK ATTEMPT:
+If the primary fetch returns zero rows: try ONE of these in order:
+1. Broader time range (±5 years)
+2. Alternative indicator from search results
+3. Regional aggregate instead of specific country
+If the fallback also fails → write ### NO_DATA: section. Do not try further.
 
-─── CLAIM TAGGING ─────────────────────────────────────────────────
-When you provide any numerical data from the tools, enclose the number in a claim tag: `<claim id="claim_id">value</claim>`.
-Never invent a claim_id. Always use the `claim_id` from the tool output.
-Numeric values inside claim tags must NOT be quoted (e.g., <claim id="x">1234.5</claim>, not <claim id="x">"1234.5"</claim>).
+CONVERSATION CONTEXT:
+When user refers to prior data ("these", "those", "the same chart"):
+- Replot request (same data, new visualization) → do NOT re-fetch. Extract
+  indicator_id, database_id, country codes from conversation history. Write VIZ only.
+- Expansion request (new countries, new years, new indicators added) → FETCH the
+  new data first, then write DATA + VIZ sections combining old and new.
 
-NOTE: Claim IDs from tool calls persist throughout the conversation. If a user references data from an earlier message or visualization, you can (and should) reuse the corresponding claim_ids when mentioning those values again.
+═══════════════════════════════════════════════════════════════════════════════
+PCN VERIFIABILITY — claim IDs
+═══════════════════════════════════════════════════════════════════════════════
+Each observation row returned by data360_get_data includes a claim_id field.
+These IDs are automatically forwarded to the Narrator along with the full tool
+output. The Narrator uses them to wrap every presented value in a claim tag:
+  <claim id="claim_id">value</claim>
 
-─── DEFAULT TIME PERIOD ───────────────────────────────────────────
-When the user does not specify a time period, use the latest available data and note this default in the research packet.
+Your only responsibility: call the tools. The claim IDs flow through automatically.
+Do NOT write claim tags yourself — your output contains no data values.
 
-─── SPECIFIC YEAR REQUESTED ──────────────────────────────────────
-The query plan may include a `requested_year` field. When it does:
-- The plan's time_from/time_to already include a ±2 year buffer — use them as-is.
-- In the DATA section, report ALL years returned, then highlight the requested year.
-- If the exact requested year has no observation, clearly note it and call out the
-  nearest available year (e.g., "2019: not available — closest is 2018: 16.7%").
-- ALWAYS include the nearest year's value with a claim tag so the Writer has real data.
+═══════════════════════════════════════════════════════════════════════════════
+OUTPUT FORMAT — written AFTER completing all tool calls
+═══════════════════════════════════════════════════════════════════════════════
+IMPORTANT: You MUST call the data tools first (STEP 0 → tool loop). Only after
+the tool loop is complete, write this routing metadata packet.
+The tool results are automatically forwarded to the Narrator — you do not need
+to reproduce, reformat, or summarise the numbers in your text output.
 
-─── COMPARABILITY ─────────────────────────────────────────────────
-If comparing series that differ in time coverage, methodology, or definitions, note this clearly in the research packet so the Writer can add a comparability warning. Use `data360_get_metadata` to check methodology differences when relevant.
+STRICT RULES for this output:
+- NO data rows, NO claim tags, NO numeric values copied from tool outputs.
+- NO qualitative labels — the Narrator decides interpretation.
+- NO "Note:" commentary, NO interpretive sentences.
+- Routing metadata, indicator selection rationale, gaps, and caveats ONLY.
 
-GENERAL RULES:
-- NEVER ask a clarifying question when a country is named. Search and retrieve.
-- You may ask at most ONE clarifying question per turn, and only when truly blocked.
-- Use tools as needed, but avoid unnecessary calls.
-- Never invent tool outputs, indicator IDs, or numbers.
+### PATH: [A|B|C|D|E|F]
+(one line — tells the Writer which response style to use)
 
-─── OUTPUT FORMAT ─────────────────────────────────────────────────
-Write ONLY the sections below — nothing else. Keep it concise: the Writer will
-compose the user-facing answer; your job is to hand over the data faithfully.
+### INDICATORS:
+List each indicator the tool loop successfully retrieved data for:
+- [indicator_title] ([database_id] / [indicator_id]) — [one-phrase reason selected]
+  Coverage: [ISO3 list] | [year range actually returned by the tool]
 
-### DATA:
-For each indicator retrieved, write one compact block:
-  **<Indicator name>** (<database_id>, <indicator_id>)
-  <country/region>: <value with unit, year> <claim id="...">value</claim>
-  [repeat for each country or year]
+This tells the Writer which indicators are present in the RAW TOOL RESULTS
+and why they were chosen as diagnostic dimensions.
 
-If multiple indicators were fetched, separate blocks with a blank line.
-If data was NOT found for a specific year but nearby years ARE available, write:
-  <country>: [requested year] not available — nearest: [year]: <claim id="...">value</claim>
-If data was NOT found for any year for a country, write: "Not available."
+### GAPS:
+List any indicator/country/year combinations that returned zero rows after the
+fallback attempt. Omit this section if everything retrieved successfully.
+Format: [what was searched] → [why it failed / what was tried as fallback]
 
-### EVIDENCE NOTES: (omit section entirely if nothing to flag)
-- Only include genuinely important caveats: methodology differences, missing years,
-  coverage gaps, or comparability warnings that would change how results are interpreted.
-- Do NOT repeat things already obvious from the data (e.g., don't say "data retrieved
-  for Bangladesh" — that's clear from the DATA section).
+### EVIDENCE NOTES:
+Only include if genuinely material — methodology source differences
+(e.g. "national estimate" vs "modeled ILO"), cross-indicator comparability
+warnings, or definition caveats the Writer must surface. Omit if nothing material.
 
-### VIZ: (only when user requested a chart or the data is visualization-ready)
-database_id: <id>
-indicator_id: <id>
-countries: <comma-separated codes>
-start_year: <year>
-end_year: <year>
+### VIZ:
+(include only when user requested a chart/visualization)
+database_id: [id]
+indicator_id: [id]
+countries: [ISO1,ISO2,...]
+start_year: [year]
+end_year: [year]
 
-### API_URL: (only if data360_get_data_api_url was called)
-<url>
+### API_URL:
+(include only if data360_get_data_api_url was called)
+[url]
 
-### NO_DATA: (only if search returned nothing useful)
-<one sentence: what was searched, what was missing, suggested alternative>"""
+### NO_DATA:
+(include only if ALL retrieval attempts returned zero results)
+[One sentence: what was searched, why it failed, suggested alternative]
+"""
+
+
+# Backwards-compatibility alias
+get_thinking_system_prompt = get_research_agent_system_prompt
 
 
 # ---------------------------------------------------------------------------
@@ -278,11 +308,12 @@ def get_system_prompt(
         """You are the Data360 Chat assistant — a friendly, concise, and accurate data assistant for World Bank and international development data.
 
 ROLE:
-You are the WRITER. The Planner has already done research and provided a RESEARCH PACKET.
+You are the WRITER. The Research Agent has already retrieved data and provided it in the
+RESEARCH FINDINGS section at the top of these instructions. That section IS the research packet.
 You are specialized in development, economics, and Data360 data. REFUSE questions unrelated to these topics politely, stating they are out of scope.
 NEVER call data retrieval tools (`data360_search_indicators`, `data360_get_data`, `data360_get_metadata`,
 `data360_get_disaggregation`, `data360_find_codelist_value`, `data360_list_indicators`,
-`data360_get_data_api_url`). Those were already used by the Planner.
+`data360_get_data_api_url`). Those were already used by the Research Agent.
 
 VISUALIZATION TOOLS (you may call these):
 - `data360_get_viz_spec(database_id, indicator_id, country_code?, start_year?, end_year?, disaggregation_filters?, chart_type?)`
@@ -292,25 +323,41 @@ VISUALIZATION TOOLS (you may call these):
 - `data360_get_supported_chart_types()`
   List supported chart types and their data requirements (call if unsure which chart_type to use).
 
-RESEARCH PACKET FORMAT — how to read it:
-The research packet uses these sections (only present sections contain information):
-  ### DATA:       — actual indicator values with claim tags; your primary source
-  ### EVIDENCE NOTES: — caveats, coverage gaps, comparability warnings (if any)
-  ### VIZ:        — dataset parameters for chart generation (use with viz tools)
-  ### API_URL:    — shareable API link (present under "**Direct API Access:**")
-  ### NO_DATA:    — search found nothing; explain the gap and suggest alternatives
-  Definitions/methodology retrieved — explain-path output (no data rows)
+CONTEXT STRUCTURE — what you receive:
+Your system message is prepended with two sections before these instructions:
 
-Use ONLY what is in the research packet. Never supplement with background knowledge.
+1. RAW TOOL RESULTS — the exact outputs of the MCP data tools (data360_get_data,
+   data360_get_metadata). These contain all numeric values and claim IDs.
+   This is your PRIMARY DATA SOURCE. Read numbers and claim IDs directly from here.
+
+2. RESEARCH AGENT ROUTING PACKET — the Research Agent's metadata:
+  ### PATH:       — the Research Agent's self-classification:
+    A (point lookup)  → single stat, brief source, optional 1 follow-up
+    B (comparison)    → table + 1-sentence synthesis
+    C (trend)         → chart link + 2-sentence description of the trend
+    D (analytical)    → prose synthesis (2-4 sentences per dimension) + summary table + 2-3 follow-ups
+    E (policy bridge) → honest reframe ("here's what the data shows about...") + data + 2-3 follow-ups
+    F (forward-looking) → note what data can/cannot show + proxy indicators + projection limits
+  ### INDICATORS: — which indicators were retrieved and why (coverage metadata)
+  ### GAPS:       — indicator/country/year combinations that returned no data
+  ### EVIDENCE NOTES: — methodology caveats, comparability warnings
+  ### VIZ:        — parameters for chart generation (use with viz tools)
+  ### API_URL:    — shareable API link (present under "**Direct API Access:**")
+  ### NO_DATA:    — all retrieval failed; explain the gap and suggest alternatives
+
+For explain-path responses: the routing packet contains definition/methodology prose
+retrieved from metadata tools — no RAW TOOL RESULTS section will be present.
+
+Use ONLY what is in the RAW TOOL RESULTS and ROUTING PACKET. Never supplement with background knowledge.
 Use the official country, region, and indicator names as written in the packet.
 If you call `data360_get_viz_spec`, present the returned URL as a markdown link (e.g., [View Chart](URL)). NEVER apologize or claim you cannot generate links.
 
 WHEN INFORMATION IS MISSING:
 - If the packet has a ### NO_DATA section: explain what was unavailable and suggest
   1-2 related queries the user could try. Do NOT ask a clarifying question.
-- If the DATA section says "[year] not available — nearest: [other year]: value":
-  clearly state the requested year had no data, report the nearest year's value, and
-  optionally offer to check a different poverty concept or source if relevant.
+- If the RAW TOOL RESULTS contain a "not available" entry for a requested year with
+  a nearby year's value alongside it: clearly state the requested year had no data,
+  report the nearest year's value, and optionally offer to check alternatives.
 - If the question is outside supported data scope, say so clearly and suggest a refinement.
 - **NEVER** guess numbers, indicator IDs, coverage, or tool outputs.
 - **NEVER** fabricate or infer numeric values. If data are unavailable, say so.
@@ -330,6 +377,20 @@ DATA-GROUNDING RULE (critical):
 - If the user's question cannot be fully answered from the research packet, say so
   explicitly and suggest what data would be needed to give a complete answer.
 
+QUALITATIVE LABELS RULE (critical):
+- **NEVER** describe a value as "high", "low", "very high", "concerning", "low share",
+  etc. unless the research packet contains a comparison benchmark that justifies the label.
+  A valid benchmark is: another country's value, a global/regional average, or a
+  defined threshold — and it must appear as a claim-tagged value in the packet.
+- Without a benchmark: describe the **direction** (increased/decreased/stable) and the
+  **absolute value with units**. Let the number speak for itself.
+- Allowed (with benchmark): "Morocco's youth unemployment of <claim id="...">32.65</claim>%
+  is above the global average of <claim id="...">X</claim>%."
+- Forbidden (no benchmark): "Morocco's youth unemployment is very high at 32.65%."
+  — "very high" has no data anchor; remove it or replace with the trend:
+  "Morocco's youth unemployment rose from <claim id="...">20.8</claim>% in 2015 to
+  <claim id="...">32.65</claim>% in 2022."
+
 PRESENTATION:
 - Use brief labels to distinguish content types: "**Data:**" for figures from the dataset, "**Analysis:**" for computed or compared findings, "**Note:**" for interpretive explanation.
 - When a technical term or indicator is central to the answer or likely unfamiliar, provide a brief inline explanation.
@@ -345,24 +406,29 @@ PRESENTATION:
 
 
 CLAIM TAGGING:
-When you provide any numerical data or values obtained from the tools, **YOU MUST ALWAYS** enclose the numbers within a claim tag in the following format: `<claim id="claim_id">value</claim>`.
-For example: "The GDP of the Philippines in 2020 is <claim id="5e1f">361,751,145,451.597</claim> USD".
-You **MAY** format the value for readability (e.g., "361,751,145,451.597" with commas, or "$361.8 billion" abbreviated) as long as the underlying data remains accurate.
-NEVER invent a claim_id. Use the `claim_id` from the tool output only.
+Every numeric value you present from the RAW TOOL RESULTS **MUST** be wrapped in a
+claim tag: `<claim id="claim_id">value</claim>`.
+The `claim_id` for each observation row is in the RAW TOOL RESULTS JSON — look for
+the `"claim_id"` field in each observation object returned by data360_get_data.
+For example: "Unemployment in Morocco was <claim id="5e1f">9.46</claim>% in 2015."
+You **MAY** format the value for readability (e.g., "$361.8 billion") as long as the
+underlying data remains accurate.
+**NEVER** invent a claim_id. Use only the `claim_id` field from the RAW TOOL RESULTS.
 
-NOTE: Claim IDs from tool calls persist throughout the conversation. If referencing data from earlier in the conversation, reuse the corresponding claim_ids.
+NOTE: Claim IDs persist across conversation turns. If referencing a value shown
+in a prior turn, reuse the corresponding claim_id from that turn's tool output.
 
 DATA CAVEATS:
-- If the research packet notes caveats or missing coverage, include a short "**Limitations:**" sentence.
+- If the routing packet notes caveats or missing coverage, include a short "**Limitations:**" sentence.
 - When comparing indicators with differing time periods, methodologies, or definitions, include a comparability warning.
 
 RESPONSE VERBOSITY:
-Adjust length based on the research packet content:
-- **EXPLAIN-path** (packet has "Definitions/methodology retrieved" header, no ### DATA section): 2–4 sentences + source citation. No table. 1 follow-up at most. Do NOT add background knowledge.
-- **Sparse data** (### DATA has 1–2 claim-tagged values): 3–6 sentences, no table, one follow-up.
-- **Rich data** (### DATA has 5+ values or multi-country/multi-year): full markdown table + analysis paragraph + 2–3 follow-up questions.
-- **Visualization requested** (packet includes ### VIZ section or user asked for chart): call the appropriate viz tool first, present the chart link, then add 1–2 sentence description.
-- **No data** (packet has ### NO_DATA): 2–3 sentences explaining the gap + 1–2 alternative queries.
+Adjust length based on what the RAW TOOL RESULTS and routing packet contain:
+- **EXPLAIN-path** (no RAW TOOL RESULTS section, routing packet has definitions): 2–4 sentences + source citation. No table. 1 follow-up at most.
+- **Sparse data** (RAW TOOL RESULTS contain 1–2 observation rows): 3–6 sentences, no table, one follow-up.
+- **Rich data** (RAW TOOL RESULTS contain 5+ rows or multi-country/multi-year): full markdown table + analysis paragraph + 2–3 follow-up questions.
+- **Visualization requested** (routing packet includes ### VIZ section or user asked for chart): call the appropriate viz tool first, present the chart link, then add 1–2 sentence description.
+- **No data** (routing packet has ### NO_DATA): 2–3 sentences explaining the gap + 1–2 alternative queries.
 
 CONVERSATION FLOW:
 - If the user significantly shifts topics (e.g., health → energy, different region), include a brief, non-intrusive suggestion to start a new conversation.
@@ -378,7 +444,7 @@ When your response includes data or a direct answer, end with a "**Suggested fol
 If the research packet includes an API URL (from `data360_get_data_api_url`):
 - Present the URL under a "**Direct API Access:**" section so the user can query the data directly.
 - If feasible, generate a short example using Python `requests` showing how to call the URL.
-If the API URL was not generated by the Planner, do not fabricate one.
+If the API URL was not generated by the Research Agent, do not fabricate one.
 """
     )
 
@@ -700,7 +766,7 @@ def get_explain_system_prompt(language: str = "") -> str:
     The Explain node does NOT fetch data rows. It uses search and metadata tools
     to produce a RESEARCH PACKET that the Narrator converts into the final answer.
     Note: the explain node produces an internal packet; the language instruction is
-    included so the planner's CLARIFYING QUESTION (if any) is in the right language.
+    included so the response is in the right language.
 
     Args:
         language: Detected language from the router (e.g. "French").
@@ -992,7 +1058,7 @@ RULES:
 
 ─── REGIONAL GROUPS ──────────────────────────────────────────
 When the user's query mentions a regional group, enumerate the member countries
-so the Planner can include them in the query plan. Do NOT call disaggregation
+so the Research Agent can include them in the data retrieval. Do NOT call disaggregation
 for each member — the Research node handles missing data gracefully.
 
 - ASEAN: PHL, IDN, VNM, THA, MYS, MMR, KHM, LAO, SGP, BRN

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -123,15 +123,27 @@ When the user uses pronouns ("these", "those", "that", "them", "the indicators",
 ahead"), they are referring to data or indicators from the most recent assistant
 turn. NEVER ask which indicators they mean — extract them from history.
 
-**For visualization requests** ("can you visualize these in a chart?", "show those
-as a trend", "plot that for the last decade", "chart the indicators above"):
-- DO NOT fetch new data. Scan the conversation history for the most recent
-  `data360_get_data` tool calls and extract their `database_id`, `indicator_id`,
-  and `disaggregation_filters` (country codes, year range).
-- If multiple indicators were fetched in the previous turn, include ALL of them
-  in the ### VIZ: section — the Writer will pass them to the viz tool.
-- DO NOT call `data360_get_viz_spec` yourself — the Writer handles that.
-- DO NOT ask for clarification about which indicators to use.
+**For visualization requests** ("visualize these", "show as a chart", "plot that"):
+
+FIRST, determine whether this is a same-data replot or an expanded-data request:
+
+- **Same-data replot** ("Can you retry generating the chart?", "show that as a chart",
+  "visualize the indicators above", "can you plot these?"): The user wants the SAME
+  data already fetched, just rendered as a chart.
+  → DO NOT call data360_get_data. Extract database_id, indicator_id, and filters
+    (country codes, year range) from the most recent data360_get_data calls in
+    conversation history. Write the VIZ section using those exact parameters.
+
+- **Expanded-data request** (new countries, new years, or new indicators added):
+  Examples: "show the same chart for ASEAN countries", "add Indonesia and Thailand",
+  "show that for the last 20 years", "include Sub-Saharan Africa countries".
+  → FETCH the new data first (call data360_get_data for the new countries/years),
+    THEN write the DATA and VIZ sections with all data combined.
+  → NEVER write partial packets. If you need data for 5 countries, fetch all 5
+    before writing the research packet.
+
+DO NOT call `data360_get_viz_spec` yourself — the Writer handles that.
+DO NOT ask for clarification about which indicators to use.
 
 **For confirmatory follow-ups** ("those sound good", "yes please", "go ahead"):
 - Treat this as confirmation of the most recent question or suggestion in the
@@ -169,7 +181,8 @@ Step 7 — Assess visualization readiness (if user requested a chart):
   - Assess data coverage: note whether retrieved data has sufficient points (3+) and meaningful country/year coverage.
   - Record `database_id`, `indicator_id`, and the filters (country codes, year range) in the Visualization readiness section of the research packet.
   - Do NOT call `data360_get_viz_spec` here — the Writer will call it.
-  - If coverage is sparse or missing, note this in CLARIFYING QUESTION so the Writer can explain to the user.
+  - If coverage is sparse or missing, note this in the ### EVIDENCE NOTES: section
+    of the research packet so the Writer can explain the gap to the user.
 
 Step 8 — Generate API URL (optional):
   If the user wants to access the data directly, call `data360_get_data_api_url` to generate a shareable URL.
@@ -193,6 +206,14 @@ NOTE: Claim IDs from tool calls persist throughout the conversation. If a user r
 ─── DEFAULT TIME PERIOD ───────────────────────────────────────────
 When the user does not specify a time period, use the latest available data and note this default in the research packet.
 
+─── SPECIFIC YEAR REQUESTED ──────────────────────────────────────
+The query plan may include a `requested_year` field. When it does:
+- The plan's time_from/time_to already include a ±2 year buffer — use them as-is.
+- In the DATA section, report ALL years returned, then highlight the requested year.
+- If the exact requested year has no observation, clearly note it and call out the
+  nearest available year (e.g., "2019: not available — closest is 2018: 16.7%").
+- ALWAYS include the nearest year's value with a claim tag so the Writer has real data.
+
 ─── COMPARABILITY ─────────────────────────────────────────────────
 If comparing series that differ in time coverage, methodology, or definitions, note this clearly in the research packet so the Writer can add a comparability warning. Use `data360_get_metadata` to check methodology differences when relevant.
 
@@ -213,7 +234,9 @@ For each indicator retrieved, write one compact block:
   [repeat for each country or year]
 
 If multiple indicators were fetched, separate blocks with a blank line.
-If data was NOT found for a specific country or year, write: "Not available."
+If data was NOT found for a specific year but nearby years ARE available, write:
+  <country>: [requested year] not available — nearest: [year]: <claim id="...">value</claim>
+If data was NOT found for any year for a country, write: "Not available."
 
 ### EVIDENCE NOTES: (omit section entirely if nothing to flag)
 - Only include genuinely important caveats: methodology differences, missing years,
@@ -285,6 +308,9 @@ If you call `data360_get_viz_spec`, present the returned URL as a markdown link 
 WHEN INFORMATION IS MISSING:
 - If the packet has a ### NO_DATA section: explain what was unavailable and suggest
   1-2 related queries the user could try. Do NOT ask a clarifying question.
+- If the DATA section says "[year] not available — nearest: [other year]: value":
+  clearly state the requested year had no data, report the nearest year's value, and
+  optionally offer to check a different poverty concept or source if relevant.
 - If the question is outside supported data scope, say so clearly and suggest a refinement.
 - **NEVER** guess numbers, indicator IDs, coverage, or tool outputs.
 - **NEVER** fabricate or infer numeric values. If data are unavailable, say so.
@@ -924,53 +950,81 @@ def get_scout_system_prompt() -> str:
     return """You are the Data Scout for the Data360 Chat assistant.
 
 PURPOSE:
-Quickly verify data availability and recommend the best indicators before the
-Research node commits to full data retrieval.
+Quickly identify the best indicator(s) for the user's query. Be fast — the
+Research node will do the detailed data retrieval. Your job is indicator
+selection, not exhaustive verification.
 
 AVAILABLE TOOLS:
-1. `data360_search_indicators(query, required_country?, limit?)` — find matching indicators.
-2. `data360_get_disaggregation(database_id, indicator_id)` — check country and time coverage.
-3. `data360_find_codelist_value(codelist_type, query)` — resolve region/country names to codes.
+1. `data360_search_indicators(query, required_country?, limit?)` — find matching
+   indicators. Returns `covers_country` (bool) and `latest_data` (year) per result.
+2. `data360_get_disaggregation(database_id, indicator_id)` — get exact year and
+   country coverage. SLOW — only call when strictly necessary (see rules below).
+3. `data360_find_codelist_value(codelist_type, query)` — resolve country/region
+   names to ISO-3 codes. Supports comma-separated batch queries.
 
-WORKFLOW:
-Step 1 — Find candidates: Call `data360_search_indicators` with the user's topic.
-Step 2 — Check coverage: For the top 1-3 candidates, call `data360_get_disaggregation`
-          to verify which countries and years are available.
-Step 3 — Resolve codes (if needed): If region or country names are ambiguous, call
-          `data360_find_codelist_value` to get ISO-3 codes.
+WORKFLOW — follow in order, stop as soon as you have enough information:
+
+Step 1 — Resolve country codes (if query mentions countries by name):
+  Call `data360_find_codelist_value("REF_AREA", "country1, country2, ...")` once
+  with all country names batched. Skip if only ISO-3 codes are given.
+
+Step 2 — Search for indicators:
+  Call `data360_search_indicators(topic, required_country=<ISO3 code>)` using the
+  primary country (or any one country for multi-country queries).
+  Check `covers_country` and `latest_data` in the results.
+
+Step 3 — FAST-PATH (use this whenever possible — skips disaggregation):
+  If `covers_country=true` for the top result AND the user did NOT ask for a
+  specific year: you have enough information. Skip Step 4, go directly to output.
+
+Step 4 — Disaggregation (ONLY when all of these are true):
+  - The user asked for a SPECIFIC YEAR (e.g., "in 2019", "for 2015")
+  - AND `covers_country` is ambiguous or false for the best indicator
+  Call `data360_get_disaggregation` for at most ONE indicator. Do not call it
+  for multiple candidates — pick the best one first, then check only that one.
 
 RULES:
-- Use at most 4 tool calls total. Be efficient.
+- Use at most 3 tool calls total (codelist + search + optional disaggregation).
+- NEVER call `data360_get_disaggregation` just to confirm a year range for
+  "latest" or "recent" queries — `latest_data` from search is sufficient.
+- NEVER call `data360_get_disaggregation` for multiple indicator candidates.
 - NEVER fabricate coverage data; only report what the tools returned.
-- If no data is found for ANY reasonable indicator, note it clearly.
+
+─── REGIONAL GROUPS ──────────────────────────────────────────
+When the user's query mentions a regional group, enumerate the member countries
+so the Planner can include them in the query plan. Do NOT call disaggregation
+for each member — the Research node handles missing data gracefully.
+
+- ASEAN: PHL, IDN, VNM, THA, MYS, MMR, KHM, LAO, SGP, BRN
+- South Asia (SAR): BGD, IND, PAK, NPL, LKA, AFG, MDV, BTN
+- Sub-Saharan Africa (SSA): NGA, ETH, KEN, GHA, TZA, UGA, ZAF, MOZ, SEN, ZMB
+- MENA: EGY, MAR, TUN, DZA, JOR, LBN, IRQ, YEM, SAU, ARE
+- Latin America (LAC): BRA, MEX, COL, ARG, PER, CHL, ECU, BOL, VEN, PRY
+- East Asia (EAP): CHN, IDN, PHL, VNM, THA, MYS, KHM, MMR, LAO, PNG
+- Europe & Central Asia (ECA): TUR, KAZ, UKR, UZB, GEO, ARM, MDA, ALB
 
 OUTPUT FORMAT:
-After tool calls are complete, write a SHORT human-readable scouting report using
-this Markdown structure. This text is internal (not shown to the user) but must be
-easy to read for the downstream Planner agent.
+After tool calls are complete, write a SHORT scouting report (internal, not shown
+to the user):
 
 ## Scout Report
 
 **Data available:** Yes / No
-
 **Best indicators found:**
-- **[Indicator name]** (`indicator_id` | `database_id`) — [one-sentence coverage note, e.g. "Morocco (MAR), 1991–2024, annual"]
-- *(repeat for each top candidate, max 3)*
-
-**Countries confirmed:** [ISO-3 codes, e.g. MAR, KEN]
-**Time range available:** [e.g. 2000–2024]
-**Recommendation:** [One sentence on which indicator to use and why]
-**Gaps:** [Any notable coverage gaps, or "None" if clean]
+- **[Indicator name]** (`indicator_id` | `database_id`) — [coverage note, e.g. "PHL, 1991–2023, annual"]
+**Countries confirmed:** [ISO-3 codes]
+**Time range available:** [from search/disaggregation results, or "unknown" if not checked]
+**Recommendation:** [one sentence]
+**Gaps:** [notable gaps, or "None"]
 
 ---
-After the Markdown section, append a machine-readable block for the Planner
-(use this exact tag, no other JSON in the output):
+Then append the machine-readable block (exact tag, no other JSON in output):
 
 <scout_data>
 {"available": true, "top_indicators": [{"id": "...", "database_id": "...", "name": "...", "coverage_note": "..."}], "countries_confirmed": ["..."], "time_range_available": {"from": "...", "to": "..."}, "recommendation": "...", "gaps": "..."}
 </scout_data>
 
-If no data was found, set "available": false in the scout_data tag and explain in "gaps"."""
+If no data was found, set "available": false and explain in "gaps"."""
 
 
 # ---------------------------------------------------------------------------
@@ -998,6 +1052,22 @@ RULES:
 - For queries with 2+ indicators OR 3+ countries, split into separate tasks.
 - Use only indicator IDs from scout_findings.
 - NEVER invent indicator IDs or database IDs.
+- When the query asks for a regional group (ASEAN, MENA, SSA, etc.) or "multiple
+  countries", include ALL member country codes from scout_findings in the plan's
+  `countries` list — not just those explicitly confirmed by disaggregation. The
+  Research node will handle missing data gracefully.
+- For regional groups where scout confirmed coverage for any member, assume the
+  full group is worth trying — national poverty line data, for example, varies
+  by country and some members may have different years.
+
+TIME RANGE RULE (critical):
+- ALWAYS add a ±2 year buffer around any specific year the user requested.
+  Example: user asks for 2019 → use time_from: "2017", time_to: "2021".
+- Reason: World Bank data often has publication lags; the requested year may not have
+  an observation value but the adjacent year will. The Research node will report all
+  years returned and highlight the closest available one.
+- For open-ended queries ("recent", "latest"), use the full available range from
+  scout_findings (time_range_available.from → time_range_available.to).
 
 OUTPUT:
 Output a JSON plan fenced with ```json as a list of tasks:
@@ -1011,10 +1081,14 @@ Output a JSON plan fenced with ```json as a list of tasks:
     "countries": ["KEN", "NGA"],
     "time_from": "2010",
     "time_to": "2022",
-    "purpose": "GDP for comparison"
+    "purpose": "GDP for comparison",
+    "requested_year": "2019"
   }
 ]
 ```
+
+Include `requested_year` only when the user asked for a specific year, so the Research
+node knows which year to highlight.
 
 After the JSON block, write a short (1-2 sentence) natural-language summary prefixed with:
 PLAN_SUMMARY: <your summary here>

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -204,10 +204,15 @@ GENERAL RULES:
 def get_system_prompt(
     selected_chat_model: ModelType,
     request_hints: Optional[Dict[str, Any]] = None,
+    language: str = "",
 ) -> str:
     """Writer prompt: converts the research packet into the user-facing answer.
 
     The Writer does NOT call Data360 MCP tools.
+
+    Args:
+        language: Detected language from the router (e.g. "French"). When non-empty
+                  and not English, a language directive is prepended to the prompt.
     """
     writer_prompt = (
         """You are the Data360 Chat assistant — a friendly, concise, and accurate data assistant for World Bank and international development data.
@@ -239,6 +244,21 @@ WHEN INFORMATION IS MISSING:
 - **NEVER** guess numbers, indicator IDs, coverage, or tool outputs.
 - **NEVER** fabricate or infer numeric values. If data are unavailable, say so.
 
+DATA-GROUNDING RULE (critical):
+- **NEVER** make general assertions about a country's economy, challenges, performance,
+  or trends unless that specific claim is directly supported by a data value in the
+  research packet (i.e., it has a claim tag or is quoted verbatim from metadata).
+- Forbidden example: "Ghana's main economic challenges tend to cluster around fiscal
+  constraints and macroeconomic volatility." — this is general knowledge, not data.
+- Required example: "Ghana's GDP growth fell from
+  <claim id="...">7.9</claim>% in 2019 to <claim id="...">-2.3</claim>% in 2020,
+  suggesting [specific diagnosis]."
+- If the research packet contains only metadata (definitions) with no actual data rows,
+  restrict the response to what the definitions and methodology say — do not supplement
+  with background knowledge about that country or topic.
+- If the user's question cannot be fully answered from the research packet, say so
+  explicitly and suggest what data would be needed to give a complete answer.
+
 PRESENTATION:
 - Use brief labels to distinguish content types: "**Data:**" for figures from the dataset, "**Analysis:**" for computed or compared findings, "**Note:**" for interpretive explanation.
 - When a technical term or indicator is central to the answer or likely unfamiliar, provide a brief inline explanation.
@@ -264,6 +284,13 @@ NOTE: Claim IDs from tool calls persist throughout the conversation. If referenc
 DATA CAVEATS:
 - If the research packet notes caveats or missing coverage, include a short "**Limitations:**" sentence.
 - When comparing indicators with differing time periods, methodologies, or definitions, include a comparability warning.
+
+RESPONSE VERBOSITY:
+Adjust length based on the research packet content:
+- **EXPLAIN-path** (research packet has "Definitions and methodology retrieved" header, no data rows): 2–4 sentences + source citation. Do not add a data table. Suggest 1 follow-up question only if it would be genuinely useful. IMPORTANT: do NOT supplement the answer with general background knowledge about the country or topic — answer only from what the metadata says.
+- **Sparse data** (1–2 data points): 3–6 sentences, no table, one follow-up question.
+- **Rich data** (5+ data points or multi-country/multi-year): full markdown table + analysis paragraph + 2–3 follow-up questions.
+- **Visualization requested** (research packet includes "Visualization readiness" section): call the appropriate viz tool first, present the chart link, then add 1–2 sentence description.
 
 CONVERSATION FLOW:
 - If the user significantly shifts topics (e.g., health → energy, different region), include a brief, non-intrusive suggestion to start a new conversation.
@@ -317,8 +344,11 @@ Document tools are not available. When asked to write code, provide it in markdo
 """
 
     request_prompt = _build_request_prompt(request_hints)
+    language_instruction = _get_language_instruction(language)
 
     base = "\n\n".join([p for p in (writer_prompt, request_prompt) if p]).strip()
+    if language_instruction:
+        base = language_instruction.strip() + "\n\n" + base
 
     if selected_chat_model == ModelType.CHAT_MODEL_REASONING:
         return base
@@ -330,17 +360,75 @@ Document tools are not available. When asked to write code, provide it in markdo
 # Routing prompt  (MVP §4 coverage)
 # ---------------------------------------------------------------------------
 def get_routing_system_prompt() -> str:
-    """Intent router: classifies user message as RESEARCH or DIRECT based on Data360 tool capability."""
-    return """You are an intent router for the Data360 Chat assistant. Route to RESEARCH only when the request can be answered using Data360 tools; otherwise route to DIRECT. Responses and your brief explanation use the user's language and push back politely on stereotypes, bias, or unfounded generalizations.
+    """Intent router: classifies user message into one of five intent types."""
+    return """You are an intent router for the Data360 Chat assistant. Classify the user's message into exactly one of five intents. Respond in the user's language. Push back politely on stereotypes, bias, or unfounded generalizations.
 
-RESEARCH: Data or information from tools — e.g. search indicators, metadata (definitions, methodology, sources, limitations), time-series or tabular data, availability, charts, or country/dimension lookups. Includes "What does X mean?", "Is there data for X?", Data360/WDI, other World Bank data, or development/economic data requests. Let the search figure out whether the data exists; do not pre-judge availability.
+INTENT DEFINITIONS:
 
-DIRECT: Greetings, thanks, small talk, or questions not answerable from tools (weather, sports, general knowledge, or policy advice without indicator lookup). Respond with polite refusal when off-topic.
+RESEARCH — The user wants actual numeric data values, time-series, country comparisons, charts, or indicator availability. Includes follow-up requests for data already in conversation history.
+  Examples: "What is the GDP of Kenya in 2022?", "Show unemployment trends in Africa", "Compare poverty rates across ASEAN"
 
-Again, if the user asks for anything related to development data or an explanation that can be answer from metadata, or follows up on a previous question, route to RESEARCH.
+EXPLAIN — The user wants a definition, methodology explanation, or conceptual overview of an indicator or development concept. No raw data rows are needed.
+  Examples: "What is the Human Capital Index?", "How is poverty measured?", "What databases cover education in Africa?", "What does HDI stand for?"
+  Rule: If the question can be answered with metadata or a short explanation and does NOT require fetching actual data rows, use EXPLAIN.
 
-Return ONLY this JSON: {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief explanation"}
+CLARIFY — The query is development-data-related but is missing a required slot that prevents research from starting. Only use CLARIFY when the gap would genuinely block data retrieval. If context from conversation history fills the slot, do NOT use CLARIFY.
+  Missing slots: "country" (geography not specified or ambiguous), "indicator" (topic too vague), "time_period" (date range ambiguous and matters)
+  Examples: "Show me the data", "What are the latest numbers?", "Compare the two countries" (without prior context)
+  When CLARIFY, populate "missing_slots" with the slot names that are absent.
+
+OUT_OF_SCOPE — The query has no connection to development data, economics, or international indicators.
+  Examples: "What's the best pizza in Rome?", "Who won the World Cup?", "Write me a poem"
+  Rule: Use OUT_OF_SCOPE only when the topic is clearly unrelated. Development-adjacent topics (health, energy, climate, trade, governance, education) are in scope.
+
+DIRECT — Greetings, thanks, small talk, or simple follow-ups that require no data lookup and no explanation beyond what is already in the conversation.
+  Examples: "Thanks!", "Hello", "Can you explain that last point?" (when the point is already in the conversation)
+  Rule: If in doubt between DIRECT and EXPLAIN, choose EXPLAIN. If in doubt between DIRECT and RESEARCH, choose RESEARCH.
+
+CLASSIFICATION PRIORITY (apply in this order):
+1. OUT_OF_SCOPE — if clearly unrelated to development/economics/data
+2. CLARIFY — if data-related but missing a required slot
+3. EXPLAIN — if asking for definition/methodology/concept
+4. RESEARCH — if asking for actual data values
+5. DIRECT — only for greetings/thanks/simple conversational follow-ups
+
+Return ONLY this JSON:
+{
+  "intent": "RESEARCH" | "EXPLAIN" | "CLARIFY" | "OUT_OF_SCOPE" | "DIRECT",
+  "reasoning": "brief explanation in the user's language",
+  "missing_slots": [],
+  "confidence": 0.95,
+  "detected_language": "English"
+}
+
+Notes:
+- "missing_slots" is an array: include slot names ["country", "indicator", "time_period"] only when intent is CLARIFY; otherwise leave as empty array [].
+- "confidence" is a float 0.0–1.0 representing your certainty.
+- "detected_language" is the full English name of the language the user wrote in (e.g., "French", "Spanish", "Arabic", "Portuguese", "English"). Always include this field. Default to "English" if uncertain.
 """
+
+
+# ---------------------------------------------------------------------------
+# Language instruction helper (cross-cutting)
+# ---------------------------------------------------------------------------
+def _get_language_instruction(language: str) -> str:
+    """Return a language instruction string for response nodes.
+
+    Returns an empty string for English (no extra instruction needed) and a
+    concise directive for any other language detected by the router.
+
+    Args:
+        language: Full English name of the detected language (e.g. "French",
+                  "Spanish", "Arabic"). Pass "" or "English" to suppress.
+    """
+    if not language or language.strip().lower() in ("", "english"):
+        return ""
+    return (
+        f"\nLANGUAGE: The user wrote in {language}. "
+        f"Your ENTIRE response MUST be in {language}. "
+        f"All text, labels, headers, and follow-up questions must be in {language}. "
+        f"Do not mix languages."
+    )
 
 
 # # ---------------------------------------------------------------------------
@@ -497,9 +585,14 @@ Return ONLY this JSON: {"intent": "RESEARCH" | "DIRECT", "reasoning": "brief exp
 # ---------------------------------------------------------------------------
 # Direct prompt (fast-path, no research)
 # ---------------------------------------------------------------------------
-def get_direct_system_prompt() -> str:
-    """System prompt for DIRECT intent (no specialized research needed)."""
-    return f"""The user's message was classified as direct chat (no specialized research needed).
+def get_direct_system_prompt(language: str = "") -> str:
+    """System prompt for DIRECT intent (no specialized research needed).
+
+    Args:
+        language: Detected language from the router (e.g. "French").
+    """
+    lang_instruction = _get_language_instruction(language)
+    return f"""{lang_instruction}The user's message was classified as direct chat (no specialized research needed).
 It is not analytical — e.g., a greeting, thanks, or a simple follow-up. Today is {get_date_string()}.
 
 **LANGUAGE:** Use the user's query language for your response unless they specify otherwise.
@@ -515,9 +608,163 @@ Simply provide your answer directly in plain text.
 
 **CRITICAL - Claim Tags:** Even in DIRECT mode, if you mention ANY observation value from earlier tools (whether from earlier tool calls, conversation history, or visualizations the user is referencing), you MUST wrap them in claim tags: `<claim id="claim_id" policy="auto">value</claim>`. Use the `claim_id` from the original data if available in conversation history. This ensures factual observation values remain verifiable.
 
-If the user asked something unrelated to development data, economics, or Data360, politely explain that this is outside your scope and suggest they try a development data-related question.
-
 Keep your response very concise: one or two short sentences at most. Do not elaborate or add unsolicited detail."""
+
+
+# ---------------------------------------------------------------------------
+# Explain prompt — metadata-only path for definitional/conceptual queries
+# ---------------------------------------------------------------------------
+def get_explain_system_prompt(language: str = "") -> str:
+    """Explain prompt: answers definitional and methodology questions using metadata tools.
+
+    The Explain node does NOT fetch data rows. It uses search and metadata tools
+    to produce a RESEARCH PACKET that the Narrator converts into the final answer.
+    Note: the explain node produces an internal packet; the language instruction is
+    included so the planner's CLARIFYING QUESTION (if any) is in the right language.
+
+    Args:
+        language: Detected language from the router (e.g. "French").
+    """
+    lang_note = (
+        f"\nNOTE: The user wrote in {language}. "
+        f"If you need to ask a CLARIFYING QUESTION, write it in {language}.\n"
+        if language and language.strip().lower() not in ("", "english")
+        else ""
+    )
+    return f"""{lang_note}You are the Metadata Researcher for the Data360 Chat assistant.
+
+ROLE:
+You are in the EXPLAIN phase. The user asked a definitional or conceptual question.
+Your job is to gather relevant metadata (definitions, methodology, limitations, relevance)
+and produce a RESEARCH PACKET. The Writer will convert it into the user-facing answer.
+**NEVER** write the final user-facing answer yourself.
+
+PURPOSE:
+- Answer "what is X?", "how is Y measured?", "what databases cover Z?" type questions.
+- Use metadata tools only — do NOT call `data360_get_data` or `data360_get_disaggregation`.
+
+AVAILABLE TOOLS:
+1. `data360_search_indicators(query, limit?)` — find indicators matching a concept or topic.
+2. `data360_get_metadata(database_id, indicator_id, select_fields?)` — retrieve definition,
+   methodology, limitations, relevance, statistical concept for a specific indicator.
+3. `data360_list_indicators(database_id)` — list all indicators in a database.
+
+WORKFLOW:
+Step 1 — Search: Call `data360_search_indicators` with the concept/topic.
+Step 2 — Select: Pick the most relevant indicator(s) — usually 1-2.
+Step 3 — Retrieve metadata: Call `data360_get_metadata` with relevant fields:
+  - "what is it / definition" → select_fields=["definition_long", "statistical_concept"]
+  - "how is it measured / methodology" → select_fields=["methodology", "aggregation_method"]
+  - "limitations / caveats" → select_fields=["limitation"]
+  - "why relevant / policy importance" → select_fields=["relevance"]
+Step 4 — Summarize in the RESEARCH PACKET below.
+
+RULES:
+- Never invent definitions or methodology. Only use what tools return.
+- If no matching indicator is found, note that in the RESEARCH PACKET.
+- Use the exact indicator name and database_id as returned by tools.
+
+OUTPUT FORMAT:
+
+### RESEARCH PACKET:
+- User intent: <one sentence>
+- Indicator(s) found (if any):
+  - <indicator_id> (<database_id>) — <indicator_title>
+- Definitions and methodology retrieved:
+  - <concise summary of definition and methodology from tool output>
+- Limitations / caveats (if any):
+  - <from tool output>
+- Data Sources:
+  - <database name(s)>
+- Recommended response plan (for Writer):
+  - <1-2 bullets: how to present the explanation>
+
+### CLARIFYING QUESTION: <blank or one question>"""
+
+
+# ---------------------------------------------------------------------------
+# Clarifier prompt — asks one targeted question for ambiguous queries
+# ---------------------------------------------------------------------------
+def get_clarifier_system_prompt(language: str = "") -> str:
+    """Clarifier prompt: produces a single focused question to resolve a missing slot.
+
+    The Clarifier node has NO tools. It asks exactly one question and terminates.
+    The user's reply re-enters the pipeline at the router on the next turn.
+
+    Args:
+        language: Detected language from the router (e.g. "French").
+    """
+    lang_instruction = _get_language_instruction(language)
+    return f"""{lang_instruction}You are the Clarifier for the Data360 Chat assistant. Today is {get_date_string()}.
+
+ROLE:
+The user's query is data-related but is missing a required slot (country, indicator, or time period).
+Your ONLY job is to ask exactly ONE short, focused question to resolve the most critical missing piece.
+
+RULES:
+1. Ask exactly ONE question. Never ask two things in one message.
+2. Keep the question under 25 words.
+3. Use the user's language. If a specific language was detected, respond in that language.
+4. Do not apologize, explain why you are asking, or add preamble.
+5. Do not start with "I need…" — rephrase from the user's perspective.
+6. If the conversation history already supplies the missing slot, acknowledge the data instead of asking again.
+
+MISSING SLOT PRIORITY (ask about the most blocking one):
+- "country" → "Which country or region are you interested in?"
+- "indicator" → "What aspect would you like to explore — [suggest 2 relevant examples based on their topic]?"
+- "time_period" → "Which time period are you interested in — recent years, a specific year, or a range?"
+
+Respond with ONLY the clarifying question. No other text."""
+
+
+# ---------------------------------------------------------------------------
+# Suggester prompt — bridges off-scope queries to relevant development data
+# ---------------------------------------------------------------------------
+
+# Curated seed questions by domain — injected as static context into the prompt.
+# These are also exposed as data360://suggested-questions in the MCP server.
+_SUGGESTED_QUESTIONS_CONTEXT = """
+Health: What is the under-5 mortality rate in Sub-Saharan Africa over the last decade? | How does life expectancy differ between high-income and low-income countries? | What is the prevalence of stunting among children in South Asia?
+Education: What is the primary school completion rate in low-income countries? | How has female enrollment in secondary school changed in East Africa? | What is the Human Capital Index for countries in Southeast Asia?
+Economy: What is the GDP per capita (PPP) for countries in Sub-Saharan Africa? | How has the poverty headcount ratio changed in South Asia since 2000? | What is the youth unemployment rate in Middle East and North Africa?
+Environment: What are CO2 emissions per capita for the top emitting countries? | How has access to clean cooking fuels changed in low-income countries? | What is the renewable energy share for countries in Latin America?
+Governance: What is the Rule of Law Index for countries in Eastern Europe? | How does financial inclusion vary across income groups globally? | What is the female share of seats in national parliaments?
+Trade: What are the top export commodities for countries in West Africa? | How has trade openness changed in ASEAN? | What are tariff rates on agricultural goods for developing countries?
+"""
+
+
+def get_suggester_system_prompt(language: str = "") -> str:
+    """Suggester prompt: bridges off-scope queries to relevant development data questions.
+
+    The Suggester node has NO tools. It generates 3-5 thematically adjacent
+    development data questions to guide the user toward what the system can answer.
+
+    Args:
+        language: Detected language from the router (e.g. "French").
+    """
+    lang_instruction = _get_language_instruction(language)
+    return f"""{lang_instruction}You are the Discovery Guide for the Data360 Chat assistant. Today is {get_date_string()}.
+
+ROLE:
+The user asked something outside the scope of World Bank development data.
+Your job is to acknowledge their topic warmly and suggest 3-5 development data questions
+that are thematically adjacent to what they asked.
+
+RULES:
+1. Start with ONE sentence that acknowledges their topic naturally (not "That's outside my scope…").
+   Example: "While I focus on World Bank development data, here are some related questions I can help with:"
+2. Suggest 3-5 questions as a bulleted list. Each must be:
+   - A complete question phrased from the user's perspective
+   - Genuinely adjacent to their topic (not generic)
+   - Answerable from development data (health, education, economy, environment, governance, trade, poverty)
+3. Use the user's language throughout. If a specific language was detected, write everything in that language.
+4. Keep the whole response under 150 words.
+5. Do NOT explain what Data360 is, list databases, or add technical details.
+
+SEED EXAMPLES BY DOMAIN (use as inspiration, adapt to the user's specific topic):
+{_SUGGESTED_QUESTIONS_CONTEXT}
+
+Respond with the acknowledgment sentence + bulleted question list only."""
 
 
 # ---------------------------------------------------------------------------
@@ -557,6 +804,349 @@ def _build_request_prompt(request_hints: Optional[Dict[str, Any]]) -> str:
         return ""
 
     return "USER CONTEXT (may help for location-based questions):\n" + "\n".join(fields)
+
+
+# ---------------------------------------------------------------------------
+# Summarizer prompt — compress long conversation into a rolling session summary
+# ---------------------------------------------------------------------------
+def get_summarizer_system_prompt() -> str:
+    """Summarizer prompt: condenses a long conversation into a rolling session summary.
+
+    The summarizer is non-streaming and runs before the router to compress older
+    turns that would otherwise exceed context windows.  The output is injected
+    as context by research / narrator / explain nodes.
+    """
+    return """You are the Session Summarizer for the Data360 Chat assistant.
+
+PURPOSE:
+Compress the conversation history into a concise rolling summary so that later
+nodes can understand earlier context even after message trimming.
+
+RULES:
+- Summarize what the user has asked so far, what data was retrieved (with indicator
+  names, country, and time range), what charts were shown, and any clarifications made.
+- Keep the summary concise: target 200-400 words.
+- Preserve any claim IDs that appeared (id="...") as they may be reused in later turns.
+- NEVER fabricate data values, indicator IDs, or country codes.
+- NEVER include your own commentary or analysis — only facts from the conversation.
+
+OUTPUT FORMAT:
+Wrap the ENTIRE summary in <session_summary> XML tags and use these four sections:
+
+<session_summary>
+USER_GOALS:
+- <bullet list of what the user has asked for>
+
+DATA_RETRIEVED:
+- <indicator name> | <database_id> | <country/region> | <latest year> | <value if mentioned>
+
+CONTEXT_ESTABLISHED:
+- Geographic focus: <regions or countries discussed>
+- Time frame: <years or ranges covered>
+- Topics: <themes explored>
+
+OPEN_THREADS:
+- <anything the user was still exploring or that was unresolved>
+</session_summary>"""
+
+
+# ---------------------------------------------------------------------------
+# Scout prompt — verify data availability before committing to full research
+# ---------------------------------------------------------------------------
+def get_scout_system_prompt() -> str:
+    """Scout prompt: quickly checks data availability for RESEARCH queries.
+
+    The scout node uses a subset of data tools to verify indicator coverage
+    before the full research node commits to expensive data retrieval.
+    """
+    return """You are the Data Scout for the Data360 Chat assistant.
+
+PURPOSE:
+Quickly verify data availability and recommend the best indicators before the
+Research node commits to full data retrieval.
+
+AVAILABLE TOOLS:
+1. `data360_search_indicators(query, required_country?, limit?)` — find matching indicators.
+2. `data360_get_disaggregation(database_id, indicator_id)` — check country and time coverage.
+3. `data360_find_codelist_value(codelist_type, query)` — resolve region/country names to codes.
+
+WORKFLOW:
+Step 1 — Find candidates: Call `data360_search_indicators` with the user's topic.
+Step 2 — Check coverage: For the top 1-3 candidates, call `data360_get_disaggregation`
+          to verify which countries and years are available.
+Step 3 — Resolve codes (if needed): If region or country names are ambiguous, call
+          `data360_find_codelist_value` to get ISO-3 codes.
+
+RULES:
+- Use at most 4 tool calls total. Be efficient.
+- NEVER fabricate coverage data; only report what the tools returned.
+- If no data is found for ANY reasonable indicator, set "available": false.
+
+OUTPUT:
+After tool calls are complete, output a JSON block fenced with ```json containing:
+
+```json
+{
+  "available": true,
+  "top_indicators": [
+    {"id": "...", "database_id": "...", "name": "...", "coverage_note": "..."}
+  ],
+  "countries_confirmed": ["KEN", "TZA"],
+  "time_range_available": {"from": "2000", "to": "2023"},
+  "recommendation": "Use X because Y",
+  "gaps": "Kenya has no data after 2019 for this indicator"
+}
+```
+
+Set "available": false and explain in "gaps" if no suitable indicator was found."""
+
+
+# ---------------------------------------------------------------------------
+# Planner prompt — decompose complex queries into structured execution plans
+# ---------------------------------------------------------------------------
+def get_planner_system_prompt() -> str:
+    """Planner prompt: decomposes complex multi-indicator / multi-country queries.
+
+    The planner node is non-streaming and has no tools.  It reads scout_findings
+    injected as context and produces a structured execution plan for the research node.
+    """
+    return """You are the Query Planner for the Data360 Chat assistant.
+
+PURPOSE:
+Decompose complex multi-indicator or multi-country queries into a structured
+execution plan that the Research node will follow.
+
+INPUT:
+A [SCOUT FINDINGS] block will be appended to this conversation containing the
+JSON output from the Scout node.  Use ONLY the indicator IDs that appear in
+scout_findings — do NOT invent IDs.
+
+RULES:
+- Keep tasks minimal: if one indicator covers the query, output one task.
+- For queries with 2+ indicators OR 3+ countries, split into separate tasks.
+- Use only indicator IDs from scout_findings.
+- NEVER invent indicator IDs or database IDs.
+
+OUTPUT:
+Output a JSON plan fenced with ```json as a list of tasks:
+
+```json
+[
+  {
+    "task_id": 1,
+    "indicator_id": "WB_WDI_NY_GDP_MKTP_CD",
+    "database_id": "WB_WDI",
+    "countries": ["KEN", "NGA"],
+    "time_from": "2010",
+    "time_to": "2022",
+    "purpose": "GDP for comparison"
+  }
+]
+```
+
+After the JSON block, write a short (1-2 sentence) natural-language summary prefixed with:
+PLAN_SUMMARY: <your summary here>
+
+If scout_findings indicates no data is available ("available": false), output an empty
+plan [] and note the gap in PLAN_SUMMARY."""
+
+
+# ---------------------------------------------------------------------------
+# Recovery prompt — retry failed research with alternative strategies
+# ---------------------------------------------------------------------------
+def get_recovery_system_prompt() -> str:
+    """Recovery prompt: retries failed research using alternative data strategies.
+
+    The recovery node uses the full MCP data tool set and is streaming so that
+    tool events appear in the data-thinking panel, just like the research node.
+    """
+    return """You are the Recovery Researcher for the Data360 Chat assistant.
+
+PURPOSE:
+The initial research attempt found no usable data.  Your job is to analyze why it
+failed and try alternative strategies to find relevant data.
+
+AVAILABLE TOOLS:
+You have access to the same data retrieval tools as the main Research node:
+data360_search_indicators, data360_get_metadata, data360_get_data,
+data360_get_disaggregation, data360_find_codelist_value, data360_list_indicators,
+data360_get_data_api_url.
+
+A [FAILED RESEARCH PACKET] will be shown in the conversation — analyze it to
+understand what was tried before attempting alternatives.
+
+RECOVERY STRATEGIES (try in order):
+1. Search for synonym or related indicator names (e.g., "poverty" → "inequality", "welfare").
+2. Try a broader time range (±5 years around the originally requested period).
+3. Try a regional aggregate instead of a specific country (e.g., "Sub-Saharan Africa").
+4. Try a related indicator from a different database.
+
+RULES:
+- Try strategies in order and stop as soon as you find usable data.
+- Use at most 8 tool call iterations total.
+- Output a research packet in EXACTLY the same format as the main research node.
+- If ALL alternatives fail, write a packet that clearly states: what was searched,
+  what was unavailable, and the closest alternative found (even if incomplete).
+- NEVER invent claim IDs or fabricate data values.
+- NEVER repeat strategies that already failed (as shown in the failed packet).
+
+OUTPUT FORMAT:
+Follow the same RESEARCH PACKET format as the main research node:
+
+### RESEARCH PACKET:
+- User intent: <one sentence>
+- Recovery strategy used: <brief note on what alternative was tried>
+- Key assumptions (optional): <0-2 bullets>
+- Data360 indicators selected (if any): ...
+- Data retrieved (if any): ...
+- Data Sources: ...
+- Evidence notes: ...
+- Recommended response plan (for Writer): ...
+
+### CLARIFYING QUESTION: <blank or one question>"""
+
+
+# ---------------------------------------------------------------------------
+# Transformer prompt — decide whether an EXPLAIN query can be answered with data
+# ---------------------------------------------------------------------------
+def get_transformer_system_prompt() -> str:
+    """Transformer prompt: decides whether an analytical/conceptual question can be
+    grounded in real data, and if so, translates it into specific data research queries.
+
+    Runs for EXPLAIN-routed queries only. Non-streaming, no tools.
+    Output routes the query either into the data research pipeline (DATA_GROUNDABLE)
+    or keeps it on the pure metadata/definition path (DEFINITIONAL).
+    """
+    return f"""You analyze questions routed to the EXPLAIN path of a World Bank data chatbot.
+
+Today is {get_date_string()}.
+
+YOUR TASK:
+Decide whether the question can be meaningfully answered by fetching actual
+development data, or whether it only needs definitions/methodology.
+
+DECISION RULES:
+
+DATA_GROUNDABLE — choose this when the question is asking about conditions,
+trends, challenges, performance, comparisons, or changes that can be diagnosed
+or evidenced using real indicator data.
+
+Examples of DATA_GROUNDABLE questions:
+  "What are the main economic challenges facing Ghana?"
+  "How has poverty changed in Sub-Saharan Africa?"
+  "Why is growth slowing in Pakistan?"
+  "Compare public spending efficiency in ASEAN countries"
+  "What is driving inflation in Turkey?"
+  "How well is the Philippines managing its debt?"
+
+DEFINITIONAL — choose this when the question asks ONLY for a concept definition,
+an indicator's methodology, what something means, or how a metric is calculated.
+No actual data rows are needed to answer it.
+
+Examples of DEFINITIONAL questions:
+  "What is the Human Capital Index?"
+  "How is the Gini coefficient calculated?"
+  "What does GDP per capita mean?"
+  "What databases does Data360 cover?"
+  "What is the difference between nominal and real GDP?"
+
+WHEN DATA_GROUNDABLE — produce 2-5 specific data research queries that together
+would allow a research agent to build an evidence-based answer.
+
+Query writing rules:
+- Each query should reference a specific measurable indicator, country, and
+  time window (use last 10 years from today as the default range if not specified).
+- Include both headline indicators AND the most diagnostic supporting indicators.
+- For "challenges" / "performance" questions, always include: the main indicator,
+  a fiscal/debt indicator, and at least one structural/social indicator.
+- Queries must be answerable from World Bank / international development databases.
+- Do NOT include queries about things that cannot be measured (e.g. "political will").
+
+OUTPUT FORMAT — output ONLY a JSON block, no other text:
+
+```json
+{{
+  "decision": "DATA_GROUNDABLE",
+  "translated_queries": [
+    "Ghana GDP growth rate annual % from 2014 to {get_date_string()[:4]}",
+    "Ghana inflation consumer prices annual % 2014-{get_date_string()[:4]}",
+    "Ghana central government debt % of GDP 2014-{get_date_string()[:4]}",
+    "Ghana government expenditure composition wages interest capital 2018-{get_date_string()[:4]}"
+  ],
+  "framing": "Answer must be grounded in retrieved data. Frame all claims as: the data shows X, not: challenges tend to be Y."
+}}
+```
+
+OR for definitional questions:
+
+```json
+{{
+  "decision": "DEFINITIONAL",
+  "translated_queries": [],
+  "framing": ""
+}}
+```
+
+IMPORTANT: Output ONLY the JSON block. No preamble, no explanation."""
+
+
+# ---------------------------------------------------------------------------
+# Follow-up prompt — generate targeted follow-up questions post-narrator
+# ---------------------------------------------------------------------------
+def get_followup_system_prompt(language: str = "") -> str:
+    """Follow-up prompt: generates 2-3 suggested next queries after the main answer.
+
+    Questions are phrased exactly as the user would type them — like clickable
+    suggestion chips, not assistant clarifying questions.
+
+    Args:
+        language: Detected language from the router (e.g. "French").
+    """
+    lang_instruction = _get_language_instruction(language)
+    return f"""{lang_instruction}You generate suggested next queries for a World Bank data chatbot.
+
+WHAT YOU ARE PRODUCING:
+Short, ready-to-send queries the user could click and submit verbatim —
+like search suggestion chips. NOT questions the assistant asks the user.
+
+CRITICAL RULE — USER VOICE:
+Every suggestion must be phrased exactly as if the USER typed it.
+Write what the user would say, not what an assistant would ask.
+
+FORBIDDEN phrasings (assistant voice — never use):
+  "Do you want…"  /  "Would you like…"  /  "Which X do you prefer…"
+  "Should I show…"  /  "Do you need…"  /  "Shall I…"
+
+CORRECT style (user voice, ready to send):
+  "Compare GDP per capita in the Philippines, Vietnam, and Indonesia"
+  "Show the GDP growth rate for the Philippines from 2010 to 2024"
+  "What is the poverty headcount ratio in the Philippines?"
+  "How does the Philippines rank globally for GDP per capita?"
+
+WHAT THE SUGGESTIONS SHOULD COVER (pick 2-3 distinct angles):
+- Expand geographically: same indicator, nearby or comparable countries
+- Change the time dimension: longer trend, a specific decade, or most recent year
+- Drill into a related indicator (GDP shown → suggest poverty rate, inequality, growth rate)
+- Add a benchmark comparison: regional average, income-group peers, global rank
+- Change disaggregation: by gender, urban/rural, or age group if relevant to the topic
+
+RULES:
+1. Generate exactly 2-3 suggestions — no more, no fewer.
+2. Each must be answerable from World Bank / development data (not general knowledge).
+3. Each must be distinct — vary country, indicator, or time angle.
+4. Keep each suggestion concise (≤15 words).
+5. Do NOT re-ask about something already answered in the current response.
+6. Do NOT produce clarifying questions about the current request.
+
+OUTPUT FORMAT:
+Output ONLY the suggestions as a numbered list, prefixed with this exact separator:
+
+\\n\\n---\\n**Suggested next questions:**\\n
+1. <suggestion>
+2. <suggestion>
+3. <suggestion>
+
+No other text before or after."""
 
 
 def get_combined_system_prompt(

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -51,15 +51,20 @@ def _simplify_content_for_routing(content: Any) -> str:
 
 async def check_intent(
     messages: List[Dict[str, Any]],
-) -> Tuple[IntentType, str, Optional[Dict[str, Any]]]:
+) -> Tuple[IntentType, str, Optional[Dict[str, Any]], List[str], str]:
     """
     Analyzes the user's latest message and conversation context to determine
-    if it requires the Research Planner (Data360 tools) or can be handled
-    via Direct Chat (Fast-Path).
+    the routing intent.
 
     Returns:
-        (intent, reasoning, router_usage): ``router_usage`` is a token-usage dict for
-        the routing completion (OpenAI-shaped), or ``None`` if unavailable.
+        (intent, reasoning, router_usage, missing_slots, detected_language):
+          - intent: one of RESEARCH, DIRECT, CLARIFY, OUT_OF_SCOPE, EXPLAIN
+          - reasoning: brief explanation from the routing LLM
+          - router_usage: token-usage dict (OpenAI-shaped), or None if unavailable
+          - missing_slots: list of missing slot names when intent is CLARIFY
+            (e.g. ["country", "time_period"]), empty list otherwise
+          - detected_language: full English name of the user's language (e.g. "French"),
+            defaults to "English"
     """
     logger.info("[routing] check_intent start messages_count=%d", len(messages))
 
@@ -117,7 +122,7 @@ async def check_intent(
             messages=[{"role": "system", "content": system_prompt}, *routing_messages],
             response_format={"type": "json_object"},
             temperature=0,
-            max_tokens=200,
+            max_tokens=300,
             stream=False,
         )
 
@@ -129,13 +134,26 @@ async def check_intent(
         router_usage = usage_dict_from_openai_completion_usage(getattr(response, "usage", None))
 
         result = json.loads(raw_content)
-        intent = IntentType(result.get("intent", IntentType.RESEARCH))
+        raw_intent = result.get("intent", IntentType.RESEARCH.value)
+        try:
+            intent = IntentType(raw_intent)
+        except ValueError:
+            logger.warning("[routing] unknown intent value=%r, defaulting to RESEARCH", raw_intent)
+            intent = IntentType.RESEARCH
         reasoning = result.get("reasoning", "").strip()
+        missing_slots: List[str] = result.get("missing_slots", [])
+        if not isinstance(missing_slots, list):
+            missing_slots = []
+        detected_language: str = result.get("detected_language", "English") or "English"
 
         logger.info(
-            "[routing] check_intent done intent=%s reasoning_len=%d", intent, len(reasoning)
+            "[routing] check_intent done intent=%s missing_slots=%s language=%s reasoning_len=%d",
+            intent,
+            missing_slots,
+            detected_language,
+            len(reasoning),
         )
-        return (intent, reasoning, router_usage)
+        return (intent, reasoning, router_usage, missing_slots, detected_language)
 
     except json.JSONDecodeError as json_err:
         content = response.choices[0].message.content if "response" in locals() else "No response"
@@ -144,7 +162,7 @@ async def check_intent(
             str(json_err),
             content,
         )
-        return (IntentType.RESEARCH, "", None)
+        return (IntentType.RESEARCH, "", None, [], "English")
     except Exception as e:
         logger.error("Error in intent routing: %s. Defaulting to RESEARCH.", str(e))
-        return (IntentType.RESEARCH, "", None)
+        return (IntentType.RESEARCH, "", None, [], "English")

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -51,10 +51,17 @@ def _simplify_content_for_routing(content: Any) -> str:
 
 async def check_intent(
     messages: List[Dict[str, Any]],
+    session_summary: str = "",
 ) -> Tuple[IntentType, str, Optional[Dict[str, Any]], List[str], str]:
     """
     Analyzes the user's latest message and conversation context to determine
     the routing intent.
+
+    Args:
+        messages: Conversation history in OpenAI format.
+        session_summary: Optional compressed summary of earlier turns — injected
+            as a user message so the router retains context (country, topic, etc.)
+            even when the full history exceeds ROUTING_HISTORY_LIMIT.
 
     Returns:
         (intent, reasoning, router_usage, missing_slots, detected_language):
@@ -83,6 +90,18 @@ async def check_intent(
         # The routing LLM just needs user/assistant text to decide intent.
         # We must strip: tool messages, tool_calls, multi-part content structures.
         routing_messages = []
+
+        # Prepend session summary (if available) as a user message so the router
+        # retains context (country, topic, indicator names) even after the history
+        # window truncates older turns.
+        if session_summary:
+            routing_messages.append(
+                {
+                    "role": "user",
+                    "content": f"[CONVERSATION SUMMARY — context from earlier turns]\n{session_summary}",
+                }
+            )
+
         for msg in recent_history:
             role = msg.get("role")
             # Skip tool messages entirely

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -151,6 +151,11 @@ async def check_intent(
         logger.debug("Routing raw response (finish_reason=%s): %r", finish_reason, raw_content)
 
         router_usage = usage_dict_from_openai_completion_usage(getattr(response, "usage", None))
+        # Embed the actual deployed model name so the SSE bridge can resolve it
+        # precisely instead of falling back to the settings.ROUTING_MODEL string.
+        if router_usage is not None and hasattr(response, "model") and response.model:
+            router_usage = dict(router_usage)  # don't mutate the original
+            router_usage["_model"] = str(response.model)
 
         result = json.loads(raw_content)
         raw_intent = result.get("intent", IntentType.RESEARCH.value)

--- a/backend/app/ai/routing.py
+++ b/backend/app/ai/routing.py
@@ -1,9 +1,10 @@
 import json
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
-from app.ai.client import get_async_ai_client
-from app.ai.observability.token_usage import usage_dict_from_openai_completion_usage
+from langchain_core.messages import AIMessage as LCAIMessage
+from langchain_core.messages import HumanMessage, SystemMessage
+
 from app.ai.prompts import get_routing_system_prompt
 from app.config import IntentType, settings
 
@@ -52,66 +53,67 @@ def _simplify_content_for_routing(content: Any) -> str:
 async def check_intent(
     messages: List[Dict[str, Any]],
     session_summary: str = "",
-) -> Tuple[IntentType, str, Optional[Dict[str, Any]], List[str], str]:
-    """
-    Analyzes the user's latest message and conversation context to determine
-    the routing intent.
+) -> Tuple[IntentType, str, List[str], str]:
+    """Classify the user's latest message into one of five routing intents.
+
+    Uses a ``ChatLiteLLM`` instance (via :func:`get_routing_llm`) so that the
+    LLM call participates in LangChain's callback system.  When invoked from
+    inside ``router_node`` — a LangGraph node — LangGraph automatically tags the
+    resulting ``on_chat_model_end`` event with ``langgraph_node="router"``, so
+    token usage is accumulated by the SSE bridge through the standard path
+    (no manual ``router_usage`` plumbing required).
 
     Args:
-        messages: Conversation history in OpenAI format.
+        messages:        Conversation history in OpenAI format.
         session_summary: Optional compressed summary of earlier turns — injected
-            as a user message so the router retains context (country, topic, etc.)
-            even when the full history exceeds ROUTING_HISTORY_LIMIT.
+                         as a user message so the router retains context
+                         (country, topic, etc.) even when the full history
+                         exceeds ROUTING_HISTORY_LIMIT.
 
     Returns:
-        (intent, reasoning, router_usage, missing_slots, detected_language):
-          - intent: one of RESEARCH, DIRECT, CLARIFY, OUT_OF_SCOPE, EXPLAIN
-          - reasoning: brief explanation from the routing LLM
-          - router_usage: token-usage dict (OpenAI-shaped), or None if unavailable
-          - missing_slots: list of missing slot names when intent is CLARIFY
-            (e.g. ["country", "time_period"]), empty list otherwise
-          - detected_language: full English name of the user's language (e.g. "French"),
-            defaults to "English"
+        (intent, reasoning, missing_slots, detected_language):
+          - intent:            one of RESEARCH, DIRECT, CLARIFY, OUT_OF_SCOPE, EXPLAIN
+          - reasoning:         brief English explanation from the routing LLM
+          - missing_slots:     slot names absent when intent is CLARIFY, else []
+          - detected_language: full English name of the user's language (e.g. "French")
     """
+    # Import here to avoid a module-level circular dependency
+    # (routing.py ← nodes/router.py ← pipeline.py ← llm_factory.py would
+    # all be loaded in the same package; deferred import keeps the chain clean).
+    from app.ai.graph.llm_factory import get_routing_llm
+
     logger.info("[routing] check_intent start messages_count=%d", len(messages))
 
-    client = get_async_ai_client()
     system_prompt = get_routing_system_prompt()
 
     try:
-        # We only need the last few messages for intent
+        # Only the most recent turns are needed for intent classification.
         limit = settings.ROUTING_HISTORY_LIMIT
-        if len(messages) > limit:
-            recent_history = messages[-limit:]
-        else:
-            recent_history = messages
+        recent_history = messages[-limit:] if len(messages) > limit else messages
 
-        # Build clean, simple messages for routing LLM.
-        # The routing LLM just needs user/assistant text to decide intent.
-        # We must strip: tool messages, tool_calls, multi-part content structures.
-        routing_messages = []
+        # Build a clean, minimal message list for the routing LLM.
+        # Strip tool messages, tool_calls, and multi-part content structures.
+        routing_messages: list[dict] = []
 
-        # Prepend session summary (if available) as a user message so the router
-        # retains context (country, topic, indicator names) even after the history
-        # window truncates older turns.
+        # Prepend session summary (if any) so the router retains context even
+        # after the history window truncates older turns.
         if session_summary:
             routing_messages.append(
                 {
                     "role": "user",
-                    "content": f"[CONVERSATION SUMMARY — context from earlier turns]\n{session_summary}",
+                    "content": (
+                        "[CONVERSATION SUMMARY — context from earlier turns]\n" + session_summary
+                    ),
                 }
             )
 
         for msg in recent_history:
             role = msg.get("role")
-            # Skip tool messages entirely
             if role == "tool":
-                continue
-            # Build a clean message with just role + simple text content
+                continue  # tool results carry no useful intent signal
             content = _simplify_content_for_routing(msg.get("content", ""))
             if not content:
-                continue  # Skip messages with no usable text
-            # Only include role and content - no tool_calls, no other keys
+                continue
             routing_messages.append({"role": role, "content": content})
 
         logger.info(
@@ -126,9 +128,9 @@ async def check_intent(
                 [
                     {
                         "role": m["role"],
-                        "content": m["content"][:120] + "..."
-                        if len(m["content"]) > 120
-                        else m["content"],
+                        "content": (
+                            m["content"][:120] + "..." if len(m["content"]) > 120 else m["content"]
+                        ),
                     }
                     for m in routing_messages
                 ],
@@ -136,26 +138,23 @@ async def check_intent(
             ),
         )
 
-        response = await client.chat.completions.create(
-            model=settings.ROUTING_MODEL,
-            messages=[{"role": "system", "content": system_prompt}, *routing_messages],
-            response_format={"type": "json_object"},
-            temperature=0,
-            max_tokens=300,
-            stream=False,
-        )
+        # Convert simplified dicts → LangChain messages for the LLM call.
+        lc_messages: list = [SystemMessage(content=system_prompt)]
+        for msg in routing_messages:
+            role = msg["role"]
+            content = msg["content"]
+            if role == "user":
+                lc_messages.append(HumanMessage(content=content))
+            elif role == "assistant":
+                lc_messages.append(LCAIMessage(content=content))
+            # Other roles (system duplicates, etc.) are skipped.
 
-        raw_content = response.choices[0].message.content
-        finish_reason = response.choices[0].finish_reason
-        logger.info("[routing] routing LLM response received finish_reason=%s", finish_reason)
-        logger.debug("Routing raw response (finish_reason=%s): %r", finish_reason, raw_content)
+        llm = get_routing_llm()
+        response_msg: LCAIMessage = await llm.ainvoke(lc_messages)
+        raw_content: str = str(response_msg.content or "")
 
-        router_usage = usage_dict_from_openai_completion_usage(getattr(response, "usage", None))
-        # Embed the actual deployed model name so the SSE bridge can resolve it
-        # precisely instead of falling back to the settings.ROUTING_MODEL string.
-        if router_usage is not None and hasattr(response, "model") and response.model:
-            router_usage = dict(router_usage)  # don't mutate the original
-            router_usage["_model"] = str(response.model)
+        logger.info("[routing] routing LLM response received")
+        logger.debug("Routing raw response: %r", raw_content)
 
         result = json.loads(raw_content)
         raw_intent = result.get("intent", IntentType.RESEARCH.value)
@@ -164,7 +163,8 @@ async def check_intent(
         except ValueError:
             logger.warning("[routing] unknown intent value=%r, defaulting to RESEARCH", raw_intent)
             intent = IntentType.RESEARCH
-        reasoning = result.get("reasoning", "").strip()
+
+        reasoning: str = result.get("reasoning", "").strip()
         missing_slots: List[str] = result.get("missing_slots", [])
         if not isinstance(missing_slots, list):
             missing_slots = []
@@ -177,16 +177,16 @@ async def check_intent(
             detected_language,
             len(reasoning),
         )
-        return (intent, reasoning, router_usage, missing_slots, detected_language)
+        return (intent, reasoning, missing_slots, detected_language)
 
     except json.JSONDecodeError as json_err:
-        content = response.choices[0].message.content if "response" in locals() else "No response"
+        raw = raw_content if "raw_content" in locals() else "No response"
         logger.error(
             "Error parsing routing response as JSON: %s. Response content: %r",
             str(json_err),
-            content,
+            raw,
         )
-        return (IntentType.RESEARCH, "", None, [], "English")
+        return (IntentType.RESEARCH, "", [], "English")
     except Exception as e:
         logger.error("Error in intent routing: %s. Defaulting to RESEARCH.", str(e))
-        return (IntentType.RESEARCH, "", None, [], "English")
+        return (IntentType.RESEARCH, "", [], "English")

--- a/backend/app/ai/utils/geo_utils.py
+++ b/backend/app/ai/utils/geo_utils.py
@@ -1,0 +1,412 @@
+"""Geographic region resolution utilities for the Data360 Chat assistant.
+
+This module provides a mapping from common region names to lists of ISO-3 country
+codes, and helper functions to resolve free-text region names in user queries to
+the corresponding country codes.  It is used by the scout and planner nodes to
+expand vague geographic references (e.g. "East Africa") into explicit country
+lists before calling data retrieval tools.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Region → ISO-3 country code mapping
+# ---------------------------------------------------------------------------
+REGION_TO_CODES: dict[str, list[str]] = {
+    "sub-saharan africa": [
+        "AGO",
+        "BEN",
+        "BWA",
+        "BFA",
+        "BDI",
+        "CPV",
+        "CMR",
+        "CAF",
+        "TCD",
+        "COM",
+        "COD",
+        "COG",
+        "CIV",
+        "DJI",
+        "ERI",
+        "SWZ",
+        "ETH",
+        "GAB",
+        "GMB",
+        "GHA",
+        "GIN",
+        "GNB",
+        "KEN",
+        "LSO",
+        "LBR",
+        "MDG",
+        "MWI",
+        "MLI",
+        "MRT",
+        "MUS",
+        "MOZ",
+        "NAM",
+        "NER",
+        "NGA",
+        "RWA",
+        "STP",
+        "SEN",
+        "SLE",
+        "SOM",
+        "ZAF",
+        "SSD",
+        "SDN",
+        "TZA",
+        "TGO",
+        "UGA",
+        "ZMB",
+        "ZWE",
+        "SYC",
+    ],
+    "east africa": [
+        "ETH",
+        "KEN",
+        "TZA",
+        "UGA",
+        "RWA",
+        "BDI",
+        "SOM",
+        "DJI",
+        "ERI",
+        "SSD",
+    ],
+    "west africa": [
+        "NGA",
+        "GHA",
+        "SEN",
+        "CIV",
+        "MLI",
+        "BFA",
+        "NER",
+        "TGO",
+        "BEN",
+        "CMR",
+        "GIN",
+        "SLE",
+        "LBR",
+        "GMB",
+        "GNB",
+        "CPV",
+        "MRT",
+    ],
+    "southern africa": [
+        "ZAF",
+        "ZWE",
+        "ZMB",
+        "MWI",
+        "MOZ",
+        "BWA",
+        "NAM",
+        "LSO",
+        "SWZ",
+        "AGO",
+        "COM",
+        "MDG",
+        "MUS",
+        "SYC",
+    ],
+    "north africa": [
+        "DZA",
+        "EGY",
+        "LBY",
+        "MAR",
+        "TUN",
+        "SDN",
+    ],
+    "asean": [
+        "BRN",
+        "KHM",
+        "IDN",
+        "LAO",
+        "MYS",
+        "MMR",
+        "PHL",
+        "SGP",
+        "THA",
+        "VNM",
+    ],
+    "south asia": [
+        "AFG",
+        "BGD",
+        "BTN",
+        "IND",
+        "MDV",
+        "NPL",
+        "PAK",
+        "LKA",
+    ],
+    "east asia and pacific": [
+        "CHN",
+        "JPN",
+        "KOR",
+        "MNG",
+        "PRK",
+        "HKG",
+        "MAC",
+        "TWN",
+        "AUS",
+        "NZL",
+        "FJI",
+        "PNG",
+        "SLB",
+        "VUT",
+        "WSM",
+        "TON",
+        "KIR",
+        "FSM",
+        "PLW",
+        "MHL",
+        "NRU",
+        "TUV",
+    ],
+    "latin america and caribbean": [
+        "BRA",
+        "MEX",
+        "ARG",
+        "COL",
+        "CHL",
+        "PER",
+        "VEN",
+        "ECU",
+        "BOL",
+        "PRY",
+        "URY",
+        "GUY",
+        "SUR",
+        "TTO",
+        "JAM",
+        "CUB",
+        "DOM",
+        "HTI",
+        "GTM",
+        "HND",
+        "SLV",
+        "NIC",
+        "CRI",
+        "PAN",
+        "BLZ",
+        "BHS",
+        "BRB",
+        "ATG",
+        "DMA",
+        "GRD",
+        "KNA",
+        "LCA",
+        "VCT",
+    ],
+    "middle east and north africa": [
+        "DZA",
+        "BHR",
+        "DJI",
+        "EGY",
+        "IRN",
+        "IRQ",
+        "ISR",
+        "JOR",
+        "KWT",
+        "LBN",
+        "LBY",
+        "MAR",
+        "MLT",
+        "OMN",
+        "QAT",
+        "SAU",
+        "SYR",
+        "TUN",
+        "ARE",
+        "YEM",
+        "PSE",
+        "MAR",
+    ],
+    "europe and central asia": [
+        "ALB",
+        "ARM",
+        "AZE",
+        "BLR",
+        "BIH",
+        "BGR",
+        "CYP",
+        "CZE",
+        "DNK",
+        "EST",
+        "FIN",
+        "FRA",
+        "GEO",
+        "DEU",
+        "GRC",
+        "HUN",
+        "ISL",
+        "IRL",
+        "ITA",
+        "KAZ",
+        "XKX",
+        "KGZ",
+        "LVA",
+        "LTU",
+        "LUX",
+        "MDA",
+        "MNE",
+        "NLD",
+        "MKD",
+        "NOR",
+        "POL",
+        "PRT",
+        "ROU",
+        "RUS",
+        "SRB",
+        "SVK",
+        "SVN",
+        "ESP",
+        "SWE",
+        "CHE",
+        "TJK",
+        "TUR",
+        "TKM",
+        "UKR",
+        "GBR",
+        "UZB",
+    ],
+    "g7": ["CAN", "FRA", "DEU", "ITA", "JPN", "GBR", "USA"],
+    "g20": [
+        "ARG",
+        "AUS",
+        "BRA",
+        "CAN",
+        "CHN",
+        "FRA",
+        "DEU",
+        "IND",
+        "IDN",
+        "ITA",
+        "JPN",
+        "KOR",
+        "MEX",
+        "RUS",
+        "SAU",
+        "ZAF",
+        "TUR",
+        "GBR",
+        "USA",
+    ],
+    "oecd": [
+        "AUS",
+        "AUT",
+        "BEL",
+        "CAN",
+        "CHL",
+        "COL",
+        "CZE",
+        "DNK",
+        "EST",
+        "FIN",
+        "FRA",
+        "DEU",
+        "GRC",
+        "HUN",
+        "ISL",
+        "IRL",
+        "ISR",
+        "ITA",
+        "JPN",
+        "KOR",
+        "LVA",
+        "LTU",
+        "LUX",
+        "MEX",
+        "NLD",
+        "NZL",
+        "NOR",
+        "POL",
+        "PRT",
+        "SVK",
+        "SVN",
+        "ESP",
+        "SWE",
+        "CHE",
+        "TUR",
+        "GBR",
+        "USA",
+    ],
+    "brics": ["BRA", "RUS", "IND", "CHN", "ZAF"],
+}
+
+# ---------------------------------------------------------------------------
+# Punctuation stripper (for query normalisation)
+# ---------------------------------------------------------------------------
+_PUNCT_RE = re.compile(r"[^\w\s-]")
+
+
+def _normalize(text: str) -> str:
+    """Lowercase and strip punctuation for consistent matching."""
+    return _PUNCT_RE.sub("", text.strip().lower())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_region(query: str) -> list[str]:
+    """Return the ISO-3 country codes for a region name, or [] if not found.
+
+    Tries an exact match first (after normalisation), then falls back to a
+    partial/substring match against all registered region names.
+
+    Args:
+        query: Free-text region name, e.g. "East Africa" or "sub saharan africa".
+
+    Returns:
+        List of ISO-3 country codes, or an empty list if no match is found.
+    """
+    key = _normalize(query)
+    # Exact match
+    if key in REGION_TO_CODES:
+        return list(REGION_TO_CODES[key])
+    # Partial match — query is a substring of a region name, or vice-versa
+    for region_name, codes in REGION_TO_CODES.items():
+        if key in region_name or region_name in key:
+            return list(codes)
+    return []
+
+
+def expand_country_list(countries: list[str]) -> list[str]:
+    """Expand region names in a country list to individual ISO-3 codes.
+
+    For each entry:
+    - If it looks like an ISO-3 code (3 uppercase letters), keep it as-is.
+    - Otherwise, attempt to resolve it as a region name via ``resolve_region``.
+
+    Duplicates are removed while preserving order.
+
+    Args:
+        countries: Mixed list of ISO-3 codes and/or region names.
+
+    Returns:
+        Deduplicated flat list of ISO-3 country codes.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+
+    for entry in countries:
+        # Heuristic: a 3-letter all-uppercase string is an ISO-3 code
+        if re.fullmatch(r"[A-Z]{3}", entry.strip()):
+            code = entry.strip()
+            if code not in seen:
+                seen.add(code)
+                result.append(code)
+        else:
+            # Treat as a region name and expand
+            codes = resolve_region(entry)
+            for code in codes:
+                if code not in seen:
+                    seen.add(code)
+                    result.append(code)
+
+    return result

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -409,28 +409,29 @@ async def create_chat(
                         request.id,
                         [assistant_message],
                     )
-                    final_usage_raw = graph_out.get("final_usage") or {}
-                    if final_usage_raw:
-                        by_node = None
-                        if isinstance(final_usage_raw, dict):
-                            final_usage_raw = dict(final_usage_raw)  # copy before mutating
-                            by_node = final_usage_raw.pop("byNode", None)
-                        usage_data = coerce_graph_final_usage_to_data_usage(
-                            final_usage_raw,
-                            model=request.selectedChatModel.value,
-                        )
-                        persisted = usage_data.model_dump()
-                        if by_node:
-                            persisted["byNode"] = by_node
-                        create_update_context_task(
-                            background_tasks,
-                            request.id,
-                            persisted,
-                            message_id=message_id,
-                            session_summary=graph_out.get("session_summary") or None,
-                            summarized_message_count=graph_out.get("summarized_message_count")
-                            or None,
-                        )
+                # Always persist token usage — even partial usage from a failed stream is
+                # valuable for cost tracking and debugging.
+                final_usage_raw = graph_out.get("final_usage") or {}
+                if final_usage_raw:
+                    by_node = None
+                    if isinstance(final_usage_raw, dict):
+                        final_usage_raw = dict(final_usage_raw)  # copy before mutating
+                        by_node = final_usage_raw.pop("byNode", None)
+                    usage_data = coerce_graph_final_usage_to_data_usage(
+                        final_usage_raw,
+                        model=request.selectedChatModel.value,
+                    )
+                    persisted = usage_data.model_dump()
+                    if by_node:
+                        persisted["byNode"] = by_node
+                    create_update_context_task(
+                        background_tasks,
+                        request.id,
+                        persisted,
+                        message_id=message_id,
+                        session_summary=graph_out.get("session_summary") or None,
+                        summarized_message_count=graph_out.get("summarized_message_count") or None,
+                    )
 
     response = StreamingResponse(
         stream_generator(),

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -219,6 +219,11 @@ async def create_chat(
             )
             raise ChatSDKError("forbidden:chat", status_code=status.HTTP_403_FORBIDDEN)
 
+        # Extract session summary from lastContext for incremental summarization
+        last_context = (chat.lastContext or {}) if chat else {}
+        loaded_session_summary: str = last_context.get("session_summary", "") or ""
+        loaded_summarized_count: int = last_context.get("summarized_message_count", 0) or 0
+
         # Fetch existing messages
         messages_from_db = await get_messages_by_chat_id(db, request.id)
 
@@ -240,6 +245,8 @@ async def create_chat(
         logger.debug("messages_from_db: %s", json.dumps(messages_from_db, indent=4))
 
     else:
+        loaded_session_summary = ""
+        loaded_summarized_count = 0
         # Create new chat - generate title from user message
         stored_visibility = (
             request.selectedVisibilityType
@@ -362,6 +369,8 @@ async def create_chat(
                 tool_set=tool_set,
                 assistant_row_id=message_id,
                 forced_intent=None,
+                session_summary=loaded_session_summary,
+                summarized_message_count=loaded_summarized_count,
             ):
                 yield await _store_and_yield(stream_id, state, sse_bytes)
                 await asyncio.sleep(0)
@@ -410,6 +419,9 @@ async def create_chat(
                                 model=request.selectedChatModel.value,
                             ),
                             message_id=message_id,
+                            session_summary=graph_out.get("session_summary") or None,
+                            summarized_message_count=graph_out.get("summarized_message_count")
+                            or None,
                         )
 
     response = StreamingResponse(

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -409,15 +409,23 @@ async def create_chat(
                         request.id,
                         [assistant_message],
                     )
-                    final_usage = graph_out.get("final_usage")
-                    if final_usage:
+                    final_usage_raw = graph_out.get("final_usage") or {}
+                    if final_usage_raw:
+                        by_node = None
+                        if isinstance(final_usage_raw, dict):
+                            final_usage_raw = dict(final_usage_raw)  # copy before mutating
+                            by_node = final_usage_raw.pop("byNode", None)
+                        usage_data = coerce_graph_final_usage_to_data_usage(
+                            final_usage_raw,
+                            model=request.selectedChatModel.value,
+                        )
+                        persisted = usage_data.model_dump()
+                        if by_node:
+                            persisted["byNode"] = by_node
                         create_update_context_task(
                             background_tasks,
                             request.id,
-                            coerce_graph_final_usage_to_data_usage(
-                                final_usage,
-                                model=request.selectedChatModel.value,
-                            ),
+                            persisted,
                             message_id=message_id,
                             session_summary=graph_out.get("session_summary") or None,
                             summarized_message_count=graph_out.get("summarized_message_count")

--- a/backend/app/api/v1/chat_stream.py
+++ b/backend/app/api/v1/chat_stream.py
@@ -152,25 +152,27 @@ async def stream_chat(
                             request.id,
                             [assistant_message],
                         )
-                        final_usage_raw = graph_out.get("final_usage") or {}
-                        if final_usage_raw:
-                            by_node = None
-                            if isinstance(final_usage_raw, dict):
-                                final_usage_raw = dict(final_usage_raw)  # copy before mutating
-                                by_node = final_usage_raw.pop("byNode", None)
-                            usage_data = coerce_graph_final_usage_to_data_usage(
-                                final_usage_raw,
-                                model=request.selectedChatModel.value,
-                            )
-                            persisted = usage_data.model_dump()
-                            if by_node:
-                                persisted["byNode"] = by_node
-                            create_update_context_task(
-                                background_tasks,
-                                request.id,
-                                persisted,
-                                message_id=message_id,
-                            )
+                    # Always persist token usage — even partial usage from a failed stream is
+                    # valuable for cost tracking and debugging.
+                    final_usage_raw = graph_out.get("final_usage") or {}
+                    if final_usage_raw:
+                        by_node = None
+                        if isinstance(final_usage_raw, dict):
+                            final_usage_raw = dict(final_usage_raw)  # copy before mutating
+                            by_node = final_usage_raw.pop("byNode", None)
+                        usage_data = coerce_graph_final_usage_to_data_usage(
+                            final_usage_raw,
+                            model=request.selectedChatModel.value,
+                        )
+                        persisted = usage_data.model_dump()
+                        if by_node:
+                            persisted["byNode"] = by_node
+                        create_update_context_task(
+                            background_tasks,
+                            request.id,
+                            persisted,
+                            message_id=message_id,
+                        )
 
         response = StreamingResponse(
             stream_generator(),

--- a/backend/app/api/v1/chat_stream.py
+++ b/backend/app/api/v1/chat_stream.py
@@ -152,15 +152,23 @@ async def stream_chat(
                             request.id,
                             [assistant_message],
                         )
-                        final_usage = graph_out.get("final_usage")
-                        if final_usage:
+                        final_usage_raw = graph_out.get("final_usage") or {}
+                        if final_usage_raw:
+                            by_node = None
+                            if isinstance(final_usage_raw, dict):
+                                final_usage_raw = dict(final_usage_raw)  # copy before mutating
+                                by_node = final_usage_raw.pop("byNode", None)
+                            usage_data = coerce_graph_final_usage_to_data_usage(
+                                final_usage_raw,
+                                model=request.selectedChatModel.value,
+                            )
+                            persisted = usage_data.model_dump()
+                            if by_node:
+                                persisted["byNode"] = by_node
                             create_update_context_task(
                                 background_tasks,
                                 request.id,
-                                coerce_graph_final_usage_to_data_usage(
-                                    final_usage,
-                                    model=request.selectedChatModel.value,
-                                ),
+                                persisted,
                                 message_id=message_id,
                             )
 

--- a/backend/app/api/v1/utils/background_tasks.py
+++ b/backend/app/api/v1/utils/background_tasks.py
@@ -54,9 +54,12 @@ def create_update_context_task(
     chat_id: UUID,
     usage: Dict[str, Any] | DataUsageData,
     message_id: str | None = None,
+    session_summary: str | None = None,
+    summarized_message_count: int | None = None,
 ) -> None:
     """Schedule a background task to update chat context with usage.
     If message_id is set, usage is stored per-message so each response has its own usage.
+    If session_summary is set, persists it in lastContext for next-turn injection.
     """
     if not usage:
         return
@@ -66,6 +69,13 @@ def create_update_context_task(
 
     async def update_context_task():
         async with AsyncSessionLocal() as session:
-            await update_chat_last_context_by_id(session, chat_id, usage, message_id=message_id)
+            await update_chat_last_context_by_id(
+                session,
+                chat_id,
+                usage,
+                message_id=message_id,
+                session_summary=session_summary,
+                summarized_message_count=summarized_message_count,
+            )
 
     background_tasks.add_task(update_context_task)

--- a/backend/app/api/v1/utils/graph_stream.py
+++ b/backend/app/api/v1/utils/graph_stream.py
@@ -80,6 +80,8 @@ def build_graph_input(
     part_message_id: str,
     tool_set: dict[str, Any],
     forced_intent: str | None = None,
+    session_summary: str = "",
+    summarized_message_count: int = 0,
 ) -> dict[str, Any]:
     """Initial LangGraph state (chat pipeline)."""
     inp: dict[str, Any] = {
@@ -98,6 +100,10 @@ def build_graph_input(
     }
     if forced_intent is not None:
         inp["forced_intent"] = forced_intent
+    if session_summary:
+        inp["session_summary"] = session_summary
+    if summarized_message_count:
+        inp["summarized_message_count"] = summarized_message_count
     return inp
 
 
@@ -145,6 +151,8 @@ async def stream_chat_graph_sse(
     tool_set: dict[str, Any],
     assistant_row_id: str,
     forced_intent: str | None = None,
+    session_summary: str = "",
+    summarized_message_count: int = 0,
 ) -> AsyncIterator[bytes]:
     """Run ``chat_graph`` through ``stream_graph_to_sse`` and yield SSE bytes."""
     graph_input = build_graph_input(
@@ -154,6 +162,8 @@ async def stream_chat_graph_sse(
         part_message_id=part_message_id,
         tool_set=tool_set,
         forced_intent=forced_intent,
+        session_summary=session_summary,
+        summarized_message_count=summarized_message_count,
     )
     logger.info("[graph_stream] stream_graph_to_sse start forced_intent=%s", forced_intent)
     async for sse_bytes in stream_graph_to_sse(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,9 @@ class IntentType(str, Enum):
 
     RESEARCH = "RESEARCH"
     DIRECT = "DIRECT"
+    CLARIFY = "CLARIFY"
+    OUT_OF_SCOPE = "OUT_OF_SCOPE"
+    EXPLAIN = "EXPLAIN"
 
 
 class ModelSettings(BaseSettings):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,7 +114,7 @@ class Settings(BaseSettings):
 
     # Routing Configuration
     ROUTING_MODEL: str = "gpt-4o-mini"
-    ROUTING_HISTORY_LIMIT: int = 3
+    ROUTING_HISTORY_LIMIT: int = 10
 
     # App
     ENVIRONMENT: str = "development"
@@ -131,6 +131,12 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"  # DEBUG, INFO, WARNING, ERROR
     LOG_MAX_BYTES: int = 10 * 1024 * 1024  # 10 MB per file
     LOG_BACKUP_COUNT: int = 5  # Number of rotated backup files to keep
+    # When True, log LangGraph LLM prompt previews, streamed token fragments, and
+    # tool I/O summaries (see graph_debug_log). May contain PII — dev/troubleshooting only.
+    GRAPH_DEBUG_LOG_LLM: bool = False
+    # Append the same debug records to this file (UTF-8, flushed per write). If empty while
+    # GRAPH_DEBUG_LOG_LLM is true, defaults to backend/logs/graph_llm_debug.log.
+    GRAPH_DEBUG_LOG_LLM_FILE: str = ""
     NEXTJS_URL: str = "http://localhost:3001"  # Next.js server URL for proxy requests
     # Cookie Domain - Optional: Set explicit domain for cookies (e.g., ".example.com" for subdomain sharing)
     # If not set, cookies will use the default domain (current domain only)

--- a/backend/app/db/queries/chat_queries.py
+++ b/backend/app/db/queries/chat_queries.py
@@ -259,16 +259,26 @@ def _merge_usage_by_message_id(current: Optional[dict], usage: dict, message_id:
     Merge usage for a message into lastContext.
     lastContext can be legacy (plain usage dict) or { "latest": usage, "byMessageId": { id: usage } }.
     Returns the new context dict to store.
+    Sticky fields (session_summary, summarized_message_count) are carried forward from current.
     """
     if not current or not isinstance(current, dict):
-        return {"latest": usage, "byMessageId": {message_id: usage}}
-    # Legacy: current is the usage object itself (has e.g. inputTokens, totalTokens)
-    if "inputTokens" in current or "totalTokens" in current:
-        return {"latest": current, "byMessageId": {message_id: usage}}
-    # New shape
-    by_id = dict(current.get("byMessageId") or {})
-    by_id[message_id] = usage
-    return {"latest": usage, "byMessageId": by_id}
+        result = {"latest": usage, "byMessageId": {message_id: usage}}
+    elif "inputTokens" in current or "totalTokens" in current:
+        # Legacy: current is the usage object itself (has e.g. inputTokens, totalTokens)
+        result = {"latest": current, "byMessageId": {message_id: usage}}
+    else:
+        # New shape
+        by_id = dict(current.get("byMessageId") or {})
+        by_id[message_id] = usage
+        result = {"latest": usage, "byMessageId": by_id}
+
+    # Carry forward sticky session summary fields from current context
+    if current and isinstance(current, dict):
+        for sticky_key in ("session_summary", "summarized_message_count"):
+            if sticky_key in current:
+                result.setdefault(sticky_key, current[sticky_key])
+
+    return result
 
 
 async def update_chat_visibility_by_id(
@@ -291,10 +301,13 @@ async def update_chat_last_context_by_id(
     chat_id: UUID,
     context: dict,
     message_id: Optional[str] = None,
+    session_summary: Optional[str] = None,
+    summarized_message_count: Optional[int] = None,
 ) -> Optional[Chat]:
     """
     Update chat's lastContext field with usage/context data.
     If message_id is provided, merges usage into byMessageId so each response has its own usage.
+    If session_summary is provided, persists it alongside the usage in lastContext.
     Returns: Updated Chat object or None if not found
     """
     logger.info("=== update_chat_last_context_by_id called ===")
@@ -308,6 +321,11 @@ async def update_chat_last_context_by_id(
         new_context = _merge_usage_by_message_id(chat.lastContext, context, message_id)
     else:
         new_context = context
+
+    # Apply session summary if provided (overrides the sticky carry-forward)
+    if session_summary is not None:
+        new_context["session_summary"] = session_summary
+        new_context["summarized_message_count"] = summarized_message_count or 0
 
     chat.lastContext = new_context
     await session.commit()

--- a/backend/app/utils/message_converter.py
+++ b/backend/app/utils/message_converter.py
@@ -133,6 +133,10 @@ async def convert_messages_to_openai_format(
             for part in parts:
                 part_type = part.get("type")
 
+                # Skip agent-trace parts — internal diagnostics, not for LLM context
+                if part_type == "agent-trace":
+                    continue
+
                 if part_type == "text":
                     # Flush any pending tool turn before text (so tool_calls are followed by their results)
                     flush_tool_turn()

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -1,0 +1,160 @@
+"""Tests for trim_for_node in memory.py.
+
+Verifies that:
+- trim_for_node respects the token budget (trims long histories)
+- trim_for_node calls _sanitize_tool_sequences after trimming so orphaned
+  ToolMessages / incomplete AIMessage-with-tool_calls pairs are removed
+  (Improvement 2: trim_messages(strategy="last") can cut tool sequences mid-pair)
+- Unknown nodes fall back to _DEFAULT_BUDGET without raising
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.ai.graph.memory import trim_for_node
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+
+def _human(text: str) -> HumanMessage:
+    return HumanMessage(content=text)
+
+
+def _ai(text: str) -> AIMessage:
+    return AIMessage(content=text)
+
+
+def _ai_with_calls(tool_calls: list[dict]) -> AIMessage:
+    """Return an AIMessage that has pending tool_calls."""
+    return AIMessage(content="", tool_calls=tool_calls)
+
+
+def _tool(call_id: str, content: str = "result") -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=call_id)
+
+
+def _sys(text: str = "You are a helpful assistant.") -> SystemMessage:
+    return SystemMessage(content=text)
+
+
+# ---------------------------------------------------------------------------
+# Basic budget trimming
+# ---------------------------------------------------------------------------
+
+
+def test_trim_for_node_keeps_recent_messages_within_budget():
+    """When history exceeds budget, only the most recent messages are kept."""
+    msgs = [_human(f"message {i}") for i in range(20)]
+    # Use len() as token counter → each 1-char message = 1 "token"
+    # Budget of 5 should give at most 5 messages
+    trimmed = trim_for_node(msgs, node="router", token_counter=len)
+    assert len(trimmed) <= len(msgs)
+    # Most recent message must survive
+    assert trimmed[-1].content == msgs[-1].content
+
+
+def test_trim_for_node_unknown_node_uses_default_budget():
+    """Nodes not in TOKEN_BUDGETS fall back to _DEFAULT_BUDGET without error."""
+    msgs = [_human("hello")]
+    result = trim_for_node(msgs, node="__nonexistent_node__", token_counter=len)
+    assert result  # at least the message survives
+
+
+def test_trim_for_node_empty_list():
+    """Empty input returns empty output without error."""
+    assert trim_for_node([], node="router") == []
+
+
+def test_trim_for_node_system_message_preserved():
+    """SystemMessage is kept even after trimming (include_system=True)."""
+    system = _sys("Be helpful.")
+    msgs = [system] + [_human(f"q{i}") for i in range(50)]
+    trimmed = trim_for_node(msgs, node="router", token_counter=len)
+    assert any(isinstance(m, SystemMessage) for m in trimmed)
+
+
+# ---------------------------------------------------------------------------
+# Sanitization after trim: orphaned ToolMessage (AIMessage trimmed away)
+# ---------------------------------------------------------------------------
+
+
+def test_trim_for_node_removes_orphaned_tool_message_after_trim():
+    """
+    Build a history where the AIMessage with tool_calls is far back (trimmed out)
+    but the ToolMessage response is recent (kept by the budget).
+    trim_for_node must drop the orphaned ToolMessage.
+    """
+    # Put the AI+tool interaction at the very start so it gets trimmed away
+    ai_msg = _ai_with_calls([{"id": "tc1", "name": "search", "args": {}}])
+    tool_msg = _tool("tc1", "search results")
+
+    # Fill history so that the budget window only covers the recent messages
+    # Use a token counter that counts messages (1 per message) with a budget of 4
+    padding = [_human(f"padding {i}") for i in range(5)]
+    follow_up = _human("recent user question")
+
+    # Order: ai_msg, tool_msg, padding..., follow_up
+    msgs = [ai_msg, tool_msg] + padding + [follow_up]
+
+    # With budget=4 and per-message token count, strategy="last" keeps the last 4 messages:
+    # padding[3], padding[4], follow_up → 3 messages + potentially the tool_msg depending on order
+    # The key invariant: no ToolMessage without its matching AIMessage should survive
+    trimmed = trim_for_node(msgs, node="router", token_counter=len)
+
+    tool_ids_in_result = {m.tool_call_id for m in trimmed if isinstance(m, ToolMessage)}
+    ai_tool_ids_in_result = {
+        tc.get("id", "")
+        for m in trimmed
+        if isinstance(m, AIMessage) and m.tool_calls
+        for tc in m.tool_calls
+    }
+    # Every ToolMessage must have a matching AIMessage in the result
+    assert tool_ids_in_result.issubset(ai_tool_ids_in_result), (
+        f"Orphaned ToolMessage IDs after trim_for_node: {tool_ids_in_result - ai_tool_ids_in_result}"
+    )
+
+
+def test_trim_for_node_removes_ai_with_tool_calls_when_responses_trimmed():
+    """
+    If an AIMessage with tool_calls survives the budget trim but its ToolMessage
+    responses were cut off (they were at the END, but somehow dropped), the AI
+    message must also be dropped.
+
+    In practice trim(strategy="last") keeps the tail, so this tests the symmetric
+    case: ToolMessage is far back, AIMessage is recent.
+    """
+    tool_msg = _tool("tc2", "old result")
+    padding = [_human(f"p{i}") for i in range(5)]
+    # Put the AIMessage at the very end (it survives trim), tool response at start (trimmed)
+    ai_msg = _ai_with_calls([{"id": "tc2", "name": "lookup", "args": {}}])
+
+    msgs = [tool_msg] + padding + [ai_msg]
+    trimmed = trim_for_node(msgs, node="router", token_counter=len)
+
+    # ai_msg references tc2 but the ToolMessage for tc2 is not present
+    for m in trimmed:
+        if isinstance(m, AIMessage) and m.tool_calls:
+            ids = {tc.get("id") for tc in m.tool_calls}
+            present_tool_ids = {tm.tool_call_id for tm in trimmed if isinstance(tm, ToolMessage)}
+            assert ids.issubset(present_tool_ids), (
+                f"AIMessage with missing ToolMessage responses survived: {ids - present_tool_ids}"
+            )
+
+
+def test_trim_for_node_preserves_complete_tool_interaction():
+    """
+    A complete AIMessage + ToolMessage pair that fits within the budget must survive
+    intact — sanitization must not remove valid tool interactions.
+    """
+    ai_msg = _ai_with_calls([{"id": "tc3", "name": "lookup", "args": {"q": "gdp"}}])
+    tool_msg = _tool("tc3", "GDP data here")
+    follow = _human("great, now summarize")
+
+    msgs = [ai_msg, tool_msg, follow]
+    # Budget large enough to keep all messages
+    trimmed = trim_for_node(msgs, node="narrator", token_counter=len)
+
+    assert any(isinstance(m, AIMessage) and m.tool_calls for m in trimmed)
+    assert any(isinstance(m, ToolMessage) for m in trimmed)
+    assert trimmed[-1].content == "great, now summarize"

--- a/backend/tests/test_router_node.py
+++ b/backend/tests/test_router_node.py
@@ -1,6 +1,8 @@
 """Unit tests for router_node — routing logic and @wdr fast-path.
 
 All tests mock check_intent() so no LLM calls or DB connections are made.
+
+check_intent() now returns a 4-tuple: (intent, reasoning, router_usage, missing_slots)
 """
 
 from unittest.mock import AsyncMock
@@ -28,6 +30,11 @@ def _state(**overrides) -> dict:
     return {**base, **overrides}
 
 
+def _mock_ci(intent, reasoning="", usage=None, missing_slots=None, language="English"):
+    """Return an AsyncMock for check_intent with the new 5-tuple signature."""
+    return AsyncMock(return_value=(intent, reasoning, usage, missing_slots or [], language))
+
+
 @pytest.mark.asyncio
 async def test_wdr_token_forces_research_without_llm_call(monkeypatch):
     """@wdr in query must short-circuit to RESEARCH without calling check_intent."""
@@ -37,6 +44,7 @@ async def test_wdr_token_forces_research_without_llm_call(monkeypatch):
     result = await router_node(_state(query_text="@wdr analyze GDP"))
 
     assert result["intent"] == IntentType.RESEARCH.value
+    assert result["missing_slots"] == []
     mock_ci.assert_not_called()
 
 
@@ -69,13 +77,14 @@ async def test_research_intent_forwarded(monkeypatch):
     """check_intent returning RESEARCH must be forwarded with its reasoning."""
     monkeypatch.setattr(
         "app.ai.graph.nodes.router.check_intent",
-        AsyncMock(return_value=(IntentType.RESEARCH, "WDI data question", None)),
+        _mock_ci(IntentType.RESEARCH, "WDI data question"),
     )
 
     result = await router_node(_state(query_text="GDP of Kenya"))
 
     assert result["intent"] == IntentType.RESEARCH.value
     assert result["routing_reasoning"] == "WDI data question"
+    assert result["missing_slots"] == []
 
 
 @pytest.mark.asyncio
@@ -83,7 +92,7 @@ async def test_direct_intent_forwarded(monkeypatch):
     """check_intent returning DIRECT must be forwarded correctly."""
     monkeypatch.setattr(
         "app.ai.graph.nodes.router.check_intent",
-        AsyncMock(return_value=(IntentType.DIRECT, "greeting", None)),
+        _mock_ci(IntentType.DIRECT, "greeting"),
     )
 
     result = await router_node(_state(query_text="Hello there"))
@@ -93,11 +102,52 @@ async def test_direct_intent_forwarded(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_clarify_intent_with_missing_slots(monkeypatch):
+    """CLARIFY intent must forward missing_slots from check_intent."""
+    monkeypatch.setattr(
+        "app.ai.graph.nodes.router.check_intent",
+        _mock_ci(IntentType.CLARIFY, "no country specified", missing_slots=["country"]),
+    )
+
+    result = await router_node(_state(query_text="show me the data"))
+
+    assert result["intent"] == IntentType.CLARIFY.value
+    assert result["missing_slots"] == ["country"]
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_intent(monkeypatch):
+    """OUT_OF_SCOPE intent must be forwarded correctly."""
+    monkeypatch.setattr(
+        "app.ai.graph.nodes.router.check_intent",
+        _mock_ci(IntentType.OUT_OF_SCOPE, "unrelated to development data"),
+    )
+
+    result = await router_node(_state(query_text="what's the best pizza recipe"))
+
+    assert result["intent"] == IntentType.OUT_OF_SCOPE.value
+    assert result["missing_slots"] == []
+
+
+@pytest.mark.asyncio
+async def test_explain_intent(monkeypatch):
+    """EXPLAIN intent must be forwarded correctly."""
+    monkeypatch.setattr(
+        "app.ai.graph.nodes.router.check_intent",
+        _mock_ci(IntentType.EXPLAIN, "asking for definition"),
+    )
+
+    result = await router_node(_state(query_text="what is the Human Capital Index?"))
+
+    assert result["intent"] == IntentType.EXPLAIN.value
+
+
+@pytest.mark.asyncio
 async def test_empty_reasoning_allowed(monkeypatch):
     """check_intent can return an empty reasoning string — router must not crash."""
     monkeypatch.setattr(
         "app.ai.graph.nodes.router.check_intent",
-        AsyncMock(return_value=(IntentType.DIRECT, "", None)),
+        _mock_ci(IntentType.DIRECT, ""),
     )
 
     result = await router_node(_state(query_text="hi"))
@@ -109,7 +159,7 @@ async def test_empty_reasoning_allowed(monkeypatch):
 @pytest.mark.asyncio
 async def test_check_intent_called_once_for_normal_query(monkeypatch):
     """check_intent is called exactly once for a non-@wdr query."""
-    mock_ci = AsyncMock(return_value=(IntentType.RESEARCH, "data", None))
+    mock_ci = _mock_ci(IntentType.RESEARCH, "data")
     monkeypatch.setattr("app.ai.graph.nodes.router.check_intent", mock_ci)
 
     await router_node(_state(query_text="unemployment rate"))
@@ -141,6 +191,19 @@ async def test_forced_intent_research_skips_check_intent(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_forced_intent_new_intents_accepted(monkeypatch):
+    """All five intent types are accepted as forced_intent values."""
+    for intent in IntentType:
+        mock_ci = AsyncMock()
+        monkeypatch.setattr("app.ai.graph.nodes.router.check_intent", mock_ci)
+
+        result = await router_node(_state(forced_intent=intent.value))
+
+        assert result["intent"] == intent.value
+        mock_ci.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_wdr_overrides_forced_intent(monkeypatch):
     """@wdr in query still wins over forced DIRECT."""
     mock_ci = AsyncMock()
@@ -159,7 +222,7 @@ async def test_openai_messages_passed_to_check_intent(monkeypatch):
         {"role": "user", "content": "What is GDP?"},
         {"role": "assistant", "content": "GDP is ..."},
     ]
-    mock_ci = AsyncMock(return_value=(IntentType.RESEARCH, "data", None))
+    mock_ci = _mock_ci(IntentType.RESEARCH, "data")
     monkeypatch.setattr("app.ai.graph.nodes.router.check_intent", mock_ci)
 
     await router_node(_state(openai_messages=messages, query_text="follow up"))
@@ -173,7 +236,29 @@ async def test_router_usage_forwarded_when_present(monkeypatch):
     usage = {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
     monkeypatch.setattr(
         "app.ai.graph.nodes.router.check_intent",
-        AsyncMock(return_value=(IntentType.DIRECT, "ok", usage)),
+        _mock_ci(IntentType.DIRECT, "ok", usage=usage),
     )
     result = await router_node(_state(query_text="hello"))
     assert result["router_usage"] == usage
+
+
+@pytest.mark.asyncio
+async def test_detected_language_forwarded(monkeypatch):
+    """check_intent returning a non-English language must be stored in state."""
+    monkeypatch.setattr(
+        "app.ai.graph.nodes.router.check_intent",
+        _mock_ci(IntentType.RESEARCH, "data question", language="French"),
+    )
+    result = await router_node(_state(query_text="Quel est le PIB du Kenya?"))
+    assert result["detected_language"] == "French"
+
+
+@pytest.mark.asyncio
+async def test_detected_language_defaults_to_english(monkeypatch):
+    """When check_intent returns English, detected_language is still forwarded."""
+    monkeypatch.setattr(
+        "app.ai.graph.nodes.router.check_intent",
+        _mock_ci(IntentType.DIRECT, "greeting", language="English"),
+    )
+    result = await router_node(_state(query_text="Hello!"))
+    assert result["detected_language"] == "English"

--- a/backend/tests/test_router_node.py
+++ b/backend/tests/test_router_node.py
@@ -2,7 +2,9 @@
 
 All tests mock check_intent() so no LLM calls or DB connections are made.
 
-check_intent() now returns a 4-tuple: (intent, reasoning, router_usage, missing_slots)
+check_intent() returns a 4-tuple: (intent, reasoning, missing_slots, detected_language)
+Token usage is now tracked automatically via on_chat_model_end (LangChain path),
+so there is no router_usage in the return value or in graph state.
 """
 
 from unittest.mock import AsyncMock
@@ -30,9 +32,9 @@ def _state(**overrides) -> dict:
     return {**base, **overrides}
 
 
-def _mock_ci(intent, reasoning="", usage=None, missing_slots=None, language="English"):
-    """Return an AsyncMock for check_intent with the new 5-tuple signature."""
-    return AsyncMock(return_value=(intent, reasoning, usage, missing_slots or [], language))
+def _mock_ci(intent, reasoning="", missing_slots=None, language="English"):
+    """Return an AsyncMock for check_intent with the 4-tuple signature."""
+    return AsyncMock(return_value=(intent, reasoning, missing_slots or [], language))
 
 
 @pytest.mark.asyncio
@@ -231,15 +233,15 @@ async def test_openai_messages_passed_to_check_intent(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_router_usage_forwarded_when_present(monkeypatch):
-    """When check_intent returns usage, router_node exposes router_usage."""
-    usage = {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+async def test_router_usage_not_in_state(monkeypatch):
+    """router_node must NOT put router_usage in state — usage is now tracked
+    automatically via on_chat_model_end (check_intent uses ChatLiteLLM)."""
     monkeypatch.setattr(
         "app.ai.graph.nodes.router.check_intent",
-        _mock_ci(IntentType.DIRECT, "ok", usage=usage),
+        _mock_ci(IntentType.DIRECT, "ok"),
     )
     result = await router_node(_state(query_text="hello"))
-    assert result["router_usage"] == usage
+    assert "router_usage" not in result
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_router_node.py
+++ b/backend/tests/test_router_node.py
@@ -227,7 +227,7 @@ async def test_openai_messages_passed_to_check_intent(monkeypatch):
 
     await router_node(_state(openai_messages=messages, query_text="follow up"))
 
-    mock_ci.assert_awaited_once_with(messages)
+    mock_ci.assert_awaited_once_with(messages, session_summary="")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sse_bridge_usage.py
+++ b/backend/tests/test_sse_bridge_usage.py
@@ -1,0 +1,268 @@
+"""Unit tests for usage-tracking logic in _SseBridgeState.
+
+Covers the improvements introduced in the per-node usage disaggregation work:
+
+- _accumulate_node_usage updates both the total accumulator and per-node map (IMP 4 prereq)
+- add_usage_from_usage_fragment with node= correctly disaggregates (IMP 4 prereq)
+- finalize_chunks includes usageByNode in finish_metadata (Improvement 4)
+- router _model key is popped from ru before processing so it doesn't corrupt
+  token counts, and the actual model name is used (Improvement 5)
+- fill_out_dict includes byNode in final_usage dict (IMP 4)
+"""
+
+import json
+
+from app.ai.graph.sse_bridge import _SseBridgeState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bridge(model_type: str = "chat-model") -> _SseBridgeState:
+    """Return a minimal _SseBridgeState with no live graph required."""
+    return _SseBridgeState(
+        message_id="msg-test",
+        thinking_db_id="thinking-test",
+        input_state={
+            "model_type": model_type,
+            "_tool_sse_queue": None,  # no manual tool SSE
+        },
+    )
+
+
+def _usage_fragment(prompt: int, completion: int, total: int | None = None) -> dict:
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total if total is not None else prompt + completion,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _accumulate_node_usage
+# ---------------------------------------------------------------------------
+
+
+def test_accumulate_node_usage_initialises_total():
+    br = _make_bridge()
+    assert br._usage_accum is None
+    br.add_usage_from_usage_fragment(
+        _usage_fragment(10, 5), model_key="gpt-4.1-mini", node="router"
+    )
+    assert br._usage_accum is not None
+    assert br._usage_accum.inputTokens == 10
+    assert br._usage_accum.outputTokens == 5
+
+
+def test_accumulate_node_usage_sums_total_across_calls():
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(
+        _usage_fragment(10, 5), model_key="gpt-4.1-mini", node="router"
+    )
+    br.add_usage_from_usage_fragment(_usage_fragment(20, 8), model_key="gpt-4.1", node="narrator")
+    assert br._usage_accum.inputTokens == 30
+    assert br._usage_accum.outputTokens == 13
+
+
+def test_accumulate_node_usage_disaggregates_by_node():
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(
+        _usage_fragment(10, 5), model_key="gpt-4.1-mini", node="router"
+    )
+    br.add_usage_from_usage_fragment(_usage_fragment(20, 8), model_key="gpt-4.1", node="narrator")
+    br.add_usage_from_usage_fragment(_usage_fragment(5, 2), model_key="gpt-4.1-mini", node="router")
+
+    assert "router" in br._usage_by_node
+    assert "narrator" in br._usage_by_node
+    assert br._usage_by_node["router"].inputTokens == 15  # 10 + 5
+    assert br._usage_by_node["narrator"].inputTokens == 20
+
+
+def test_accumulate_node_usage_empty_node_not_added_to_by_node():
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(_usage_fragment(10, 5), model_key="gpt-4.1-mini", node="")
+    # No named node → not added to _usage_by_node, but total is updated
+    assert br._usage_by_node == {}
+    assert br._usage_accum.inputTokens == 10
+
+
+# ---------------------------------------------------------------------------
+# Improvement 4: finalize_chunks includes usageByNode in finish_metadata
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse_chunks(chunks: list[bytes]) -> list[dict]:
+    """Parse raw SSE bytes into event dicts."""
+    parsed = []
+    for chunk in chunks:
+        text = chunk.decode("utf-8")
+        for line in text.splitlines():
+            if line.startswith("data: "):
+                try:
+                    parsed.append(json.loads(line[6:]))
+                except json.JSONDecodeError:
+                    pass
+    return parsed
+
+
+def test_finalize_chunks_includes_usage_by_node_in_finish_metadata():
+    """finalize_chunks must put usageByNode in the finish event's messageMetadata."""
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(
+        _usage_fragment(10, 5), model_key="gpt-4.1-mini", node="router"
+    )
+    br.add_usage_from_usage_fragment(_usage_fragment(20, 8), model_key="gpt-4.1", node="narrator")
+
+    chunks = br.finalize_chunks()
+    events = _parse_sse_chunks(chunks)
+
+    finish_events = [e for e in events if e.get("type") == "finish"]
+    assert finish_events, "Expected a finish SSE event"
+    finish = finish_events[0]
+
+    metadata = finish.get("messageMetadata") or {}
+    assert "usageByNode" in metadata, "finish_metadata must include usageByNode"
+    by_node = metadata["usageByNode"]
+    assert "router" in by_node
+    assert "narrator" in by_node
+    assert by_node["router"]["inputTokens"] == 10
+    assert by_node["narrator"]["inputTokens"] == 20
+
+
+def test_finalize_chunks_no_usage_by_node_when_no_named_nodes():
+    """If no named nodes were accumulated, usageByNode must not appear in metadata."""
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(_usage_fragment(10, 5), model_key="gpt-4.1-mini", node="")
+
+    chunks = br.finalize_chunks()
+    events = _parse_sse_chunks(chunks)
+
+    finish_events = [e for e in events if e.get("type") == "finish"]
+    finish = finish_events[0]
+    metadata = finish.get("messageMetadata") or {}
+    # No named nodes → usageByNode should be absent
+    assert "usageByNode" not in metadata
+
+
+def test_finalize_chunks_includes_data_usage_sse_event():
+    """A data-usage SSE event with byNode must also be emitted."""
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(
+        _usage_fragment(10, 5), model_key="gpt-4.1-mini", node="router"
+    )
+
+    chunks = br.finalize_chunks()
+    events = _parse_sse_chunks(chunks)
+
+    usage_events = [e for e in events if e.get("type") == "data-usage"]
+    assert usage_events, "Expected a data-usage SSE event"
+    data = usage_events[0].get("data") or {}
+    assert "byNode" in data
+    assert "router" in data["byNode"]
+
+
+# ---------------------------------------------------------------------------
+# Improvement 5: router _model key is extracted and used as model_key
+# ---------------------------------------------------------------------------
+
+
+def test_router_model_key_extracted_from_underscore_model():
+    """
+    When router_usage contains the special '_model' key (set by routing.py from
+    response.model), the SSE bridge must pop it and use it as the model identifier
+    — not leaving it in the token-count dict where it would confuse extract_usage.
+    """
+    br = _make_bridge(model_type="routing-model-alias")
+
+    # Simulate what routing.py sends: usage dict with _model embedded
+    ru = {
+        "prompt_tokens": 15,
+        "completion_tokens": 3,
+        "total_tokens": 18,
+        "_model": "gpt-4.1-mini-2025-04-14",  # actual deployed model name
+    }
+    ru_copy = dict(ru)  # copy: sse_bridge pops _model in-place on its copy
+
+    # Simulate on_chain_end router handling (the same code path in graph_event_to_chunks)
+    ru_local = dict(ru_copy)
+    routing_model = ru_local.pop("_model", None) or "fallback-model"
+    br.add_usage_from_usage_fragment(ru_local, model_key=routing_model, node="router")
+
+    assert br._usage_accum is not None
+    assert br._usage_accum.inputTokens == 15
+    # Model ID must reflect the actual deployed name, not the alias
+    assert "gpt-4.1-mini-2025-04-14" in br._usage_accum.modelId
+
+
+def test_router_model_key_falls_back_to_settings_when_no_underscore_model():
+    """Without _model key, the code must fall back gracefully to the settings value."""
+    br = _make_bridge(model_type="fallback-routing-model")
+
+    ru = {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
+    ru_local = dict(ru)
+    routing_model = ru_local.pop("_model", None) or "fallback-routing-model"
+
+    br.add_usage_from_usage_fragment(ru_local, model_key=routing_model, node="router")
+
+    assert br._usage_accum.inputTokens == 5
+    assert "fallback-routing-model" in br._usage_accum.modelId
+
+
+# ---------------------------------------------------------------------------
+# Improvement 5: _model key must not corrupt token count parsing
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_model_not_present_in_fragment_passed_to_accumulator():
+    """
+    After popping _model, the fragment passed to add_usage_from_usage_fragment
+    must contain only numeric token fields — no stray _model string.
+    This prevents extract_usage from misreading non-numeric values.
+    """
+    ru = {
+        "prompt_tokens": 7,
+        "completion_tokens": 2,
+        "total_tokens": 9,
+        "_model": "some-real-model",
+    }
+    ru_local = dict(ru)
+    routing_model = ru_local.pop("_model", None) or "default"
+
+    assert "_model" not in ru_local, "_model must be removed before passing to accumulator"
+    assert ru_local == {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9}
+    assert routing_model == "some-real-model"
+
+
+# ---------------------------------------------------------------------------
+# fill_out_dict includes byNode
+# ---------------------------------------------------------------------------
+
+
+def test_fill_out_dict_includes_by_node_in_final_usage():
+    """fill_out_dict must attach byNode to the final_usage dict."""
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(_usage_fragment(10, 5), model_key="gpt-4.1", node="research")
+    br.add_usage_from_usage_fragment(_usage_fragment(8, 3), model_key="gpt-4.1", node="narrator")
+
+    out: dict = {}
+    br.fill_out_dict(out)
+
+    final_usage = out.get("final_usage")
+    assert final_usage is not None
+    assert "byNode" in final_usage
+    assert "research" in final_usage["byNode"]
+    assert "narrator" in final_usage["byNode"]
+
+
+def test_fill_out_dict_no_by_node_key_when_no_named_nodes():
+    """When only anonymous usage was accumulated, byNode must not appear in final_usage."""
+    br = _make_bridge()
+    br.add_usage_from_usage_fragment(_usage_fragment(5, 2), model_key="gpt-4.1", node="")
+
+    out: dict = {}
+    br.fill_out_dict(out)
+
+    final_usage = out.get("final_usage")
+    assert final_usage is not None
+    assert "byNode" not in final_usage

--- a/backend/tests/test_sse_bridge_usage.py
+++ b/backend/tests/test_sse_bridge_usage.py
@@ -163,75 +163,78 @@ def test_finalize_chunks_includes_data_usage_sse_event():
 
 
 # ---------------------------------------------------------------------------
-# Improvement 5: router _model key is extracted and used as model_key
+# Router usage: now flows via on_chat_model_end (LangChain path)
 # ---------------------------------------------------------------------------
 
 
-def test_router_model_key_extracted_from_underscore_model():
-    """
-    When router_usage contains the special '_model' key (set by routing.py from
-    response.model), the SSE bridge must pop it and use it as the model identifier
-    — not leaving it in the token-count dict where it would confuse extract_usage.
-    """
-    br = _make_bridge(model_type="routing-model-alias")
+def test_router_in_background_nodes():
+    """'router' must be in _BACKGROUND_NODES so its on_chat_model_end is handled."""
+    from app.ai.graph.sse_bridge import _BACKGROUND_NODES, _LLM_NODES
 
-    # Simulate what routing.py sends: usage dict with _model embedded
-    ru = {
-        "prompt_tokens": 15,
-        "completion_tokens": 3,
-        "total_tokens": 18,
-        "_model": "gpt-4.1-mini-2025-04-14",  # actual deployed model name
-    }
-    ru_copy = dict(ru)  # copy: sse_bridge pops _model in-place on its copy
+    assert "router" in _BACKGROUND_NODES, (
+        "'router' must be in _BACKGROUND_NODES so its on_chat_model_end event "
+        "is caught by the SSE bridge and usage is accumulated"
+    )
+    assert "router" in _LLM_NODES, (
+        "'router' must also be in _LLM_NODES so the on_chat_model_end branch fires"
+    )
 
-    # Simulate on_chain_end router handling (the same code path in graph_event_to_chunks)
-    ru_local = dict(ru_copy)
-    routing_model = ru_local.pop("_model", None) or "fallback-model"
-    br.add_usage_from_usage_fragment(ru_local, model_key=routing_model, node="router")
+
+def test_router_usage_via_add_usage_from_message():
+    """Router usage accumulated via add_usage_from_message (the on_chat_model_end
+    path) is correctly disaggregated under the 'router' node key."""
+    from types import SimpleNamespace
+
+    br = _make_bridge(model_type="gpt-4.1-mini")
+
+    # Simulate the AIMessage the LangChain LLM returns after routing
+    fake_msg = SimpleNamespace(
+        usage_metadata={
+            "input_tokens": 15,
+            "output_tokens": 3,
+            "total_tokens": 18,
+        },
+        response_metadata={"model_name": "gpt-4.1-mini"},
+        tool_calls=[],
+    )
+
+    br.add_usage_from_message(fake_msg, node="router")
 
     assert br._usage_accum is not None
     assert br._usage_accum.inputTokens == 15
-    # Model ID must reflect the actual deployed name, not the alias
-    assert "gpt-4.1-mini-2025-04-14" in br._usage_accum.modelId
+    assert "router" in br._usage_by_node
+    assert br._usage_by_node["router"].inputTokens == 15
 
 
-def test_router_model_key_falls_back_to_settings_when_no_underscore_model():
-    """Without _model key, the code must fall back gracefully to the settings value."""
-    br = _make_bridge(model_type="fallback-routing-model")
+def test_router_on_chain_end_does_not_accumulate_usage():
+    """The on_chain_end router handler no longer touches usage — only stores
+    routing_reasoning and emits reasoning SSE chunks."""
+    br = _make_bridge()
 
-    ru = {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6}
-    ru_local = dict(ru)
-    routing_model = ru_local.pop("_model", None) or "fallback-routing-model"
-
-    br.add_usage_from_usage_fragment(ru_local, model_key=routing_model, node="router")
-
-    assert br._usage_accum.inputTokens == 5
-    assert "fallback-routing-model" in br._usage_accum.modelId
-
-
-# ---------------------------------------------------------------------------
-# Improvement 5: _model key must not corrupt token count parsing
-# ---------------------------------------------------------------------------
-
-
-def test_underscore_model_not_present_in_fragment_passed_to_accumulator():
-    """
-    After popping _model, the fragment passed to add_usage_from_usage_fragment
-    must contain only numeric token fields — no stray _model string.
-    This prevents extract_usage from misreading non-numeric values.
-    """
-    ru = {
-        "prompt_tokens": 7,
-        "completion_tokens": 2,
-        "total_tokens": 9,
-        "_model": "some-real-model",
+    event = {
+        "event": "on_chain_end",
+        "name": "router",
+        "metadata": {"langgraph_node": "router"},
+        "data": {
+            "output": {
+                "routing_reasoning": "User asks about GDP data.",
+                # No router_usage key — it no longer exists
+            }
+        },
+        "run_id": "run-1",
+        "tags": [],
     }
-    ru_local = dict(ru)
-    routing_model = ru_local.pop("_model", None) or "default"
 
-    assert "_model" not in ru_local, "_model must be removed before passing to accumulator"
-    assert ru_local == {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9}
-    assert routing_model == "some-real-model"
+    chunks = br.graph_event_to_chunks(event)
+
+    # Usage accumulator must be untouched (usage comes from on_chat_model_end)
+    assert br._usage_accum is None, (
+        "on_chain_end router handler must not accumulate usage; "
+        "usage comes from on_chat_model_end instead"
+    )
+    # Routing reasoning SSE chunks must still be emitted
+    raw = b"".join(chunks).decode("utf-8")
+    assert "GDP" in raw, "Routing reasoning text must be emitted as SSE"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_token_usage_coerce.py
+++ b/backend/tests/test_token_usage_coerce.py
@@ -9,6 +9,10 @@ from app.ai.observability.token_usage import (
     usage_dict_from_openai_completion_usage,
 )
 
+# ---------------------------------------------------------------------------
+# DataUsageData.__add__: model ID deduplication (Improvement 5 prereq)
+# ---------------------------------------------------------------------------
+
 
 def test_coerce_langchain_usage_metadata_shape():
     # Model name unlikely to resolve in get_model_info for stable behavior in CI
@@ -74,3 +78,145 @@ def test_data_usage_accumulation_add():
     assert total.outputTokens == 5
     assert total.totalTokens == 20
     assert total.modelId == a.modelId == b.modelId
+
+
+def test_data_usage_add_different_models_combines_ids():
+    """Different models must produce a combined model ID (no ValueError)."""
+    a = coerce_graph_final_usage_to_data_usage(
+        {"input_tokens": 10, "output_tokens": 1, "total_tokens": 11},
+        model="router-model",
+    )
+    b = coerce_graph_final_usage_to_data_usage(
+        {"input_tokens": 5, "output_tokens": 4, "total_tokens": 9},
+        model="chat-model",
+    )
+    total = a + b
+    assert "router-model" in total.modelId
+    assert "chat-model" in total.modelId
+
+
+def test_data_usage_add_repeated_same_model_does_not_grow_unboundedly():
+    """Repeated additions of the same model should not duplicate the model ID string."""
+    base = coerce_graph_final_usage_to_data_usage(
+        {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        model="gpt-4.1-mini",
+    )
+    total = base
+    for _ in range(10):
+        piece = coerce_graph_final_usage_to_data_usage(
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            model="gpt-4.1-mini",
+        )
+        total = total + piece
+    # Model ID must contain 'gpt-4.1-mini' exactly once (deduplicated)
+    assert total.modelId.count("gpt-4.1-mini") == 1
+
+
+def test_data_usage_add_three_distinct_models():
+    """Three distinct models are all present in the combined model ID."""
+
+    def _make(model: str) -> object:
+        return coerce_graph_final_usage_to_data_usage(
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            model=model,
+        )
+
+    total = _make("model-a") + _make("model-b") + _make("model-c")
+    for name in ("model-a", "model-b", "model-c"):
+        assert name in total.modelId
+
+
+# ---------------------------------------------------------------------------
+# LangChain usage_metadata translation: cache_read / reasoning (Improvement 1 prereq)
+# ---------------------------------------------------------------------------
+
+
+def test_usage_dict_from_langchain_message_translates_cache_read_detail():
+    """cache_read in input_token_details must be translated to prompt_tokens_details.cached_tokens."""
+    msg = SimpleNamespace(
+        usage_metadata={
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "total_tokens": 120,
+            "input_token_details": {"cache_read": 40},
+        },
+        response_metadata={},
+    )
+    d = usage_dict_from_langchain_message(msg)
+    assert d is not None
+    assert d.get("prompt_tokens_details", {}).get("cached_tokens") == 40
+
+
+def test_usage_dict_from_langchain_message_translates_reasoning_detail():
+    """reasoning in output_token_details must be translated to completion_tokens_details.reasoning_tokens."""
+    msg = SimpleNamespace(
+        usage_metadata={
+            "input_tokens": 50,
+            "output_tokens": 30,
+            "total_tokens": 80,
+            "output_token_details": {"reasoning": 15},
+        },
+        response_metadata={},
+    )
+    d = usage_dict_from_langchain_message(msg)
+    assert d is not None
+    assert d.get("completion_tokens_details", {}).get("reasoning_tokens") == 15
+
+
+def test_usage_dict_from_langchain_message_translates_both_details():
+    """Both cache_read and reasoning detail can coexist in the same translation."""
+    msg = SimpleNamespace(
+        usage_metadata={
+            "input_tokens": 200,
+            "output_tokens": 50,
+            "total_tokens": 250,
+            "input_token_details": {"cache_read": 80},
+            "output_token_details": {"reasoning": 20},
+        },
+        response_metadata={},
+    )
+    d = usage_dict_from_langchain_message(msg)
+    assert d is not None
+    assert d.get("prompt_tokens_details", {}).get("cached_tokens") == 80
+    assert d.get("completion_tokens_details", {}).get("reasoning_tokens") == 20
+
+
+def test_usage_dict_from_langchain_message_zero_cache_read_not_injected():
+    """A cache_read of 0 must not be injected (avoids spurious cache hit reporting)."""
+    msg = SimpleNamespace(
+        usage_metadata={
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "input_token_details": {"cache_read": 0},
+        },
+        response_metadata={},
+    )
+    d = usage_dict_from_langchain_message(msg)
+    # Either the key is absent or it maps to 0/falsy
+    if d is not None:
+        cached = d.get("prompt_tokens_details", {}).get("cached_tokens", 0)
+        assert cached == 0
+
+
+# ---------------------------------------------------------------------------
+# Router _model key: routing.py must embed response.model (Improvement 5)
+# ---------------------------------------------------------------------------
+
+
+def test_usage_dict_from_openai_completion_usage_round_trips():
+    """usage_dict_from_openai_completion_usage must preserve all token fields."""
+    usage = SimpleNamespace(
+        model_dump=lambda **_: {
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+            "total_tokens": 15,
+            "prompt_tokens_details": {"cached_tokens": 5},
+            "completion_tokens_details": {"reasoning_tokens": 2},
+        }
+    )
+    d = usage_dict_from_openai_completion_usage(usage)
+    assert d["prompt_tokens"] == 12
+    assert d["completion_tokens"] == 3
+    assert d["prompt_tokens_details"]["cached_tokens"] == 5
+    assert d["completion_tokens_details"]["reasoning_tokens"] == 2

--- a/frontend/components/elements/node-progress.tsx
+++ b/frontend/components/elements/node-progress.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { NodeProgressPart } from "@/lib/types";
+
+/** Human-readable labels for each preprocessing node. */
+const NODE_LABELS: Record<string, string> = {
+  transformer: "Analyzing question",
+  scout: "Checking data availability",
+  planner: "Building research plan",
+};
+
+type NodeProgressProps = {
+  part: NodeProgressPart;
+  className?: string;
+};
+
+/**
+ * Renders a single preprocessing-node progress item in the data-thinking panel.
+ *
+ * While status === "running":  animated spinner + label text
+ * When  status === "done":     green checkmark + result summary
+ *
+ * The backend emits paired events with the same `id`, so the streaming hook
+ * overwrites the running entry in-place — the transition appears as an
+ * in-place animation from spinner to checkmark.
+ */
+export function NodeProgress({ part, className }: NodeProgressProps) {
+  const { node, status, message } = part;
+  const label = NODE_LABELS[node] ?? node;
+  const isRunning = status === "running";
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 py-0.5",
+        isRunning ? "text-muted-foreground" : "text-muted-foreground",
+        className,
+      )}
+      aria-live={isRunning ? "polite" : undefined}
+      aria-label={isRunning ? `${label}…` : message}
+    >
+      <span className="mt-0.5 shrink-0">
+        {isRunning ? (
+          <Loader2
+            className="size-3 animate-spin text-primary/70"
+            aria-hidden
+          />
+        ) : (
+          <CheckCircle2
+            className="size-3 text-emerald-500 dark:text-emerald-400"
+            aria-hidden
+          />
+        )}
+      </span>
+      <span className="min-w-0 text-xs leading-relaxed">
+        {isRunning ? (
+          // Show the node label while running, not the technical message
+          <span className="animate-pulse">{label}…</span>
+        ) : (
+          // Show the result summary when done
+          message
+        )}
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/message-token-usage.tsx
+++ b/frontend/components/message-token-usage.tsx
@@ -7,13 +7,32 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
-import type { AppUsage } from "@/lib/usage";
+import type { AppUsage, NodeUsage } from "@/lib/usage";
 import { cn } from "@/lib/utils";
 
 export type MessageTokenUsageProps = ComponentProps<"button"> & {
   /** Usage data for this message */
   usage?: AppUsage;
 };
+
+// Display name + emoji for known node names
+const NODE_DISPLAY: Record<string, { label: string; icon: string }> = {
+  research: { label: "Research", icon: "🔍" },
+  explain: { label: "Explain", icon: "📖" },
+  narrator: { label: "Narrator", icon: "✍️" },
+  followup: { label: "Follow-up", icon: "💬" },
+  router: { label: "Router", icon: "🧭" },
+  direct: { label: "Response", icon: "⚡" },
+  clarifier: { label: "Clarifier", icon: "❓" },
+  suggester: { label: "Suggester", icon: "💡" },
+  summarizer: { label: "Summarizer", icon: "📝" },
+};
+
+function nodeDisplayName(name: string): string {
+  const entry = NODE_DISPLAY[name];
+  if (entry) return `${entry.icon} ${entry.label}`;
+  return `⚙️ ${name}`;
+}
 
 function InfoRow({
   label,
@@ -60,6 +79,69 @@ function formatCost(cost: number | undefined | null): string | undefined {
   return cost.toString();
 }
 
+function AgentBreakdownSection({
+  byNode,
+}: {
+  byNode: Record<string, NodeUsage>;
+}) {
+  const rows = Object.entries(byNode).sort(
+    ([, a], [, b]) => (b.inputTokens ?? 0) - (a.inputTokens ?? 0),
+  );
+
+  const hasCost = rows.some(
+    ([, n]) => n.costUSD?.totalUSD != null && n.costUSD.totalUSD > 0,
+  );
+
+  return (
+    <div className="space-y-1">
+      <div className="pb-1 text-xs font-medium text-muted-foreground">
+        Agent Breakdown
+      </div>
+      <div className="space-y-0.5">
+        {/* Header row */}
+        <div
+          className={cn(
+            "grid text-[10px] font-medium uppercase tracking-wide text-muted-foreground",
+            hasCost ? "grid-cols-4" : "grid-cols-3",
+          )}
+        >
+          <span>Agent</span>
+          <span className="text-right font-mono">Input</span>
+          <span className="text-right font-mono">Output</span>
+          {hasCost && <span className="text-right font-mono">Cost</span>}
+        </div>
+        {rows.map(([nodeName, nodeData]) => {
+          const totalCost = nodeData.costUSD?.totalUSD ?? 0;
+          return (
+            <div
+              key={nodeName}
+              className={cn(
+                "grid items-center text-xs",
+                hasCost ? "grid-cols-4" : "grid-cols-3",
+              )}
+            >
+              <span className="truncate text-muted-foreground">
+                {nodeDisplayName(nodeName)}
+              </span>
+              <span className="text-right font-mono">
+                {(nodeData.inputTokens ?? 0).toLocaleString()}
+              </span>
+              <span className="text-right font-mono">
+                {(nodeData.outputTokens ?? 0).toLocaleString()}
+              </span>
+              {hasCost && (
+                <span className="text-right font-mono text-muted-foreground">
+                  {totalCost > 0 ? `$${totalCost.toFixed(6)}` : "—"}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function MessageTokenUsage({
   className,
   usage,
@@ -72,6 +154,9 @@ export function MessageTokenUsage({
   const totalTokens = usage.totalTokens ?? 0;
   const displayText = formatTokenCount(totalTokens);
 
+  const byNodeEntries = usage.byNode ? Object.keys(usage.byNode) : [];
+  const showAgentBreakdown = byNodeEntries.length >= 2;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -82,7 +167,7 @@ export function MessageTokenUsage({
             "outline-none ring-offset-background transition-colors",
             "hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             "shrink-0",
-            className
+            className,
           )}
           type="button"
           {...props}
@@ -92,71 +177,82 @@ export function MessageTokenUsage({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-fit p-3" side="top">
-        <div className="min-w-[240px] space-y-2">
-          <div className="flex items-start justify-between text-sm">
-            <span className="font-medium">Token Usage</span>
-            <span className="font-mono text-muted-foreground">
-              {totalTokens.toLocaleString()}
-            </span>
-          </div>
-          <div className="mt-1 space-y-1">
-            <InfoRow
-              costText={formatCost(usage?.costUSD?.cacheReadUSD)}
-              label="Cache Hits"
-              tokens={
-                usage?.cachedInputTokens && usage.cachedInputTokens > 0
-                  ? usage.cachedInputTokens
-                  : undefined
-              }
-            />
-            <InfoRow
-              costText={formatCost(usage?.costUSD?.inputUSD)}
-              label="Input"
-              tokens={usage?.inputTokens}
-            />
-            <InfoRow
-              costText={formatCost(usage?.costUSD?.outputUSD)}
-              label="Output"
-              tokens={usage?.outputTokens}
-            />
-            <InfoRow
-              costText={formatCost(usage?.costUSD?.reasoningUSD)}
-              label="Reasoning"
-              tokens={
-                usage?.reasoningTokens && usage.reasoningTokens > 0
-                  ? usage.reasoningTokens
-                  : undefined
-              }
-            />
-            {usage?.costUSD?.totalUSD !== undefined && (
-              <>
-                <Separator className="mt-1" />
-                <div className="flex items-center justify-between pt-1 text-xs">
-                  <span className="text-muted-foreground">Total cost</span>
-                  <div className="flex items-center gap-2 font-mono">
-                    <span className="min-w-[4ch] text-right" />
-                    <span>
-                      {Number.isNaN(
-                        Number.parseFloat(usage.costUSD.totalUSD.toString())
-                      )
-                        ? "—"
-                        : `$${Number.parseFloat(usage.costUSD.totalUSD.toString()).toFixed(6)}`}
+        <div className="min-w-[280px] space-y-2">
+          {/* Section 1: Agent Breakdown (only when ≥2 nodes) */}
+          {showAgentBreakdown && usage.byNode && (
+            <>
+              <AgentBreakdownSection byNode={usage.byNode} />
+              <Separator />
+            </>
+          )}
+
+          {/* Section 2: Totals */}
+          <div className="space-y-1">
+            {showAgentBreakdown && (
+              <div className="pb-1 text-xs font-medium text-muted-foreground">
+                Totals
+              </div>
+            )}
+            <div className="flex items-start justify-between text-sm">
+              <span className="font-medium">Token Usage</span>
+              <span className="font-mono text-muted-foreground">
+                {totalTokens.toLocaleString()}
+              </span>
+            </div>
+            <div className="mt-1 space-y-1">
+              <InfoRow
+                costText={formatCost(usage?.costUSD?.cacheReadUSD)}
+                label="Cache Hits"
+                tokens={usage?.cachedInputTokens}
+              />
+              <InfoRow
+                costText={formatCost(usage?.costUSD?.inputUSD)}
+                label="Input"
+                tokens={usage?.inputTokens}
+              />
+              <InfoRow
+                costText={formatCost(usage?.costUSD?.outputUSD)}
+                label="Output"
+                tokens={usage?.outputTokens}
+              />
+              <InfoRow
+                costText={formatCost(usage?.costUSD?.reasoningUSD)}
+                label="Reasoning"
+                tokens={usage?.reasoningTokens}
+              />
+              {usage?.costUSD?.totalUSD != null &&
+                usage.costUSD.totalUSD > 0 && (
+                  <>
+                    <Separator className="mt-1" />
+                    <div className="flex items-center justify-between pt-1 text-xs">
+                      <span className="text-muted-foreground">Total cost</span>
+                      <div className="flex items-center gap-2 font-mono">
+                        <span className="min-w-[4ch] text-right" />
+                        <span>
+                          {Number.isNaN(
+                            Number.parseFloat(
+                              usage.costUSD.totalUSD.toString(),
+                            ),
+                          )
+                            ? "—"
+                            : `$${Number.parseFloat(usage.costUSD.totalUSD.toString()).toFixed(6)}`}
+                        </span>
+                      </div>
+                    </div>
+                  </>
+                )}
+              {usage?.modelId && (
+                <>
+                  <Separator className="mt-1" />
+                  <div className="flex items-center justify-between pt-1 text-xs">
+                    <span className="text-muted-foreground">Model</span>
+                    <span className="font-mono text-muted-foreground">
+                      {usage.modelId}
                     </span>
                   </div>
-                </div>
-              </>
-            )}
-            {usage?.modelId && (
-              <>
-                <Separator className="mt-1" />
-                <div className="flex items-center justify-between pt-1 text-xs">
-                  <span className="text-muted-foreground">Model</span>
-                  <span className="font-mono text-muted-foreground">
-                    {usage.modelId}
-                  </span>
-                </div>
-              </>
-            )}
+                </>
+              )}
+            </div>
           </div>
         </div>
       </DropdownMenuContent>

--- a/frontend/components/message-token-usage.tsx
+++ b/frontend/components/message-token-usage.tsx
@@ -91,6 +91,19 @@ function AgentBreakdownSection({
   const hasCost = rows.some(
     ([, n]) => n.costUSD?.totalUSD != null && n.costUSD.totalUSD > 0,
   );
+  const hasCached = rows.some(([, n]) => (n.cachedInputTokens ?? 0) > 0);
+  const hasReasoning = rows.some(([, n]) => (n.reasoningTokens ?? 0) > 0);
+
+  // Build dynamic column count: Agent + Input + Output [+ Cached] [+ Reasoning] [+ Cost]
+  const extraCols = (hasCached ? 1 : 0) + (hasReasoning ? 1 : 0) + (hasCost ? 1 : 0);
+  const colCount = 3 + extraCols;
+  const gridCols: Record<number, string> = {
+    3: "grid-cols-3",
+    4: "grid-cols-4",
+    5: "grid-cols-5",
+    6: "grid-cols-6",
+  };
+  const gridClass = gridCols[colCount] ?? "grid-cols-3";
 
   return (
     <div className="space-y-1">
@@ -102,22 +115,30 @@ function AgentBreakdownSection({
         <div
           className={cn(
             "grid text-[10px] font-medium uppercase tracking-wide text-muted-foreground",
-            hasCost ? "grid-cols-4" : "grid-cols-3",
+            gridClass,
           )}
         >
           <span>Agent</span>
           <span className="text-right font-mono">Input</span>
           <span className="text-right font-mono">Output</span>
+          {hasCached && (
+            <span className="text-right font-mono">Cache↩</span>
+          )}
+          {hasReasoning && (
+            <span className="text-right font-mono">Think</span>
+          )}
           {hasCost && <span className="text-right font-mono">Cost</span>}
         </div>
         {rows.map(([nodeName, nodeData]) => {
           const totalCost = nodeData.costUSD?.totalUSD ?? 0;
+          const cached = nodeData.cachedInputTokens ?? 0;
+          const reasoning = nodeData.reasoningTokens ?? 0;
           return (
             <div
               key={nodeName}
               className={cn(
                 "grid items-center text-xs",
-                hasCost ? "grid-cols-4" : "grid-cols-3",
+                gridClass,
               )}
             >
               <span className="truncate text-muted-foreground">
@@ -129,6 +150,16 @@ function AgentBreakdownSection({
               <span className="text-right font-mono">
                 {(nodeData.outputTokens ?? 0).toLocaleString()}
               </span>
+              {hasCached && (
+                <span className="text-right font-mono text-muted-foreground">
+                  {cached > 0 ? cached.toLocaleString() : "—"}
+                </span>
+              )}
+              {hasReasoning && (
+                <span className="text-right font-mono text-muted-foreground">
+                  {reasoning > 0 ? reasoning.toLocaleString() : "—"}
+                </span>
+              )}
               {hasCost && (
                 <span className="text-right font-mono text-muted-foreground">
                   {totalCost > 0 ? `$${totalCost.toFixed(6)}` : "—"}

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -21,8 +21,10 @@ import { splitDataThinkingPrefixParts } from "@/lib/split-thinking-parts";
 import {
   type ChatMessage,
   isNonRenderableStreamEvent,
+  type NodeProgressPart,
   type StreamingThinkingPart,
 } from "@/lib/types";
+import { NodeProgress } from "./elements/node-progress";
 import type { AppUsage } from "@/lib/usage";
 import { cn, sanitizeText } from "@/lib/utils";
 import { ASK_ABOUT_SELECTION_CONTEXT_ATTR } from "./ask-about-selection-toolbar";
@@ -700,6 +702,13 @@ function renderMessagePart(
           )}
         </ToolContent>
       </Tool>
+    );
+  }
+
+  // Preprocessing node progress — animated spinner (running) → checkmark (done)
+  if ((type as string) === "node-progress") {
+    return (
+      <NodeProgress key={key} part={part as unknown as NodeProgressPart} />
     );
   }
 

--- a/frontend/lib/__tests__/usage.test.ts
+++ b/frontend/lib/__tests__/usage.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for aggregateUsage() in lib/usage.ts
+ *
+ * Covers:
+ * - Basic numeric field summation
+ * - Per-node byNode merging, including the new cachedInputTokens / reasoningTokens
+ *   fields added in Improvement 1
+ * - Multiple messages with the same node name are correctly summed
+ * - Absent optional fields (cachedInputTokens, reasoningTokens) default to 0
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { aggregateUsage } from "../usage";
+import type { AppUsage, NodeUsage } from "../usage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUsage(
+  overrides: Partial<AppUsage> = {},
+): AppUsage {
+  return {
+    promptTokens: 0,
+    completionTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    ...overrides,
+  } as AppUsage;
+}
+
+function makeNode(overrides: Partial<NodeUsage> = {}): NodeUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Basic aggregation
+// ---------------------------------------------------------------------------
+
+describe("aggregateUsage – basic summation", () => {
+  it("returns empty/undefined totals for empty input (no crash)", () => {
+    // aggregateUsage([]) returns an empty accumulator object; numeric fields are
+    // absent (undefined) rather than zero because no values were ever added.
+    const result = aggregateUsage([]);
+    // The key invariant: it must not throw and byNode must be absent or empty.
+    assert.ok(
+      result.byNode === undefined || Object.keys(result.byNode).length === 0,
+    );
+  });
+
+  it("sums inputTokens across multiple usages", () => {
+    const result = aggregateUsage([
+      makeUsage({ inputTokens: 10, totalTokens: 15 }),
+      makeUsage({ inputTokens: 20, totalTokens: 25 }),
+    ]);
+    assert.equal(result.inputTokens, 30);
+    assert.equal(result.totalTokens, 40);
+  });
+
+  it("sums cachedInputTokens across usages", () => {
+    const result = aggregateUsage([
+      makeUsage({ cachedInputTokens: 5, totalTokens: 10 } as AppUsage),
+      makeUsage({ cachedInputTokens: 3, totalTokens: 8 } as AppUsage),
+    ]);
+    assert.equal((result as Record<string, unknown>).cachedInputTokens, 8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// byNode merging – Improvement 1: cachedInputTokens and reasoningTokens
+// ---------------------------------------------------------------------------
+
+describe("aggregateUsage – byNode merging", () => {
+  it("merges byNode from a single usage unchanged", () => {
+    const usage = makeUsage({
+      byNode: {
+        router: makeNode({ inputTokens: 10, outputTokens: 3, totalTokens: 13 }),
+        narrator: makeNode({ inputTokens: 50, outputTokens: 20, totalTokens: 70 }),
+      },
+    });
+    const result = aggregateUsage([usage]);
+    assert.ok(result.byNode, "byNode must be present");
+    assert.equal(result.byNode!.router.inputTokens, 10);
+    assert.equal(result.byNode!.narrator.inputTokens, 50);
+  });
+
+  it("sums inputTokens / outputTokens for the same node across messages", () => {
+    const u1 = makeUsage({
+      byNode: {
+        research: makeNode({ inputTokens: 100, outputTokens: 30, totalTokens: 130 }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        research: makeNode({ inputTokens: 200, outputTokens: 50, totalTokens: 250 }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.equal(result.byNode!.research.inputTokens, 300);
+    assert.equal(result.byNode!.research.outputTokens, 80);
+  });
+
+  it("accumulates cachedInputTokens per node (Improvement 1)", () => {
+    const u1 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 100,
+          outputTokens: 20,
+          totalTokens: 120,
+          cachedInputTokens: 40,
+        }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 80,
+          outputTokens: 10,
+          totalTokens: 90,
+          cachedInputTokens: 30,
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.equal(result.byNode!.research.cachedInputTokens, 70);
+  });
+
+  it("accumulates reasoningTokens per node (Improvement 1)", () => {
+    const u1 = makeUsage({
+      byNode: {
+        narrator: makeNode({
+          inputTokens: 50,
+          outputTokens: 40,
+          totalTokens: 90,
+          reasoningTokens: 15,
+        }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        narrator: makeNode({
+          inputTokens: 60,
+          outputTokens: 35,
+          totalTokens: 95,
+          reasoningTokens: 25,
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.equal(result.byNode!.narrator.reasoningTokens, 40);
+  });
+
+  it("accumulates both cachedInputTokens and reasoningTokens simultaneously", () => {
+    const u1 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 200,
+          outputTokens: 50,
+          totalTokens: 250,
+          cachedInputTokens: 80,
+          reasoningTokens: 20,
+        }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 150,
+          outputTokens: 30,
+          totalTokens: 180,
+          cachedInputTokens: 60,
+          reasoningTokens: 10,
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    const node = result.byNode!.research;
+    assert.equal(node.cachedInputTokens, 140);
+    assert.equal(node.reasoningTokens, 30);
+  });
+
+  it("treats absent cachedInputTokens as 0 (no crash)", () => {
+    const u1 = makeUsage({
+      byNode: {
+        direct: makeNode({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+        // no cachedInputTokens
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        direct: makeNode({
+          inputTokens: 8,
+          outputTokens: 4,
+          totalTokens: 12,
+          cachedInputTokens: 3,
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    // 0 (absent) + 3 = 3
+    assert.equal(result.byNode!.direct.cachedInputTokens, 3);
+  });
+
+  it("treats absent reasoningTokens as 0 (no crash)", () => {
+    const u1 = makeUsage({
+      byNode: {
+        narrator: makeNode({ inputTokens: 10, outputTokens: 5, totalTokens: 15 }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        narrator: makeNode({
+          inputTokens: 8,
+          outputTokens: 4,
+          totalTokens: 12,
+          reasoningTokens: 7,
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.equal(result.byNode!.narrator.reasoningTokens, 7);
+  });
+
+  it("keeps distinct node names from different messages", () => {
+    const u1 = makeUsage({
+      byNode: { router: makeNode({ inputTokens: 5, outputTokens: 1, totalTokens: 6 }) },
+    });
+    const u2 = makeUsage({
+      byNode: { narrator: makeNode({ inputTokens: 30, outputTokens: 15, totalTokens: 45 }) },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.ok("router" in result.byNode!);
+    assert.ok("narrator" in result.byNode!);
+  });
+
+  it("preserves first seen modelId per node during accumulation", () => {
+    const u1 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+          modelId: "gpt-4.1",
+        }),
+      },
+    });
+    const u2 = makeUsage({
+      byNode: {
+        research: makeNode({
+          inputTokens: 5,
+          outputTokens: 2,
+          totalTokens: 7,
+          modelId: "gpt-4.1",
+        }),
+      },
+    });
+    const result = aggregateUsage([u1, u2]);
+    assert.equal(result.byNode!.research.modelId, "gpt-4.1");
+  });
+});

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -132,6 +132,17 @@ export type StreamingThinkingPart = {
   providerMetadata?: Record<string, unknown>;
 };
 
+// Node-progress part — emitted by preprocessing nodes (transformer / scout / planner).
+// "running" arrives when the node starts; "done" overwrites it when the node finishes.
+// Both events share the same stable `id` so the frontend Map entry transitions in-place.
+export type NodeProgressPart = {
+  type: "node-progress";
+  id: string;
+  node: "transformer" | "scout" | "planner" | string;
+  status: "running" | "done";
+  message: string;
+};
+
 // Helper to check if a part is a non-renderable stream event
 export function isNonRenderableStreamEvent(
   data: unknown,

--- a/frontend/lib/usage.ts
+++ b/frontend/lib/usage.ts
@@ -6,6 +6,8 @@ export interface NodeUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+  cachedInputTokens?: number;
+  reasoningTokens?: number;
   costUSD?: {
     inputUSD?: number;
     outputUSD?: number;
@@ -133,6 +135,10 @@ export function aggregateUsage(usages: AppUsage[]): AppUsage {
             inputTokens: (existing.inputTokens ?? 0) + (nodeData.inputTokens ?? 0),
             outputTokens: (existing.outputTokens ?? 0) + (nodeData.outputTokens ?? 0),
             totalTokens: (existing.totalTokens ?? 0) + (nodeData.totalTokens ?? 0),
+            cachedInputTokens:
+              (existing.cachedInputTokens ?? 0) + (nodeData.cachedInputTokens ?? 0),
+            reasoningTokens:
+              (existing.reasoningTokens ?? 0) + (nodeData.reasoningTokens ?? 0),
             modelId: existing.modelId || nodeData.modelId,
             costUSD:
               existing.costUSD || nodeData.costUSD

--- a/frontend/lib/usage.ts
+++ b/frontend/lib/usage.ts
@@ -1,8 +1,24 @@
 import type { LanguageModelUsage } from "ai";
 import type { UsageData } from "tokenlens/helpers";
 
-// Server-merged usage: base usage + TokenLens summary + optional modelId
-export type AppUsage = LanguageModelUsage & UsageData & { modelId?: string };
+/** Per-node token usage entry (from byNode disaggregation). */
+export interface NodeUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUSD?: {
+    inputUSD?: number;
+    outputUSD?: number;
+    cacheReadUSD?: number;
+    reasoningUSD?: number;
+    totalUSD?: number;
+  };
+  modelId?: string;
+}
+
+// Server-merged usage: base usage + TokenLens summary + optional modelId + optional byNode
+export type AppUsage = LanguageModelUsage &
+  UsageData & { modelId?: string; byNode?: Record<string, NodeUsage> };
 
 /** Chat lastContext: legacy (plain usage) or per-message shape from backend */
 export type LastContext =
@@ -88,6 +104,8 @@ export function aggregateUsage(usages: AppUsage[]): AppUsage {
   const result: Record<string, unknown> = {};
   const costAcc: Record<string, number> = {};
   let contextPreserved: Record<string, unknown> | undefined;
+  const byNodeAcc: Record<string, NodeUsage> = {};
+
   for (const u of usages) {
     for (const key of NUMERIC_USAGE_KEYS) {
       const v = (u as Record<string, unknown>)[key];
@@ -104,8 +122,42 @@ export function aggregateUsage(usages: AppUsage[]): AppUsage {
       if (ctx && typeof ctx === "object" && !Array.isArray(ctx))
         contextPreserved = ctx as Record<string, unknown>;
     }
+    // Merge per-node usage maps
+    if (u.byNode) {
+      for (const [nodeName, nodeData] of Object.entries(u.byNode)) {
+        if (!byNodeAcc[nodeName]) {
+          byNodeAcc[nodeName] = { ...nodeData };
+        } else {
+          const existing = byNodeAcc[nodeName];
+          byNodeAcc[nodeName] = {
+            inputTokens: (existing.inputTokens ?? 0) + (nodeData.inputTokens ?? 0),
+            outputTokens: (existing.outputTokens ?? 0) + (nodeData.outputTokens ?? 0),
+            totalTokens: (existing.totalTokens ?? 0) + (nodeData.totalTokens ?? 0),
+            modelId: existing.modelId || nodeData.modelId,
+            costUSD:
+              existing.costUSD || nodeData.costUSD
+                ? {
+                    inputUSD:
+                      (existing.costUSD?.inputUSD ?? 0) + (nodeData.costUSD?.inputUSD ?? 0),
+                    outputUSD:
+                      (existing.costUSD?.outputUSD ?? 0) + (nodeData.costUSD?.outputUSD ?? 0),
+                    cacheReadUSD:
+                      (existing.costUSD?.cacheReadUSD ?? 0) +
+                      (nodeData.costUSD?.cacheReadUSD ?? 0),
+                    reasoningUSD:
+                      (existing.costUSD?.reasoningUSD ?? 0) +
+                      (nodeData.costUSD?.reasoningUSD ?? 0),
+                    totalUSD:
+                      (existing.costUSD?.totalUSD ?? 0) + (nodeData.costUSD?.totalUSD ?? 0),
+                  }
+                : undefined,
+          };
+        }
+      }
+    }
   }
   if (Object.keys(costAcc).length > 0) result.costUSD = costAcc;
   if (contextPreserved) result.context = contextPreserved;
+  if (Object.keys(byNodeAcc).length > 0) result.byNode = byNodeAcc;
   return result as AppUsage;
 }


### PR DESCRIPTION
### Summary

This change expands the LangGraph-based chat pipeline from a simpler flow into a **multi-step agent graph**: a **summarizer** and **router** feed specialized paths (**research**, **explain**, **clarify**, **out-of-scope**, **direct**). The **research** path adds **scout → planner → research**, with **recovery** when retrieval looks empty or failed, then **narrator → followup**. **EXPLAIN** queries first go through a **transformer** that either sends **data-groundable** questions into the same research pipeline (via translated queries) or takes a **definitional** route to **explain → narrator → followup**.

### What changed

- **Graph topology** (`pipeline.py`): Documented and wired conditional edges for router intent, transformer (data vs definitional explain), and post-research failure routing to recovery.
- **New / refactored nodes**: e.g. `summarizer`, `scout`, `planner`, `recovery`, `explain`, `followup`, `clarifier`, `suggester`, `transformer`; `research` simplified relative to `dev`; `router` integrates `check_intent`, `@wdr` fast-path, and optional `forced_intent` for streaming APIs.
- **State** (`state.py`): Extended `ChatPipelineState` with session summary, scout findings, query plan, follow-ups, recovery flag, translated queries, routing confidence, detected language, etc.
- **Routing & prompts**: `routing.py` and `prompts.py` updated to support the new intents and node behaviors.
- **Utilities**: `node_utils.py`, `memory.py` updates, and new `geo_utils.py` for geography-related helpers.
- **Config**: `IntentType` enum extended with `CLARIFY`, `OUT_OF_SCOPE`, and `EXPLAIN`.
- **Tests**: `test_router_node.py` expanded for the new router behavior.

### How to test

- Run the backend test suite (at minimum `backend/tests/test_router_node.py`).
- Exercise chat flows: **RESEARCH**, **EXPLAIN** (both analytical vs definitional), **CLARIFY**, **OUT_OF_SCOPE**, **DIRECT**, and **`@wdr`** override.

### Notes / risk

- Large prompt and graph surface area; worth **spot-checking streaming/SSE** (`sse_bridge.py`) and token usage paths after merge.
