### PR TITLE
feat(mcp): integrate data360_expand_country_group tool into Research Agent

### DIFF
--- a/backend/app/ai/mcp_tools/partitions.py
+++ b/backend/app/ai/mcp_tools/partitions.py
@@ -11,6 +11,7 @@ DATA_TOOL_NAMES: frozenset[str] = frozenset(
         "data360_find_codelist_value",
         "data360_list_indicators",
         "data360_get_data_api_url",
+        "data360_expand_country_group",
     }
 )
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -174,7 +174,7 @@ AVAILABLE TOOLS
    Get methodology, definition, limitations. Use for comparability warnings or
    when the user asks "how is X measured?"
 
-7. data360_find_codelist_value, data360_list_indicators — for advanced lookups.
+7. data360_list_indicators — for advanced catalog lookups when broader indicator discovery is needed.
 
 8. data360_get_data_api_url(database_id, indicator_id, ...) — shareable URL.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -19,6 +19,7 @@ Available tools (injected at runtime by tool_setup.py):
     - data360_get_data             — fetch data with pagination
     - data360_get_disaggregation   — list available filters (years, countries, dims)
     - data360_find_codelist_value  — resolve country/unit codes
+    - data360_expand_country_group — expand region/group to country codes
     - data360_list_indicators      — list all indicator IDs for a database
     - data360_get_data_api_url     — generate an API URL (no fetch)
   MCP — visualization (narrator_node / writer only):
@@ -150,29 +151,32 @@ AVAILABLE TOOLS
    Resolve country/region names → ISO-3 codes. Batch with comma-separated query.
    Use "REF_AREA" as codelist_type.
 
-2. data360_search_indicators(query?, queries?, query_groups?, required_country?, limit?, result_layout?)
+2. data360_expand_country_group(group_code)
+   Expand a region or income group code (e.g., "SAS", "LIC") into individual member country codes.
+
+3. data360_search_indicators(query?, queries?, query_groups?, required_country?, limit?, result_layout?)
    Find indicators. Use `query` for one topic, `queries` for many in one country,
    and `query_groups` for different topics across different countries.
    CRITICAL: If using `query_groups`, you MUST also pass `result_layout="by_query"`.
    Use `required_country` to filter by coverage. Increase limit for broader recall.
 
-3. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
+4. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
    Fetch actual observation values.
    - Always use disaggregation_filters={"REF_AREA": "ISO1,ISO2,..."} for countries.
    - Paginate if has_more=True.
 
-4. data360_get_disaggregation(database_id, indicator_id)
+5. data360_get_disaggregation(database_id, indicator_id)
    Check exact year and country coverage. ONLY call when:
    - User asked for a specific year AND covers_country result was ambiguous/false.
    - NEVER call just to confirm general coverage when covers_country=true.
 
-5. data360_get_metadata(database_id, indicator_id, select_fields?)
+6. data360_get_metadata(database_id, indicator_id, select_fields?)
    Get methodology, definition, limitations. Use for comparability warnings or
    when the user asks "how is X measured?"
 
-6. data360_find_codelist_value, data360_list_indicators — for advanced lookups.
+7. data360_find_codelist_value, data360_list_indicators — for advanced lookups.
 
-7. data360_get_data_api_url(database_id, indicator_id, ...) — shareable URL.
+8. data360_get_data_api_url(database_id, indicator_id, ...) — shareable URL.
 
 ═══════════════════════════════════════════════════════════════════════════════
 DATA RETRIEVAL RULES

--- a/backend/tests/test_mcp_adapter_integration.py
+++ b/backend/tests/test_mcp_adapter_integration.py
@@ -66,5 +66,6 @@ async def test_normalize_interceptor_overrides_args() -> None:
 
 def test_partition_tool_name_sets() -> None:
     assert "data360_get_data" in DATA_TOOL_NAMES
+    assert "data360_expand_country_group" in DATA_TOOL_NAMES
     assert "data360_get_viz_spec" in VIZ_TOOL_NAMES
     assert DATA_TOOL_NAMES.isdisjoint(VIZ_TOOL_NAMES)


### PR DESCRIPTION
## Summary

Exposes the new `data360_expand_country_group` tool (available since data360-mcp v38.0) to the chatbot's Research Agent so the LLM can resolve region/income-group codes into individual country codes before data retrieval.

## Changes

### `backend/app/ai/mcp_tools/partitions.py`
- Added `data360_expand_country_group` to `DATA_TOOL_NAMES`.
  This makes the tool available to the Research Agent node via the shared LangChain MCP adapter bundle.

### `backend/app/ai/prompts.py`
- Added `data360_expand_country_group` to the module-level docstring tool inventory.
- Inserted the tool as item **2** in the Research Agent's `AVAILABLE TOOLS` section with a brief usage description (e.g. expand `"SAS"` or `"LIC"` → member country codes), and renumbered subsequent tools accordingly.

## Motivation

Previously the Research Agent relied on a hard-coded list of regional country codes in the system prompt. With this change it can dynamically call `data360_expand_country_group` to get the authoritative, up-to-date member list for any WB region, income group, or lending category before batching a `data360_get_data` request.

CHAT images
<img width="925" height="581" alt="image" src="https://github.com/user-attachments/assets/c8f0b1b0-16e6-4a61-a0ab-a89b15d5afb4" />

LMIC

https://github.com/user-attachments/assets/f8246d16-a9b3-42a1-bab4-9229cd8e8945



## Testing

- Confirm the tool is loaded at startup: the backend log should show a `[mcp_tools] partitioned` line with `data=N` where N is one higher than before.
- Ask the chat: *"What is GDP per capita across South Asian countries?"* — the agent should call `data360_expand_country_group("SAS")` before the data fetch instead of relying on the static country list.