### PR TITLE
feat(search): integrate SearchResultCard from @data360/mcp-ui with multi-query support

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -150,9 +150,41 @@ AVAILABLE TOOLS
    Resolve country/region names → ISO-3 codes. Batch with comma-separated query.
    Use "REF_AREA" as codelist_type.
 
-2. data360_search_indicators(query, required_country?, limit?)
-   Find matching indicators. Returns covers_country (bool) and latest_data (year).
-   Use required_country to filter by coverage. Increase limit for broader recall.
+2. data360_search_indicators — find matching indicators with metadata
+   THREE call patterns — pick exactly ONE per invocation:
+
+   a) Single topic (default):
+      data360_search_indicators(query="GDP per capita", required_country="KEN", limit?)
+      Use when searching for ONE topic, optionally scoped to ONE country.
+
+   b) Multiple topics, SAME country (queries):
+      data360_search_indicators(queries=["GDP per capita", "inflation rate", "unemployment"], required_country="KEN")
+      Use when the user asks for MULTIPLE indicators for THE SAME country in one request.
+      This deduplicates results across sub-queries. Do NOT make separate single calls.
+
+   c) Multiple topics, DIFFERENT countries (query_groups):
+      data360_search_indicators(query_groups=[
+        {"queries": ["GDP per capita"], "required_country": "CHN"},
+        {"queries": ["life expectancy"], "required_country": "JPN"}
+      ], result_layout="by_query")
+      Use when each topic is scoped to a DIFFERENT country.
+      Each group can have MULTIPLE queries — e.g. comparing inflation in Japan to
+      population AND GDP per capita in China uses three queries across two groups:
+        query_groups=[
+          {"queries": ["inflation rate"], "required_country": "JPN"},
+          {"queries": ["population", "GDP per capita"], "required_country": "CHN"}
+        ], result_layout="by_query"
+      ALWAYS pass result_layout="by_query" with query_groups so results are grouped per country.
+      NEVER make separate single-query calls in this case — one query_groups call handles it all.
+
+   Decision rule (STRICT — do not deviate):
+   - One topic, one country → query
+   - Multiple topics, one country → queries
+   - Any topics spanning DIFFERENT countries → query_groups with result_layout="by_query"
+   - NEVER call data360_search_indicators multiple times for a cross-country comparison.
+
+   Returns covers_country (bool per country) and latest_data (year).
+   Increase limit for broader recall.
 
 3. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
    Fetch actual observation values.
@@ -350,8 +382,7 @@ retrieved from metadata tools — no RAW TOOL RESULTS section will be present.
 
 Use ONLY what is in the RAW TOOL RESULTS and ROUTING PACKET. Never supplement with background knowledge.
 Use the official country, region, and indicator names as written in the packet.
-If you call `data360_get_viz_spec`, present the returned URL as a markdown link (e.g., [View Chart](URL)). NEVER apologize or claim you cannot generate links.
-
+If you call `data360_get_viz_spec` or `data360_get_multi_indicator_viz_spec`, present the returned URL as a markdown link (e.g., [View Chart](URL)). NEVER apologize or claim you cannot generate links or render charts.
 WHEN INFORMATION IS MISSING:
 - If the packet has a ### NO_DATA section: explain what was unavailable and suggest
   1-2 related queries the user could try. Do NOT ask a clarifying question.
@@ -1022,8 +1053,18 @@ Research node will do the detailed data retrieval. Your job is indicator
 selection, not exhaustive verification.
 
 AVAILABLE TOOLS:
-1. `data360_search_indicators(query, required_country?, limit?)` — find matching
-   indicators. Returns `covers_country` (bool) and `latest_data` (year) per result.
+1. `data360_search_indicators` — find matching indicators with metadata.
+   THREE call patterns — pick exactly ONE:
+   - Single topic: data360_search_indicators(query="GDP per capita", required_country="KEN")
+   - Multiple topics, SAME country: data360_search_indicators(queries=["GDP", "inflation"], required_country="KEN")
+   - Different topics, DIFFERENT countries (even asymmetric counts):
+       data360_search_indicators(query_groups=[
+         {"queries": ["inflation rate"], "required_country": "JPN"},
+         {"queries": ["population", "GDP per capita"], "required_country": "CHN"}
+       ], result_layout="by_query")
+   Decision rule (STRICT): one topic → query | many topics same country → queries | any cross-country → query_groups with result_layout="by_query"
+   NEVER make multiple separate calls for a cross-country comparison — use query_groups.
+   Returns `covers_country` (bool per country) and `latest_data` (year) per result.
 2. `data360_get_disaggregation(database_id, indicator_id)` — get exact year and
    country coverage. SLOW — only call when strictly necessary (see rules below).
 3. `data360_find_codelist_value(codelist_type, query)` — resolve country/region
@@ -1035,10 +1076,10 @@ Step 1 — Resolve country codes (if query mentions countries by name):
   Call `data360_find_codelist_value("REF_AREA", "country1, country2, ...")` once
   with all country names batched. Skip if only ISO-3 codes are given.
 
-Step 2 — Search for indicators:
-  Call `data360_search_indicators(topic, required_country=<ISO3 code>)` using the
-  primary country (or any one country for multi-country queries).
+Step 2 — Search for indicators using the appropriate call pattern above:
+  For multi-country/multi-topic queries, prefer query_groups over separate calls.
   Check `covers_country` and `latest_data` in the results.
+
 
 Step 3 — FAST-PATH (use this whenever possible — skips disaggregation):
   If `covers_country=true` for the top result AND the user did NOT ask for a

--- a/frontend/app/api/mcp-static/[...path]/route.ts
+++ b/frontend/app/api/mcp-static/[...path]/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Dev-only proxy: forwards /api/mcp-static/** requests to the local MCP server's
+ * /static/** path so that viz spec JSON files (served by data360-mcp) are
+ * accessible from the frontend origin in local Docker development.
+ *
+ * Only active when ENVIRONMENT=development. Returns 404 in production to prevent
+ * accidental exposure of internal MCP URLs.
+ *
+ * Usage: the MCP server returns URLs like http://host.docker.internal:8021/static/viz_specs/<id>.json
+ * chart-url.ts rewrites these to /api/mcp-static/viz_specs/<id>.json when in dev.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+
+const ENVIRONMENT = process.env.ENVIRONMENT ?? process.env.NODE_ENV;
+const MCP_SERVER_URL = process.env.MCP_SERVER_URL;
+
+function getMcpOrigin(): string | null {
+  if (!MCP_SERVER_URL) return null;
+  try {
+    const url = new URL(MCP_SERVER_URL);
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<NextResponse> {
+  // Disabled in production
+  if (ENVIRONMENT !== "development") {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const mcpOrigin = getMcpOrigin();
+  if (!mcpOrigin) {
+    return new NextResponse(
+      "MCP_SERVER_URL not configured — cannot proxy MCP static files",
+      { status: 503 },
+    );
+  }
+
+  const { path } = await params;
+  const upstreamPath = `/static/${path.join("/")}`;
+  const upstreamUrl = `${mcpOrigin}${upstreamPath}`;
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      headers: { Accept: "application/json" },
+      // Don't verify SSL for local MCP server
+      // biome-ignore lint/suspicious/noExplicitAny: node-fetch specific
+      ...(process.env.MCP_SSL_VERIFY === "false" ? ({ agent: undefined } as any) : {}),
+    });
+
+    if (!upstream.ok) {
+      return new NextResponse(`MCP static file not found: ${upstreamPath}`, {
+        status: upstream.status,
+      });
+    }
+
+    const contentType = upstream.headers.get("content-type") ?? "application/json";
+    const body = await upstream.arrayBuffer();
+
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new NextResponse(`Failed to proxy MCP static file: ${message}`, {
+      status: 502,
+    });
+  }
+}

--- a/frontend/components/data360/search-indicators.tsx
+++ b/frontend/components/data360/search-indicators.tsx
@@ -10,10 +10,76 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { SearchIndicatorsInput, SearchIndicatorsOutput } from "./types";
+import SearchResultCard from "./SearchResultCard";
+
+// ─── Country name resolution ──────────────────────────────────────────────────
+// Maps ISO 3166-1 alpha-3 → alpha-2 for Intl.DisplayNames (which uses alpha-2).
+// Covers the most common World Bank research countries.
+const ISO3_TO_ISO2: Record<string, string> = {
+  AFG:"AF",AGO:"AO",ALB:"AL",ARE:"AE",ARG:"AR",ARM:"AM",AUS:"AU",AUT:"AT",
+  AZE:"AZ",BDI:"BI",BEL:"BE",BEN:"BJ",BFA:"BF",BGD:"BD",BGR:"BG",BHR:"BH",
+  BIH:"BA",BLR:"BY",BLZ:"BZ",BOL:"BO",BRA:"BR",BTN:"BT",BWA:"BW",CAF:"CF",
+  CAN:"CA",CHE:"CH",CHL:"CL",CHN:"CN",CIV:"CI",CMR:"CM",COD:"CD",COG:"CG",
+  COL:"CO",COM:"KM",CPV:"CV",CRI:"CR",CUB:"CU",CYP:"CY",CZE:"CZ",DEU:"DE",
+  DJI:"DJ",DNK:"DK",DOM:"DO",DZA:"DZ",ECU:"EC",EGY:"EG",ERI:"ER",ESP:"ES",
+  EST:"EE",ETH:"ET",FIN:"FI",FJI:"FJ",FRA:"FR",GAB:"GA",GBR:"GB",GEO:"GE",
+  GHA:"GH",GIN:"GN",GMB:"GM",GNB:"GW",GRC:"GR",GTM:"GT",GUY:"GY",HND:"HN",
+  HRV:"HR",HTI:"HT",HUN:"HU",IDN:"ID",IND:"IN",IRL:"IE",IRN:"IR",IRQ:"IQ",
+  ISL:"IS",ISR:"IL",ITA:"IT",JAM:"JM",JOR:"JO",JPN:"JP",KAZ:"KZ",KEN:"KE",
+  KGZ:"KG",KHM:"KH",KIR:"KI",KOR:"KR",KWT:"KW",LAO:"LA",LBN:"LB",LBR:"LR",
+  LBY:"LY",LCA:"LC",LKA:"LK",LSO:"LS",LTU:"LT",LUX:"LU",LVA:"LV",MAR:"MA",
+  MDA:"MD",MDG:"MG",MDV:"MV",MEX:"MX",MKD:"MK",MLI:"ML",MLT:"MT",MMR:"MM",
+  MNG:"MN",MOZ:"MZ",MRT:"MR",MUS:"MU",MWI:"MW",MYS:"MY",NAM:"NA",NER:"NE",
+  NGA:"NG",NIC:"NI",NLD:"NL",NOR:"NO",NPL:"NP",NZL:"NZ",OMN:"OM",PAK:"PK",
+  PAN:"PA",PER:"PE",PHL:"PH",PNG:"PG",POL:"PL",PRK:"KP",PRT:"PT",PRY:"PY",
+  PSE:"PS",QAT:"QA",ROU:"RO",RUS:"RU",RWA:"RW",SAU:"SA",SDN:"SD",SEN:"SN",
+  SLB:"SB",SLE:"SL",SLV:"SV",SOM:"SO",SRB:"RS",SSD:"SS",STP:"ST",SUR:"SR",
+  SVK:"SK",SVN:"SI",SWE:"SE",SWZ:"SZ",SYC:"SC",SYR:"SY",TCD:"TD",TGO:"TG",
+  THA:"TH",TJK:"TJ",TKM:"TM",TLS:"TL",TON:"TO",TTO:"TT",TUN:"TN",TUR:"TR",
+  TZA:"TZ",UGA:"UG",UKR:"UA",URY:"UY",USA:"US",UZB:"UZ",VEN:"VE",VNM:"VN",
+  VUT:"VU",WSM:"WS",YEM:"YE",ZAF:"ZA",ZMB:"ZM",ZWE:"ZW",
+};
+
+let _displayNames: Intl.DisplayNames | null = null;
+function getDisplayNames(): Intl.DisplayNames | null {
+  try {
+    if (!_displayNames) _displayNames = new Intl.DisplayNames(["en"], { type: "region" });
+    return _displayNames;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve an ISO-3 code to a human-readable English name, e.g. "JPN" → "Japan". */
+function resolveCountryName(code: string): string {
+  const alpha2 = ISO3_TO_ISO2[code.toUpperCase()];
+  if (!alpha2) return code;
+  try {
+    return getDisplayNames()?.of(alpha2) ?? code;
+  } catch {
+    return code;
+  }
+}
 
 const SearchIconComponent = () => (
   <SearchIcon className="size-5 text-muted-foreground" />
 );
+
+/** Derives whether the result came from query_groups, queries (shared country), or a single query. */
+function getSearchMode(
+  output: SearchIndicatorsOutput,
+): "query_groups" | "queries" | "query" {
+  const queries = output.queries;
+  if (!queries || queries.length <= 1) return "query";
+
+  // query_groups: indicators have per-indicator requested_country that differ across results
+  const countries = new Set(
+    output.indicators.map((i) => i.requested_country).filter(Boolean),
+  );
+  if (countries.size > 1) return "query_groups";
+
+  return "queries";
+}
 
 export function SearchIndicatorsRequestSummary({
   input,
@@ -72,6 +138,109 @@ export function SearchIndicatorsRequestSummary({
   );
 }
 
+/** Badge showing search mode. */
+function SearchModeBadge({
+  mode,
+}: {
+  mode: "query_groups" | "queries" | "query";
+}) {
+  if (mode === "query") return null;
+
+  const label =
+    mode === "query_groups" ? "Multi-query (grouped)" : "Multi-query";
+  const title =
+    mode === "query_groups"
+      ? "Different indicators searched per country group"
+      : "Multiple indicators searched with shared country scope";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 font-medium text-blue-400 text-[10px] leading-tight cursor-default">
+          {label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="max-w-xs text-xs">{title}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Sub-query tags shown for multi-query results. */
+function QueryTags({ queries }: { queries: string[] }) {
+  if (!queries || queries.length <= 1) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {queries.map((q) => (
+        <span
+          key={q}
+          className="inline-flex items-center rounded border border-border bg-muted/40 px-2 py-0.5 font-mono text-muted-foreground text-[10px]"
+        >
+          {q}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Dedup summary shown for merged multi-query results. */
+function DedupBadge({
+  totalCandidates,
+  dedupCount,
+}: {
+  totalCandidates: number;
+  dedupCount: number | null | undefined;
+}) {
+  if (!dedupCount) return null;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 font-medium text-amber-400 text-[10px] leading-tight cursor-default">
+          {dedupCount} deduped
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="max-w-xs text-xs">
+          {totalCandidates} total candidates found across all sub-queries.{" "}
+          {dedupCount} duplicate{dedupCount !== 1 ? "s" : ""} removed.
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Renders the covers_country map as colored country code pills. */
+function CoversCountryPills({
+  coversCountry,
+}: {
+  coversCountry: Record<string, boolean> | null | undefined;
+}) {
+  if (!coversCountry) return null;
+  const entries = Object.entries(coversCountry);
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([code, covers]) => (
+        <span
+          key={code}
+          className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px] leading-tight ${
+            covers
+              ? "border border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+              : "border border-muted bg-muted/30 text-muted-foreground"
+          }`}
+        >
+          <span
+            className={`size-1.5 rounded-full ${covers ? "bg-emerald-400" : "bg-muted-foreground/40"}`}
+          />
+          {code}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function SearchIndicators({
   input,
   output,
@@ -79,14 +248,13 @@ export function SearchIndicators({
   input?: SearchIndicatorsInput | null;
   output: SearchIndicatorsOutput;
 }) {
-  const requestSummary =
-    input != null ? <SearchIndicatorsRequestSummary input={input} /> : null;
 
-  // Handle error case
+
+  // Error case
   if (output.error) {
     return (
       <div className="flex flex-col gap-3">
-        {requestSummary}
+
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
           <div className="font-medium">Error</div>
           <div className="mt-1">{output.error}</div>
@@ -95,163 +263,318 @@ export function SearchIndicators({
     );
   }
 
-  // Handle empty results
-  if (!output.indicators || output.indicators.length === 0) {
+  const queries = output.queries ?? (output.query ? [output.query] : []);
+
+  // ── query_groups with result_layout="by_query": grouped accordion ────────
+  if (output.result_layout === "by_query" && output.results && output.results.length > 0) {
+    // Group results by country, then format as:
+    // "Japan: inflation rate · China: population, GDP per capita"
+    type CountryGroup = { name: string; queries: string[] };
+    const byCountry = new Map<string, CountryGroup>();
+
+    for (const g of output.results) {
+      const code = g.country_code ?? "__none__";
+      if (!byCountry.has(code)) {
+        byCountry.set(code, {
+          name: g.country_code ? resolveCountryName(g.country_code) : "",
+          queries: [],
+        });
+      }
+      byCountry.get(code)!.queries.push(g.query);
+    }
+
+    const groupSubtitle = Array.from(byCountry.values())
+      .map((c) => (c.name ? `${c.name}: ${c.queries.join(", ")}` : c.queries.join(", ")))
+      .join(" · ");
+
+    // Attach resolved country names onto the groups for GroupHeader to display
+    const groupsWithNames = output.results.map((g) => ({
+      ...g,
+      country_name: g.country_code ? resolveCountryName(g.country_code) : undefined,
+    }));
+
     return (
       <div className="flex flex-col gap-3">
-        {requestSummary}
-        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
-          No indicators found
-        </div>
+
+        <SearchResultCard
+          groups={groupsWithNames}
+          title="Multi-country Search"
+          subtitle={groupSubtitle}
+        />
       </div>
     );
   }
 
-  return (
-    <TooltipProvider>
-      <div className="flex w-full flex-col gap-4 overflow-hidden rounded-sm bg-background px-4 pb-4">
-        {requestSummary}
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <SearchIconComponent />
-              <div className="font-semibold text-sm">Search Results</div>
-            </div>
-          </div>
-          <div className="flex flex-col items-end gap-1">
-            <div className="text-muted-foreground text-xs">
-              Showing {output.count} of {output.total_count.toLocaleString()}{" "}
-              indicator{output.total_count !== 1 ? "s" : ""}
-            </div>
-            {/* {output.has_more && (
-              <div className="text-muted-foreground text-[10px]">
-                More results available
-              </div>
-            )} */}
-          </div>
-        </div>
+  // ── query_groups fallback: merged layout but multiple countries ───────────
+  // Detected by semicolon in required_country (e.g. "CHN;JPN") or query count
+  const isCrossCountry =
+    output.required_country?.includes(";") ||
+    output.required_country?.includes(",");
 
-        {/* Horizontal Scrollable Cards */}
-        <ScrollArea className="w-full whitespace-nowrap">
-          <div className="flex w-max gap-3 pb-4">
-            {output.indicators.map((indicator, index) => (
-              <Card
-                className="min-w-[360px] max-w-[420px] shrink-0 border-border transition-colors hover:border-primary/50"
-                key={`${indicator.idno}-${index}`}
-              >
-                <CardHeader className="pb-3">
-                  <CardTitle className="line-clamp-2 font-medium text-sm leading-tight">
-                    {indicator.name}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <div className="flex flex-col gap-3">
-                    {/* ID and Database */}
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground text-xs">
-                      <div>
-                        <span className="font-medium">ID:</span> {indicator.idno}
-                      </div>
-                      <div>
-                        <span className="font-medium">Database:</span>{" "}
-                        {indicator.database_id}
-                      </div>
-                    </div>
+  if (queries.length > 1 && isCrossCountry) {
+    const rawCodes = (output.required_country ?? "").split(/[;,]/).map((c) => c.trim()).filter(Boolean);
+    const countryNames = rawCodes.map(resolveCountryName).join(", ");
+    const subtitle = `${queries.join(", ")} · ${countryNames}`;
 
-                    {/* Definition */}
-                    {indicator.truncated_definition && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="rounded border border-border bg-muted/30 p-2.5">
-                            <div className="line-clamp-3 text-muted-foreground text-xs leading-relaxed">
-                              {indicator.truncated_definition}
-                            </div>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-md" side="top">
-                          <p className="whitespace-normal text-xs">
-                            {indicator.truncated_definition}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
+    return (
+      <div className="flex flex-col gap-3">
 
-                    {/* Metadata Grid */}
-                    <div className="grid grid-cols-2 gap-2 rounded border border-border bg-muted/20 p-2">
-                      {indicator.periodicity && (
-                        <div className="text-muted-foreground text-xs">
-                          <span className="font-medium">Periodicity:</span>{" "}
-                          <span className="text-foreground">
-                            {indicator.periodicity}
-                          </span>
-                        </div>
-                      )}
-                      {indicator.latest_data && (
-                        <div className="text-muted-foreground text-xs">
-                          <span className="font-medium">Latest:</span>{" "}
-                          <span className="text-foreground">
-                            {indicator.latest_data}
-                          </span>
-                        </div>
-                      )}
-                      {indicator.time_period_range && (
-                        <div className="col-span-2 text-muted-foreground text-xs">
-                          <span className="font-medium">Range:</span>{" "}
-                          <span className="text-foreground">
-                            {indicator.time_period_range}
-                          </span>
-                        </div>
-                      )}
-                      {indicator.dimensions &&
-                        indicator.dimensions.length > 0 && (
-                          <div className="col-span-2 text-muted-foreground text-xs">
-                            <span className="font-medium">Dimensions:</span>{" "}
-                            <span className="text-foreground">
-                              {indicator.dimensions.join(", ")}
-                            </span>
-                          </div>
-                        )}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
-
-        {/* Pagination Info
-        {output.has_more && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3 dark:border-blue-800 dark:bg-blue-950/20">
-            <div className="flex items-start gap-2">
-              <div className="mt-0.5 text-blue-600 dark:text-blue-400">
-                <svg
-                  fill="none"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13 16H12V12H11M12 8H12.01M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                  />
-                </svg>
-              </div>
-              <div className="text-blue-800 text-xs leading-relaxed dark:text-blue-200">
-                Showing results {output.offset + 1}-
-                {output.offset + output.count} of{" "}
-                {output.total_count.toLocaleString()}.
-                {output.has_more &&
-                  ` Next page starts at offset ${output.next_offset}.`}
-              </div>
-            </div>
-          </div>
-        )} */}
+        <SearchResultCard
+          indicators={output.indicators}
+          title="Multi-country Search"
+          subtitle={subtitle}
+        />
       </div>
-    </TooltipProvider>
+    );
+  }
+
+  // ── queries: multiple topics, shared country ──────────────────────────────
+  if (queries.length > 1) {
+    let subtitle = queries.join(" · ");
+    if (output.required_country) {
+      const names = output.required_country
+        .split(/[;,]/)
+        .map((c) => resolveCountryName(c.trim()))
+        .join(", ");
+      subtitle = `${names}: ${queries.join(", ")}`;
+    }
+
+    return (
+      <div className="flex flex-col gap-3">
+
+        <SearchResultCard
+          indicators={output.indicators}
+          title="Multi-query Search"
+          subtitle={subtitle}
+        />
+      </div>
+    );
+  }
+
+  // ── query: single topic ───────────────────────────────────────────────────
+  const singleQuery = queries[0] ?? output.query ?? "Search";
+  let subtitle = singleQuery;
+  if (output.required_country) {
+    const names = output.required_country
+      .split(/[;,]/)
+      .map((c) => resolveCountryName(c.trim()))
+      .join(", ");
+    subtitle = `${names}: ${singleQuery}`;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+
+      <SearchResultCard
+        indicators={output.indicators}
+        title="Indicator Search"
+        subtitle={subtitle}
+      />
+    </div>
   );
 }
+
+/*
+ * ──────────────────────────────────────────────────────────────────────────────
+ * REFERENCE IMPLEMENTATION (commented out — preserved for comparison)
+ *
+ * The components below are the original custom search UI built before
+ * @data360/mcp-ui/SearchResultCard was available. They implement the same
+ * functionality inline using shadcn/ui primitives and Tailwind.
+ *
+ * Keep these until SearchResultCard is fully validated in production.
+ * ──────────────────────────────────────────────────────────────────────────────
+ */
+
+/*
+const SearchIconComponent = () => (
+  <SearchIcon className="size-5 text-muted-foreground" />
+);
+
+function getSearchMode(
+  output: SearchIndicatorsOutput,
+): "query_groups" | "queries" | "query" {
+  const queries = output.queries;
+  if (!queries || queries.length <= 1) return "query";
+  const countries = new Set(
+    output.indicators.map((i) => i.requested_country).filter(Boolean),
+  );
+  if (countries.size > 1) return "query_groups";
+  return "queries";
+}
+
+function SearchModeBadge({ mode }: { mode: "query_groups" | "queries" | "query" }) {
+  if (mode === "query") return null;
+  const label = mode === "query_groups" ? "Multi-query (grouped)" : "Multi-query";
+  const title =
+    mode === "query_groups"
+      ? "Different indicators searched per country group"
+      : "Multiple indicators searched with shared country scope";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 font-medium text-blue-400 text-[10px] leading-tight cursor-default">
+          {label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top"><p className="max-w-xs text-xs">{title}</p></TooltipContent>
+    </Tooltip>
+  );
+}
+
+function QueryTags({ queries }: { queries: string[] }) {
+  if (!queries || queries.length <= 1) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {queries.map((q) => (
+        <span key={q} className="inline-flex items-center rounded border border-border bg-muted/40 px-2 py-0.5 font-mono text-muted-foreground text-[10px]">
+          {q}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function DedupBadge({ totalCandidates, dedupCount }: { totalCandidates: number; dedupCount: number | null | undefined }) {
+  if (!dedupCount) return null;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 font-medium text-amber-400 text-[10px] leading-tight cursor-default">
+          {dedupCount} deduped
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="max-w-xs text-xs">
+          {totalCandidates} total candidates found across all sub-queries.{" "}
+          {dedupCount} duplicate{dedupCount !== 1 ? "s" : ""} removed.
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function CoversCountryPills({ coversCountry }: { coversCountry: Record<string, boolean> | null | undefined }) {
+  if (!coversCountry) return null;
+  const entries = Object.entries(coversCountry);
+  if (entries.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([code, covers]) => (
+        <span
+          key={code}
+          className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px] leading-tight ${
+            covers
+              ? "border border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+              : "border border-muted bg-muted/30 text-muted-foreground"
+          }`}
+        >
+          <span className={`size-1.5 rounded-full ${covers ? "bg-emerald-400" : "bg-muted-foreground/40"}`} />
+          {code}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function IndicatorCard({ indicator, index, mode }: {
+  indicator: SearchIndicatorsOutput["indicators"][number];
+  index: number;
+  mode: "query_groups" | "queries" | "query";
+}) {
+  return (
+    <Tooltip>
+      <Card className="min-w-[360px] max-w-[420px] shrink-0 border-border transition-colors hover:border-primary/50" key={`${indicator.idno}-${index}`}>
+        <CardHeader className="pb-3">
+          <CardTitle className="line-clamp-2 font-medium text-sm leading-tight whitespace-normal">{indicator.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-muted-foreground text-xs">
+              <div><span className="font-medium">ID:</span> {indicator.idno}</div>
+              <div><span className="font-medium">Database:</span> {indicator.database_id}</div>
+            </div>
+            {indicator.covers_country && <CoversCountryPills coversCountry={indicator.covers_country} />}
+            {indicator.truncated_definition && (
+              <TooltipTrigger asChild>
+                <div className="rounded border border-border bg-muted/30 p-2.5 cursor-default">
+                  <div className="line-clamp-3 text-muted-foreground text-xs leading-relaxed whitespace-normal">{indicator.truncated_definition}</div>
+                </div>
+              </TooltipTrigger>
+            )}
+            {indicator.truncated_definition && (
+              <TooltipContent className="max-w-md" side="top">
+                <p className="whitespace-normal text-xs">{indicator.truncated_definition}</p>
+              </TooltipContent>
+            )}
+            <div className="grid grid-cols-2 gap-2 rounded border border-border bg-muted/20 p-2">
+              {indicator.periodicity && (
+                <div className="text-muted-foreground text-xs"><span className="font-medium">Periodicity:</span> <span className="text-foreground">{indicator.periodicity}</span></div>
+              )}
+              {indicator.latest_data && (
+                <div className="text-muted-foreground text-xs"><span className="font-medium">Latest:</span> <span className="text-foreground">{indicator.latest_data}</span></div>
+              )}
+              {indicator.time_period_range && (
+                <div className="col-span-2 text-muted-foreground text-xs"><span className="font-medium">Range:</span> <span className="text-foreground">{indicator.time_period_range}</span></div>
+              )}
+              {indicator.dimensions && indicator.dimensions.length > 0 && (
+                <div className="col-span-2 text-muted-foreground text-xs"><span className="font-medium">Dimensions:</span> <span className="text-foreground">{indicator.dimensions.join(", ")}</span></div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Tooltip>
+  );
+}
+
+function FlatIndicatorRow({ indicators, mode }: { indicators: SearchIndicatorsOutput["indicators"]; mode: "query_groups" | "queries" | "query" }) {
+  return (
+    <ScrollArea className="w-full whitespace-nowrap">
+      <div className="flex w-max gap-3 pb-4">
+        {indicators.map((indicator, index) => (
+          <IndicatorCard key={`${indicator.idno}-${index}`} indicator={indicator} index={index} mode={mode} />
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  );
+}
+
+function GroupedIndicatorRows({ output }: { output: SearchIndicatorsOutput }) {
+  const { indicators } = output;
+  const countryOrder: string[] = [];
+  const groups: Record<string, typeof indicators> = {};
+  for (const ind of indicators) {
+    const key = ind.requested_country ?? "Unknown";
+    if (!groups[key]) { groups[key] = []; countryOrder.push(key); }
+    groups[key].push(ind);
+  }
+  return (
+    <div className="flex flex-col gap-5">
+      {countryOrder.map((country) => {
+        const groupIndicators = groups[country];
+        return (
+          <div key={country} className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 font-mono font-semibold text-emerald-400 text-xs">
+                <span className="size-1.5 rounded-full bg-emerald-400" />
+                {country}
+              </span>
+              <span className="text-muted-foreground text-xs">{groupIndicators.length} indicator{groupIndicators.length !== 1 ? "s" : ""}</span>
+            </div>
+            <ScrollArea className="w-full whitespace-nowrap">
+              <div className="flex w-max gap-3 pb-3">
+                {groupIndicators.map((indicator, index) => (
+                  <IndicatorCard key={`${indicator.idno}-${index}`} indicator={indicator} index={index} mode="query_groups" />
+                ))}
+              </div>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+*/

--- a/frontend/components/data360/types.ts
+++ b/frontend/components/data360/types.ts
@@ -32,12 +32,25 @@ export type SearchIndicatorItem = {
   idno: string;
   name: string;
   database_id: string;
+  database_name?: string | null;
   truncated_definition: string;
   periodicity: string;
   latest_data: string;
   time_period_range: string;
-  covers_country: string | null;
+  /** Per-country boolean map e.g. { KEN: true, GHA: false }. Null when no country was requested. */
+  covers_country: Record<string, boolean> | null;
+  /** Resolved country code this indicator was evaluated against (set for query_groups per-group country). */
+  requested_country: string | null;
   dimensions: string[] | null;
+};
+
+/** Per-query result group returned by data360_search_indicators with result_layout="by_query". */
+export type QueryGroupResult = {
+  query: string;
+  country_code?: string | null;
+  indicators: SearchIndicatorItem[];
+  count: number;
+  error?: string | null;
 };
 
 /** Tool input for data360_search_indicators (from tool call arguments). */
@@ -50,15 +63,25 @@ export type SearchIndicatorsInput = {
 
 export type SearchIndicatorsOutput = {
   count: number;
-  total_count: number;
-  offset: number;
-  has_more: boolean;
-  next_offset: number;
+  total_count: number | null;
+  offset: number | null;
+  has_more: boolean | null;
+  next_offset: number | null;
   indicators: SearchIndicatorItem[];
   required_country: string | null;
   error: string | null;
-  /** Query used for the search (may come from tool input when not in API response). */
+  /** Query used for single-query path (from tool input). */
   query?: string | null;
+  /** Sub-queries used (multi-query paths: queries= or query_groups=). Length > 1 means multi-query was used. */
+  queries?: string[] | null;
+  /** Layout mode returned by the MCP: 'merged' or 'by_query'. */
+  result_layout?: "merged" | "by_query" | null;
+  /** Total indicators found before deduplication (multi-query paths only). */
+  total_candidates?: number | null;
+  /** Number of duplicates removed (multi-query merged layout only). */
+  deduplicated_count?: number | null;
+  /** Per-query result groups (result_layout="by_query"). Each group has its own indicators list. */
+  results?: QueryGroupResult[] | null;
 };
 
 export type GetDataDataPoint = {

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -649,10 +649,10 @@ function renderMessagePart(
       input: Record<string, unknown> | unknown;
       output: {
         count: number;
-        total_count: number;
-        offset: number;
-        has_more: boolean;
-        next_offset: number;
+        total_count: number | null;
+        offset: number | null;
+        has_more: boolean | null;
+        next_offset: number | null;
         indicators: Array<{
           idno: string;
           name: string;
@@ -661,11 +661,17 @@ function renderMessagePart(
           periodicity: string;
           latest_data: string;
           time_period_range: string;
-          covers_country: string | null;
+          covers_country: Record<string, boolean> | null;
+          requested_country: string | null;
           dimensions: string[] | null;
         }>;
         required_country: string | null;
         error: string | null;
+        // multi-query fields
+        queries?: string[] | null;
+        result_layout?: "merged" | "by_query" | null;
+        total_candidates?: number | null;
+        deduplicated_count?: number | null;
       };
     };
     const searchIndicatorsInput =
@@ -714,6 +720,7 @@ function renderMessagePart(
                   output={{
                     ...toolPart.output,
                     query: searchIndicatorsInput?.query,
+                    queries: toolPart.output.queries ?? undefined,
                   }}
                 />
               }

--- a/frontend/lib/chart-url.ts
+++ b/frontend/lib/chart-url.ts
@@ -22,6 +22,11 @@ export function applyBasePathToChartPath(
 /**
  * Normalize chart URL to a same-origin path for `fetch()` (proxy via Next.js).
  * Strips absolute URLs to pathname + search, then applies `basePath` when needed.
+ *
+ * In development, rewrites /static/... paths (served by the local MCP server) to
+ * /api/mcp-static/... so the Next.js dev proxy can serve them from the same origin.
+ * This keeps production unaffected — the MCP server in production serves its own
+ * static files and the URL returned by the tool is already absolute/resolvable.
  */
 export function proxyChartUrlForFetch(url: string, basePath: string): string {
   const trimmed = url.trim();
@@ -36,8 +41,19 @@ export function proxyChartUrlForFetch(url: string, basePath: string): string {
   } else {
     pathPart = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
   }
+
+  // In development: rewrite /static/... → /api/mcp-static/... so Next.js proxies
+  // the request to the local MCP server instead of returning 404.
+  if (
+    process.env.NODE_ENV === "development" &&
+    pathPart.startsWith("/static/")
+  ) {
+    pathPart = `/api/mcp-static/${pathPart.slice("/static/".length)}`;
+  }
+
   return applyBasePathToChartPath(pathPart, basePath);
 }
+
 
 /**
  * Regexes for detecting chart URLs in assistant text. When `basePath` is set,

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -19,7 +19,7 @@ const nextConfig: NextConfig = {
       // Redirect / and unknown paths to basePath. Exclude known app routes (chat, api, etc.)
       // so that when an external proxy strips the path prefix, /chat/:id and /api/* still work.
       const excludeAppRoutes =
-        "(?!chat/)(?!api/)(?!login)(?!register)(?!maintenance)(?!ping)(?!images/)(?!json/)(?!_next/)";
+        "(?!chat/)(?!review/)(?!api/)(?!login)(?!register)(?!maintenance)(?!ping)(?!images/)(?!json/)(?!_next/)";
       redirects.push(
         { source: "/", destination: basePath, basePath: false, permanent: false },
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "copymainfile": "node copymain.js",
     "postbuild": "node scripts/postbuild.js",
     "clean": "pnpm exec rimraf ./dist/ ./next/ ./.next/",
+    "build:data360": "npm --prefix ../../data360-mcp/packages/tool-types run build && npm --prefix ../../data360-mcp/packages/mcp-ui run build",
+    "copy:data360": "node scripts/copy-data360.js",
     "build:pcn": "pnpm --dir ../../pcn/packages/core build && pnpm --dir ../../pcn/packages/ui build && pnpm --dir ../../pcn/packages/data360 build",
+
     "copy:pcn": "node scripts/copy-pcn.js",
     "unlink:pcn": "pnpm install",
     "update:pcn": "pnpm update @pcn-js/core @pcn-js/ui @pcn-js/data360",

--- a/frontend/scripts/copy-data360.js
+++ b/frontend/scripts/copy-data360.js
@@ -1,0 +1,102 @@
+"use strict";
+
+/**
+ * copy-data360.js
+ *
+ * Builds @data360/mcp-ui and @data360/tool-types from the local data360-mcp
+ * repo and copies their dist/ output into this project's node_modules so that
+ * Turbopack picks up the latest local changes without waiting for an npm publish.
+ *
+ * Mirrors copy-pcn.js. Run via:
+ *   pnpm run copy:data360
+ *
+ * The data360-mcp repo is expected at ../../data360-mcp relative to this
+ * frontend directory (i.e. a sibling of the data-ai-chatbot repo root).
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { execSync } = require("node:child_process");
+
+const frontendDir = path.resolve(__dirname, "..");
+
+// Resolve the data360-mcp packages directory.
+// Inside Docker (dev compose): mounted at /data360-mcp/packages
+// On the host: sibling repo at ../../data360-mcp/packages
+const DOCKER_MOUNT = "/data360-mcp/packages";
+const HOST_SIBLING = path.resolve(frontendDir, "../../data360-mcp/packages");
+const isInsideDocker = fs.existsSync(DOCKER_MOUNT);
+const data360PackagesDir = isInsideDocker ? DOCKER_MOUNT : HOST_SIBLING;
+
+const nodeModulesData360 = path.join(frontendDir, "node_modules", "@data360");
+
+if (isInsideDocker) {
+  console.log("Running inside Docker container — using pre-built packages from mount.");
+  console.log("IMPORTANT: Make sure you have already run 'pnpm run build:data360' on the host.");
+} else {
+  console.log("Running on host — will build packages before copying.");
+}
+
+
+// Packages to build and copy: key = folder name inside packages/, value = npm scope name
+const packages = [
+  { dir: "tool-types", name: "tool-types" },
+  { dir: "mcp-ui", name: "mcp-ui" },
+];
+
+if (!fs.existsSync(data360PackagesDir)) {
+  console.error(
+    `data360-mcp packages directory not found: ${data360PackagesDir}\n` +
+      "Expected the data360-mcp repo to be a sibling directory of data-ai-chatbot."
+  );
+  process.exit(1);
+}
+
+fs.mkdirSync(nodeModulesData360, { recursive: true });
+
+for (const pkg of packages) {
+  const pkgDir = path.join(data360PackagesDir, pkg.dir);
+
+  if (!fs.existsSync(pkgDir)) {
+    console.error(`Package directory not found: ${pkgDir}`);
+    process.exit(1);
+  }
+
+  // Install deps for this package if node_modules is missing
+  const pkgNodeModules = path.join(pkgDir, "node_modules");
+  if (!fs.existsSync(pkgNodeModules)) {
+    console.log(`Installing dependencies for @data360/${pkg.name}...`);
+    execSync("npm install", { cwd: pkgDir, stdio: "inherit" });
+  }
+
+  // Build the package (host only — tsc not available in the frontend Docker image)
+  if (!isInsideDocker) {
+    console.log(`Building @data360/${pkg.name}...`);
+    execSync("npm run build", { cwd: pkgDir, stdio: "inherit" });
+  } else {
+    console.log(`Skipping build for @data360/${pkg.name} (Docker mode — using pre-built dist)`);
+  }
+
+
+  const distDir = path.join(pkgDir, "dist");
+  if (!fs.existsSync(distDir)) {
+    console.error(
+      `Build succeeded but dist/ not found at ${distDir}. Check the package's build output.`
+    );
+    process.exit(1);
+  }
+
+  // Wipe existing install and replace with local build
+  const dest = path.join(nodeModulesData360, pkg.name);
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true });
+  }
+
+  fs.cpSync(pkgDir, dest, { recursive: true });
+  console.log(`Copied @data360/${pkg.name} → node_modules/@data360/${pkg.name}`);
+}
+
+console.log(
+  "\nDone. Turbopack will pick up the new files on the next request.\n" +
+    "If running inside Docker, run: docker compose exec frontend node scripts/copy-data360.js"
+);


### PR DESCRIPTION
## Summary

Rewrites the search indicator UI to use the published `SearchResultCard` component from `@data360/mcp-ui`, supporting all three search modes the MCP server returns.

> **Draft status**: This PR depends on [worldbank/data360-mcp#62](https://github.com/worldbank/data360-mcp/pull/62) being merged and `@data360/mcp-ui` published with the updated version. Once that happens, update the package version in `frontend/package.json` and mark this ready for review.

## What changed

### `frontend/components/data360/search-indicators.tsx`
- Full rewrite consuming `SearchResultCard` from `@data360/mcp-ui`
- Routes to the correct render mode based on `output.result_layout`:
  - `query` — single indicator search
  - `queries` — multi-topic, shared country
  - `by_query` — cross-country groups with accordion per query
- Subtitle format: **Country: Indicator** (e.g. `Philippines: poverty headcount ratio`)
- ISO-3 → full English country name resolution for subtitles and group headers
- Removed `SearchIndicatorsRequestSummary` card from all render paths

### `backend/app/ai/prompts.py`
- Documents all three call patterns for `data360_search_indicators`
- Adds `result_layout=by_query` instruction for cross-country searches
- Adds explicit NEVER rule to prevent mixing `query` and `query_groups`

### Other files
- `frontend/app/layout.tsx`: Load Open Sans via `next/font/google`
- `frontend/app/api/mcp-static/[...path]/route.ts`: Proxy for MCP static Vega specs
- `frontend/lib/chart-url.ts`, `frontend/next.config.ts`: Chart URL utilities
- `frontend/package.json`: Add `@data360/mcp-ui` and `@data360/tool-types`
- `frontend/scripts/copy-data360.js`: Build-time sync script

## Screenshots

**Indicator Search — Philippines: poverty headcount ratio**
Horizontal card rail, green checkmark coverage badges, light-blue bold labels, Disaggregations tag.

**Multi-country Search — United States: inflation rate · Russia: population, GDP per capita**  
Accordion groups by query with country badge and indicator count per group.

## Dependencies

- worldbank/data360-mcp#62 — `SearchResultCard` component source
- worldbank/data360-mcp#57 — multi-query backend (`query_groups`, `result_layout`)