### PR TITLE
Charts: secure ingest, Vega-Lite title objects, and Data360 source parity

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -83,6 +83,10 @@ NEXTJS_URL=http://localhost:3001
 # Public chat / share-via-link. Default false. Set true with frontend NEXT_PUBLIC_ENABLE_SHARE_CONVERSATION.
 # ENABLE_SHARE_CONVERSATION=true
 
+# Charts API ingestion token (required by POST /api/v1/charts for machine clients).
+# Generate with: openssl rand -hex 32
+# CHARTS_API_WRITE_TOKEN=
+
 # GET /ready: when false, skips all dependency checks (always 200). When true (default), runs MCP probe unless MCP_READINESS_ENABLED=false.
 # READINESS_ENABLED=true
 # MCP_READINESS_ENABLED=true

--- a/backend/app/api/v1/charts.py
+++ b/backend/app/api/v1/charts.py
@@ -1,11 +1,13 @@
+from hmac import compare_digest
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_optional_user
+from app.config import settings
 from app.core.database import get_db
 from app.core.errors import ChatSDKError
 from app.db.queries.chart_queries import get_chart_by_id, save_chart
@@ -17,7 +19,8 @@ router = APIRouter()
 class ChartStoreRequest(BaseModel):
     """Vega-Lite chart spec. Must include 'title' and full spec (stored as-is)."""
 
-    title: str
+    # Vega-Lite supports both string and object forms for title.
+    title: str | dict[str, Any]
 
     # Vega-Lite-ish top-level fields, but flexible
     config: dict[str, Any] | None = None
@@ -33,10 +36,32 @@ class ChartStoreRequest(BaseModel):
         """Full spec as stored in DB (all fields including extra)."""
         return self.model_dump(exclude_none=True)
 
+    def normalized_title(self) -> str:
+        """Return a plain title string for DB/indexing.
+
+        Keeps Vega-Lite title object in the stored spec, while deriving a stable
+        string value for the `Chart.title` column.
+        """
+        if isinstance(self.title, str):
+            title = self.title.strip()
+            return title or "Generated Visualization"
+
+        title_value = self.title.get("text")
+        if isinstance(title_value, str):
+            title = title_value.strip()
+            return title or "Generated Visualization"
+        if isinstance(title_value, list):
+            lines = [part.strip() for part in title_value if isinstance(part, str)]
+            if lines:
+                return " ".join(lines)[:512]
+
+        return "Generated Visualization"
+
 
 @router.post("")
 async def store_chart(
     request: ChartStoreRequest,
+    authorization: str | None = Header(default=None),
     current_user: dict | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -44,11 +69,29 @@ async def store_chart(
     Store a Vega-Lite chart specification.
     The other app can POST the full spec here; title is required, rest is stored as JSON.
     """
+    expected_token = settings.CHARTS_API_WRITE_TOKEN.strip()
+    if not expected_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chart ingestion token is not configured",
+        )
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token",
+        )
+    provided_token = authorization.removeprefix("Bearer ").strip()
+    if not compare_digest(provided_token, expected_token):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid bearer token",
+        )
+
     user_id = get_user_id_uuid(current_user["id"]) if current_user else None
     spec = request.to_spec()
     chart = await save_chart(
         db,
-        title=request.title,
+        title=request.normalized_title()[:512],
         spec=spec,
         user_id=user_id,
     )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -190,6 +190,10 @@ class Settings(BaseSettings):
     # When True, users can set chats to public (share via link). Default False.
     ENABLE_SHARE_CONVERSATION: bool = False
 
+    # Service-to-service auth for POST /api/v1/charts.
+    # Set to a strong random value and send it as `Authorization: Bearer <token>`.
+    CHARTS_API_WRITE_TOKEN: str = ""
+
     # When False, GET /ready returns 200 immediately with readiness_checks=disabled (no MCP probe).
     # Use to bypass readiness for ops without changing MCP_* vars.
     READINESS_ENABLED: bool = True

--- a/backend/app/core/csrf.py
+++ b/backend/app/core/csrf.py
@@ -15,6 +15,11 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _should_skip_csrf(request: Request) -> bool:
+    """Allow service-to-service ingestion endpoint without browser Origin headers."""
+    return request.method == "POST" and request.url.path == "/api/v1/charts"
+
+
 def _get_origin_from_headers(request: Request) -> str | None:
     """
     Extract client origin from request headers, in order of preference:
@@ -142,6 +147,8 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if request.method not in ("POST", "PUT", "DELETE", "PATCH"):
+            return await call_next(request)
+        if _should_skip_csrf(request):
             return await call_next(request)
 
         # Debug: log CSRF validation attempt for state-changing requests

--- a/frontend/components/data360/chart-preview.tsx
+++ b/frontend/components/data360/chart-preview.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import { proxyChartUrlForFetch } from "@/lib/chart-url";
 import { getBasePath } from "@/lib/config";
+import { DATA360_CHART_SOURCE_FALLBACK } from "@/lib/data360/chart-source";
 import { normalizeChartPayloadFromJson } from "@/lib/data360/normalize-chart-payload";
 import type { UIArtifact } from "../artifact";
 import { FullscreenIcon, LoaderIcon } from "../icons";
@@ -18,6 +19,8 @@ export type ChartPreviewProps = {
   messageId?: string;
   /** Shown as the card subtitle (e.g. multi-indicator strategy). */
   subtitle?: string;
+  /** Chart card footer (World Bank attribution). Defaults to generic Data360 line. */
+  source?: string;
 };
 
 const PREVIEW_CHART_HEIGHT = 280;
@@ -27,6 +30,7 @@ export function ChartPreview({
   isReadonly,
   messageId,
   subtitle,
+  source = DATA360_CHART_SOURCE_FALLBACK,
 }: ChartPreviewProps) {
   const { setArtifact } = useArtifact();
   /** Bounds for chart artifact animation (full VegaChartCard including right rail). */
@@ -137,7 +141,7 @@ export function ChartPreview({
         <VegaChartCard
           chartHeight={PREVIEW_CHART_HEIGHT}
           railTopSlot={expandButton}
-          source="World Bank — Data360"
+          source={source}
           spec={chartData.spec as VLSpec}
           subtitle={subtitle}
           title={chartData.title}

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -12,7 +12,10 @@ import { MessageSquare } from "lucide-react";
 import { type Dispatch, memo, type SetStateAction, useState } from "react";
 import { useArtifact } from "@/hooks/use-artifact";
 import type { ProcessingStage } from "@/hooks/use-data-thinking-stream";
-import { buildChartUrlRegexes } from "@/lib/chart-url";
+import {
+  buildChartUrlRegexes,
+  splitAssistantTextIntoChartSegments,
+} from "@/lib/chart-url";
 import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
@@ -73,37 +76,7 @@ import {
 } from "./quoted-context-block";
 import { Weather } from "./weather";
 
-const { bare: CHART_URL_REGEX, markdownLink: CHART_MARKDOWN_LINK_REGEX } =
-  buildChartUrlRegexes();
-
-/** Splits text at the first chart URL (or markdown link with chart URL) so it can be replaced by ChartPreview inline. */
-function splitTextAtChartUrl(text: string): {
-  before: string;
-  chartUrl: string;
-  after: string;
-} | null {
-  // Prefer replacing the entire markdown link [label](chartUrl) so the label is not left visible
-  const mdLinkMatch = text.match(CHART_MARKDOWN_LINK_REGEX);
-  if (mdLinkMatch && mdLinkMatch.index !== undefined) {
-    const start = mdLinkMatch.index;
-    const end = start + mdLinkMatch[0].length;
-    const chartUrl = (mdLinkMatch[1] ?? mdLinkMatch[0]).trim();
-    return {
-      before: text.slice(0, start),
-      chartUrl,
-      after: text.slice(end),
-    };
-  }
-  const match = text.match(CHART_URL_REGEX);
-  if (!match || match.index === undefined) return null;
-  const start = match.index;
-  const end = start + match[0].length;
-  return {
-    before: text.slice(0, start),
-    chartUrl: match[0].trim(),
-    after: text.slice(end),
-  };
-}
+const CHART_URL_REGEXES = buildChartUrlRegexes();
 
 // Helper function to render a single message part
 // This is extracted to be reusable for nested parts in data-thinking
@@ -189,34 +162,48 @@ function renderMessagePart(
                 </Response>
               ) : message.role === "assistant" ? (
                 (() => {
-                  const split = splitTextAtChartUrl(part.text);
-                  if (!split) {
+                  const segments = splitAssistantTextIntoChartSegments(
+                    part.text,
+                    CHART_URL_REGEXES,
+                  );
+                  const hasInlineChart = segments.some((s) => s.kind === "chart");
+                  if (!hasInlineChart) {
                     return <Response>{sanitizeText(part.text)}</Response>;
                   }
-                  const { before, chartUrl, after } = split;
-                  const matchedViz = findVizOutputMatchingChartUrl(
-                    message.parts,
-                    chartUrl,
-                  );
-                  const inlineChartSource = matchedViz
-                    ? formatData360VizChartSource(matchedViz)
-                    : undefined;
                   return (
                     <>
-                      {before.trim().length > 0 ? (
-                        <Response>{sanitizeText(before)}</Response>
-                      ) : null}
-                      <ChartPreview
-                        chartUrl={chartUrl}
-                        isReadonly={isReadonly}
-                        messageId={message.id}
-                        {...(inlineChartSource
-                          ? { source: inlineChartSource }
-                          : {})}
-                      />
-                      {after.trim().length > 0 ? (
-                        <Response>{sanitizeText(after)}</Response>
-                      ) : null}
+                      {segments.map((segment) => {
+                        if (segment.kind === "text") {
+                          if (segment.text.trim().length === 0) {
+                            return null;
+                          }
+                          return (
+                            <Response
+                              key={`${key}-txt-${segment.startOffset}`}
+                            >
+                              {sanitizeText(segment.text)}
+                            </Response>
+                          );
+                        }
+                        const matchedViz = findVizOutputMatchingChartUrl(
+                          message.parts,
+                          segment.chartUrl,
+                        );
+                        const inlineChartSource = matchedViz
+                          ? formatData360VizChartSource(matchedViz)
+                          : undefined;
+                        return (
+                          <ChartPreview
+                            chartUrl={segment.chartUrl}
+                            isReadonly={isReadonly}
+                            key={`${key}-chart-${segment.startOffset}`}
+                            messageId={message.id}
+                            {...(inlineChartSource
+                              ? { source: inlineChartSource }
+                              : {})}
+                          />
+                        );
+                      })}
                     </>
                   );
                 })()

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -16,6 +16,8 @@ import { buildChartUrlRegexes } from "@/lib/chart-url";
 import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
+  findVizOutputMatchingChartUrl,
+  formatData360VizChartSource,
   getData360SourcesFromParts,
   isIndicatorUrl,
 } from "@/lib/data360";
@@ -191,6 +193,13 @@ function renderMessagePart(
                     return <Response>{sanitizeText(part.text)}</Response>;
                   }
                   const { before, chartUrl, after } = split;
+                  const matchedViz = findVizOutputMatchingChartUrl(
+                    message.parts,
+                    chartUrl,
+                  );
+                  const inlineChartSource = matchedViz
+                    ? formatData360VizChartSource(matchedViz)
+                    : undefined;
                   return (
                     <>
                       {before.trim().length > 0 ? (
@@ -200,6 +209,9 @@ function renderMessagePart(
                         chartUrl={chartUrl}
                         isReadonly={isReadonly}
                         messageId={message.id}
+                        {...(inlineChartSource
+                          ? { source: inlineChartSource }
+                          : {})}
                       />
                       {after.trim().length > 0 ? (
                         <Response>{sanitizeText(after)}</Response>
@@ -415,6 +427,7 @@ function renderMessagePart(
                     chartUrl={output.url}
                     isReadonly={isReadonly}
                     messageId={message.id}
+                    source={formatData360VizChartSource(output)}
                     subtitle={vizSubtitle}
                   />
                 }

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -172,7 +172,8 @@ function renderMessagePart(
                 // iMessage-style: soft corners except a tight bottom-right (anchor side)
                 "w-fit break-words rounded-none rounded-br-[4px] rounded-bl-[20px] rounded-tl-[20px] rounded-tr-[20px] max-w-[40rem] px-3 py-3 text-left text-white":
                   message.role === "user",
-                "bg-transparent px-0 py-0 text-left":
+                // Allow Vega-Lite / vega-embed tooltips to extend past the bubble (inline charts).
+                "overflow-visible bg-transparent px-0 py-0 text-left":
                   message.role === "assistant",
               })}
               data-testid="message-content"

--- a/frontend/lib/__tests__/chart-source.test.ts
+++ b/frontend/lib/__tests__/chart-source.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DATA360_CHART_SOURCE_FALLBACK,
+  formatData360VizChartSource,
+} from "../data360/chart-source";
+
+describe("formatData360VizChartSource", () => {
+  it("uses database and indicator names when both present", () => {
+    assert.equal(
+      formatData360VizChartSource({
+        database_name: "World Development Indicators",
+        indicator_name: "GDP growth (annual %)",
+      }),
+      "World Bank — World Development Indicators — GDP growth (annual %)",
+    );
+  });
+
+  it("falls back to ids when names missing", () => {
+    assert.equal(
+      formatData360VizChartSource({
+        database_id: "WB_WDI",
+        indicator_id: "WB_WDI_NY_GDP_MKTP_KD_ZG",
+      }),
+      "World Bank — WB_WDI — WB_WDI_NY_GDP_MKTP_KD_ZG",
+    );
+  });
+
+  it("uses generic fallback when nothing useful", () => {
+    assert.equal(formatData360VizChartSource({}), DATA360_CHART_SOURCE_FALLBACK);
+  });
+});

--- a/frontend/lib/__tests__/chart-url.test.ts
+++ b/frontend/lib/__tests__/chart-url.test.ts
@@ -1,6 +1,68 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { chartUrlsReferToSameChart } from "../chart-url";
+import {
+  chartUrlsReferToSameChart,
+  splitAssistantTextIntoChartSegments,
+} from "../chart-url";
+
+/** Same shape as `buildChartUrlRegexes()` when `basePath` is empty (tests avoid config). */
+const TEST_CHART_REGEXES = (() => {
+  const relativePart = `(?:/api/v1/charts/[^\\s"'<>)\\]]+)`;
+  const bare = new RegExp(
+    `(?:${relativePart}|https?:\\/\\/[^\\s]*/api/v1/charts/[^\\s"'<>)\\]]+)`,
+  );
+  const markdownLink = new RegExp(
+    `\\[[^\\]]*\\]\\s*\\(\\s*(${bare.source})\\s*\\)`,
+  );
+  return { bare, markdownLink };
+})();
+
+describe("splitAssistantTextIntoChartSegments", () => {
+  it("returns a single text segment when there is no chart URL", () => {
+    assert.deepEqual(
+      splitAssistantTextIntoChartSegments("Hello world", TEST_CHART_REGEXES),
+      [{ kind: "text", text: "Hello world", startOffset: 0 }],
+    );
+  });
+
+  it("splits multiple markdown chart links into alternating segments", () => {
+    const u1 = "/api/v1/charts/aaa/spec";
+    const u2 = "/api/v1/charts/bbb/spec";
+    const text = `First [A](${u1}) then [B](${u2}) end.`;
+    const md1 = `[A](${u1})`;
+    const md2 = `[B](${u2})`;
+    const afterMd1 = 6 + md1.length;
+    const chart2Start = afterMd1 + " then ".length;
+    const tailStart = chart2Start + md2.length;
+    assert.deepEqual(splitAssistantTextIntoChartSegments(text, TEST_CHART_REGEXES), [
+      { kind: "text", text: "First ", startOffset: 0 },
+      { kind: "chart", chartUrl: u1, startOffset: 6 },
+      { kind: "text", text: " then ", startOffset: afterMd1 },
+      { kind: "chart", chartUrl: u2, startOffset: chart2Start },
+      { kind: "text", text: " end.", startOffset: tailStart },
+    ]);
+  });
+
+  it("prefers markdown link over bare URL when both start at the same index", () => {
+    const u = "https://host/api/v1/charts/x/spec";
+    const text = `[View](${u})`;
+    assert.deepEqual(splitAssistantTextIntoChartSegments(text, TEST_CHART_REGEXES), [
+      { kind: "chart", chartUrl: u, startOffset: 0 },
+    ]);
+  });
+
+  it("includes a bare chart URL as its own segment", () => {
+    const u = "/api/v1/charts/z/spec";
+    assert.deepEqual(
+      splitAssistantTextIntoChartSegments(`See ${u} here`, TEST_CHART_REGEXES),
+      [
+        { kind: "text", text: "See ", startOffset: 0 },
+        { kind: "chart", chartUrl: u, startOffset: 4 },
+        { kind: "text", text: " here", startOffset: 4 + u.length },
+      ],
+    );
+  });
+});
 
 describe("chartUrlsReferToSameChart", () => {
   it("treats absolute and path-only chart URLs as the same", () => {

--- a/frontend/lib/__tests__/chart-url.test.ts
+++ b/frontend/lib/__tests__/chart-url.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { chartUrlsReferToSameChart } from "../chart-url";
+
+describe("chartUrlsReferToSameChart", () => {
+  it("treats absolute and path-only chart URLs as the same", () => {
+    assert.ok(
+      chartUrlsReferToSameChart(
+        "https://example.com/api/v1/charts/abc/spec",
+        "/api/v1/charts/abc/spec",
+      ),
+    );
+  });
+});

--- a/frontend/lib/chart-url.ts
+++ b/frontend/lib/chart-url.ts
@@ -68,3 +68,83 @@ export function buildChartUrlRegexes(): {
   );
   return { bare, markdownLink };
 }
+
+export type ChartInlineSegment =
+  | { kind: "text"; text: string; startOffset: number }
+  | { kind: "chart"; chartUrl: string; startOffset: number };
+
+/**
+ * Split assistant message text into alternating prose and chart URL segments so each
+ * chart can render as an inline {@link ChartPreview}. Preserves first-match behavior:
+ * when a markdown link and a bare URL start at the same index, the markdown link wins.
+ */
+export function splitAssistantTextIntoChartSegments(
+  text: string,
+  regexes: { bare: RegExp; markdownLink: RegExp } = buildChartUrlRegexes(),
+): ChartInlineSegment[] {
+  const { bare, markdownLink } = regexes;
+  const segments: ChartInlineSegment[] = [];
+  let pos = 0;
+
+  while (pos < text.length) {
+    const remainder = text.slice(pos);
+    const mdMatch = remainder.match(markdownLink);
+    const bareMatch = remainder.match(bare);
+
+    const mdCand =
+      mdMatch && mdMatch.index !== undefined
+        ? {
+            start: mdMatch.index,
+            end: mdMatch.index + mdMatch[0].length,
+            url: (mdMatch[1] ?? mdMatch[0]).trim(),
+          }
+        : null;
+    const bareCand =
+      bareMatch && bareMatch.index !== undefined
+        ? {
+            start: bareMatch.index,
+            end: bareMatch.index + bareMatch[0].length,
+            url: bareMatch[0].trim(),
+          }
+        : null;
+
+    let chosen: { start: number; end: number; url: string } | null = null;
+    if (mdCand && bareCand) {
+      if (mdCand.start < bareCand.start) {
+        chosen = mdCand;
+      } else if (bareCand.start < mdCand.start) {
+        chosen = bareCand;
+      } else {
+        chosen = mdCand;
+      }
+    } else {
+      chosen = mdCand ?? bareCand;
+    }
+
+    if (!chosen) {
+      segments.push({ kind: "text", text: text.slice(pos), startOffset: pos });
+      break;
+    }
+
+    if (chosen.start > 0) {
+      segments.push({
+        kind: "text",
+        text: text.slice(pos, pos + chosen.start),
+        startOffset: pos,
+      });
+    }
+    const chartStart = pos + chosen.start;
+    segments.push({
+      kind: "chart",
+      chartUrl: chosen.url,
+      startOffset: chartStart,
+    });
+    pos = pos + chosen.end;
+  }
+
+  if (segments.length === 0) {
+    return [{ kind: "text", text, startOffset: 0 }];
+  }
+
+  return segments;
+}

--- a/frontend/lib/chart-url.ts
+++ b/frontend/lib/chart-url.ts
@@ -39,6 +39,14 @@ export function proxyChartUrlForFetch(url: string, basePath: string): string {
   return applyBasePathToChartPath(pathPart, basePath);
 }
 
+/** True when two chart URLs refer to the same proxied fetch path (inline vs tool output). */
+export function chartUrlsReferToSameChart(a: string, b: string): boolean {
+  const bp = getBasePath();
+  return (
+    proxyChartUrlForFetch(a.trim(), bp) === proxyChartUrlForFetch(b.trim(), bp)
+  );
+}
+
 /**
  * Regexes for detecting chart URLs in assistant text. When `basePath` is set,
  * matches both `/api/v1/charts/...` and `/basePath/api/v1/charts/...`.

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -102,7 +102,7 @@ function getData360IndicatorBaseUrl(): string {
   );
 }
 
-/** When true, all Data360 MCP tool panels start expanded. When false, only chart + get_data expand by default. */
+/** When true, all Data360 MCP tool panels start expanded. When false, only a small allowlist (e.g. search indicators) expands by default. */
 export function getData360ToolDefaultOpen(): boolean {
   const v =
     process.env.NEXT_PUBLIC_DATA360_TOOL_DEFAULT_OPEN?.trim().toLowerCase();
@@ -262,7 +262,7 @@ export const appConfig = {
 
   /**
    * When true, all Data360 tool panels start expanded.
-   * When false (default), only chart + get_data expand; others stay collapsed.
+   * When false (default), only selected tools expand (e.g. search indicators); charts stay collapsed unless this is true.
    * Set via NEXT_PUBLIC_DATA360_TOOL_DEFAULT_OPEN.
    */
   data360ToolDefaultOpen: getData360ToolDefaultOpen(),

--- a/frontend/lib/data360/chart-inline-attribution.ts
+++ b/frontend/lib/data360/chart-inline-attribution.ts
@@ -1,0 +1,68 @@
+import {
+  isData360VizToolSuccess,
+  parseData360VizToolResult,
+} from "@data360/tool-types";
+
+import { chartUrlsReferToSameChart } from "@/lib/chart-url";
+
+const VIZ_TOOL_TYPES = new Set([
+  "tool-data360_get_viz_spec",
+  "tool-data360_get_multi_indicator_viz_spec",
+]);
+
+/**
+ * Flatten top-level parts plus one level inside `data-thinking` wrappers so viz
+ * tools that ran in the thinking stream are visible for URL matching.
+ */
+function partsForVizAttributionLookup(
+  parts: readonly { type?: string; data?: unknown }[] | undefined,
+): Array<{ type: string; output?: unknown; state?: string }> {
+  const out: Array<{ type: string; output?: unknown; state?: string }> = [];
+  if (!parts) {
+    return out;
+  }
+  for (const p of parts) {
+    if (!p || typeof p !== "object" || typeof p.type !== "string") {
+      continue;
+    }
+    if (p.type.startsWith("data-thinking") && p.data && typeof p.data === "object") {
+      const inner = p.data as { type?: string; output?: unknown; state?: string };
+      if (typeof inner.type === "string") {
+        out.push(inner as { type: string; output?: unknown; state?: string });
+      }
+      continue;
+    }
+    out.push(p as { type: string; output?: unknown; state?: string });
+  }
+  return out;
+}
+
+/**
+ * When the assistant embeds a chart URL in text, find the matching viz tool output
+ * on the same message so the inline chart card can show the same source line as the tool panel.
+ */
+export function findVizOutputMatchingChartUrl(
+  parts: readonly { type?: string; data?: unknown }[] | undefined,
+  chartUrl: string,
+): unknown | null {
+  for (const p of partsForVizAttributionLookup(parts)) {
+    if (!VIZ_TOOL_TYPES.has(p.type)) {
+      continue;
+    }
+    if (p.state !== "output-available") {
+      continue;
+    }
+    const parsed = parseData360VizToolResult(p.output ?? {});
+    if (!parsed.success) {
+      continue;
+    }
+    const data = parsed.data;
+    if (!isData360VizToolSuccess(data)) {
+      continue;
+    }
+    if (chartUrlsReferToSameChart(chartUrl, data.url)) {
+      return data;
+    }
+  }
+  return null;
+}

--- a/frontend/lib/data360/chart-source.ts
+++ b/frontend/lib/data360/chart-source.ts
@@ -1,0 +1,38 @@
+/** Default chart footer when MCP does not return attribution fields. */
+export const DATA360_CHART_SOURCE_FALLBACK = "World Bank — Data360";
+
+function readOptionalString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  if (typeof v !== "string") {
+    return "";
+  }
+  return v.trim();
+}
+
+/**
+ * One-line attribution for Data360 viz tool results (Vega chart card "Source").
+ * Accepts unknown so it stays compatible with `parseData360VizToolResult` output
+ * before optional attribution fields exist on the published `@data360/tool-types`.
+ */
+export function formatData360VizChartSource(result: unknown): string {
+  if (!result || typeof result !== "object") {
+    return DATA360_CHART_SOURCE_FALLBACK;
+  }
+  const r = result as Record<string, unknown>;
+  const db =
+    readOptionalString(r, "database_name") ||
+    readOptionalString(r, "database_id");
+  const ind =
+    readOptionalString(r, "indicator_name") ||
+    readOptionalString(r, "indicator_id");
+  if (db && ind) {
+    return `World Bank — ${db} — ${ind}`;
+  }
+  if (ind) {
+    return `World Bank — ${ind}`;
+  }
+  if (db) {
+    return `World Bank — ${db}`;
+  }
+  return DATA360_CHART_SOURCE_FALLBACK;
+}

--- a/frontend/lib/data360/index.ts
+++ b/frontend/lib/data360/index.ts
@@ -1,3 +1,8 @@
+export { findVizOutputMatchingChartUrl } from "./chart-inline-attribution";
+export {
+  DATA360_CHART_SOURCE_FALLBACK,
+  formatData360VizChartSource,
+} from "./chart-source";
 export {
   type Data360SourceEntry,
   getData360SourcesFromParts,

--- a/frontend/lib/env/schema.ts
+++ b/frontend/lib/env/schema.ts
@@ -192,7 +192,7 @@ const rawEnvSchema = z.object({
     "Base URL for Data360 indicator pages; used to build source links from tool-data360_get_data (no trailing slash required)",
   ),
   NEXT_PUBLIC_DATA360_TOOL_DEFAULT_OPEN: booleanEnv.describe(
-    "When true, all Data360 MCP tool panels start expanded. When false (default), only chart and get_data expand; other tools start collapsed.",
+    "When true, all Data360 MCP tool panels start expanded. When false (default), only selected tools (e.g. search indicators) expand; chart tools start collapsed.",
   ),
   NEXT_PUBLIC_SEARCH_TOKEN_REFRESH_URL: optionalString.describe(
     "Same-origin path or absolute URL for POST search-token refresh (e.g. /wbg/aem/service/refresh-search-token). Used only when NEXT_PUBLIC_AUTH_PROVIDER=data360; empty disables.",

--- a/frontend/lib/tool-display.ts
+++ b/frontend/lib/tool-display.ts
@@ -1,15 +1,13 @@
 import { getData360ToolDefaultOpen } from "@/lib/config";
 
 const DATA360_EXPAND_BY_DEFAULT = new Set([
-  "tool-data360_get_viz_spec",
-  "tool-data360_get_multi_indicator_viz_spec",
   "tool-data360_search_indicators",
   // "tool-data360_get_data",
 ]);
 
 /**
  * When `NEXT_PUBLIC_DATA360_TOOL_DEFAULT_OPEN` is true, all Data360-style tools expand.
- * Otherwise only chart + tabular data tools expand; plumbing tools start collapsed.
+ * Otherwise only selected tools (e.g. search indicators) expand; charts and plumbing start collapsed.
  */
 export function defaultOpenForData360Tool(toolType: string): boolean {
   if (getData360ToolDefaultOpen()) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "@codemirror/state": "^6.5.0",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.35.3",
-    "@data360/mcp-ui": "^0.0.3",
+    "@data360/mcp-ui": "^0.0.4",
     "@data360/tool-types": "^0.0.3",
     "@icons-pack/react-simple-icons": "^13.7.0",
     "@opentelemetry/api": "^1.9.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^6.35.3
         version: 6.36.4
       '@data360/mcp-ui':
-        specifier: ^0.0.3
-        version: 0.0.3(@data360/tool-types@0.0.3)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)
+        specifier: ^0.0.4
+        version: 0.0.4(@data360/tool-types@0.0.3)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)
       '@data360/tool-types':
         specifier: ^0.0.3
         version: 0.0.3
@@ -536,8 +536,8 @@ packages:
   '@codemirror/view@6.36.4':
     resolution: {integrity: sha512-ZQ0V5ovw/miKEXTvjgzRyjnrk9TwriUB1k4R5p7uNnHR9Hus+D1SXHGdJshijEzPFjU25xea/7nhIeSqYFKdbA==}
 
-  '@data360/mcp-ui@0.0.3':
-    resolution: {integrity: sha512-58wT68gejr/7LUJm1tmXBjW+k8JVPKurwb9Uqe2iAnhvcMsPqVmZyQtpvKSLzXQagmHpuaYqJYxiJU3y1VMt7w==}
+  '@data360/mcp-ui@0.0.4':
+    resolution: {integrity: sha512-q4waSm7+gUtH8eu+lEwjtcC48Aql/YNktoAzqqli+xx4Df8MeRHqf832Ru+9Q85RNwsXWYskE2899UCuZlQ2cQ==}
     peerDependencies:
       '@data360/tool-types': '>=0.0.1'
       react: '>=18.0.0'
@@ -545,6 +545,9 @@ packages:
       vega: '>=5.0.0'
       vega-embed: '>=6.0.0'
       vega-lite: '>=5.0.0'
+
+  '@data360/mcp-viz-core@0.0.1':
+    resolution: {integrity: sha512-EXB0maN4LXSVQyuy8kYn12pO+E7+xmWVyxIwnC46EpJE59qH5KAEsXHd/KyJZ9LGHqBpH587Nn7Idx4MoTVy7w==}
 
   '@data360/tool-types@0.0.3':
     resolution: {integrity: sha512-rijot4OP+TL8qzZT4tukX+DHy2dvaKvYFMhWSACkQVqyrJyuF9e/7O6DmVkpYBbKp0D+KEgaBTGn49LixyBW2A==}
@@ -3034,6 +3037,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -4763,14 +4769,18 @@ snapshots:
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
 
-  '@data360/mcp-ui@0.0.3(@data360/tool-types@0.0.3)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)':
+  '@data360/mcp-ui@0.0.4(@data360/tool-types@0.0.3)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)':
     dependencies:
+      '@data360/mcp-viz-core': 0.0.1
       '@data360/tool-types': 0.0.3
+      html-to-image: 1.11.13
       react: 19.0.0-rc-45804af1-20241021
       react-dom: 19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021)
       vega: 5.33.1
       vega-embed: 6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)
       vega-lite: 5.23.0(vega@5.33.1)
+
+  '@data360/mcp-viz-core@0.0.1': {}
 
   '@data360/tool-types@0.0.3':
     dependencies:
@@ -7205,6 +7215,8 @@ snapshots:
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 


### PR DESCRIPTION
**Description:**

This branch updates chart ingestion and the Data360 chart UI so MCP-posted Vega-Lite specs (including WB-style title objects) store cleanly, and the chat shows consistent **Source** lines for tool panels and inline chart URLs.

**Backend**
- **`POST /api/v1/charts`:** Require `Authorization: Bearer …` using `CHARTS_API_WRITE_TOKEN` (constant-time compare). Return 503 when the token is not configured.
- **`ChartStoreRequest`:** Accept Vega-Lite **`title` as `str | dict`**, keep the full spec in JSON, and derive a plain string for the `Chart.title` column via **`normalized_title()`** (string, `{ "text": … }`, or list of text lines).
- **Config / env:** Document `CHARTS_API_WRITE_TOKEN` in settings and `.env.example`.
- **CSRF:** Skip CSRF for **`POST /api/v1/charts`** so server-to-server chart uploads are not blocked by missing browser `Origin` headers.

**Frontend**
- **`ChartPreview`:** Optional **`source`** prop (default generic attribution when unknown).
- **Data360 viz tool panel:** Build source from MCP attribution fields with **`formatData360VizChartSource`**.
- **Inline chart URLs in assistant text:** Match the URL to the same message’s viz tool part (**`findVizOutputMatchingChartUrl`**, including one level under **`data-thinking`**) and reuse the same source string; **`chartUrlsReferToSameChart`** aligns absolute vs app-relative URLs.
- **Tests:** `chart-source` and `chart-url` unit tests.

**How to test**
- Set `CHARTS_API_WRITE_TOKEN`, POST a spec with `title: { "text": "…", "subtitle": "…" }` using the bearer token, confirm 200 and DB title string.
- In the app, open a viz tool chart and the same chart inlined in the reply; **Source** should match when URLs align.