### PR TITLE
feat(ui): hide token usage for non-reviewer users

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -401,6 +401,17 @@ async def get_optional_user(
         return None
 
 
+def get_reviewer_emails() -> set[str]:
+    """
+    Parse FEEDBACK_REVIEWER_EMAILS into a lower-cased set of email addresses.
+
+    Centralised here so that both require_feedback_reviewer (access control) and
+    /api/auth/me (canViewTokenUsage flag) use identical parsing logic.
+    """
+    raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
 async def require_feedback_reviewer(
     current_user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -409,8 +420,7 @@ async def require_feedback_reviewer(
     Require authenticated user whose email is in FEEDBACK_REVIEWER_EMAILS.
     Use for feedback review/list endpoints. Raises 403 if not allowed.
     """
-    allowed_raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
-    allowed = [e.strip().lower() for e in allowed_raw.split(",") if e.strip()]
+    allowed = get_reviewer_emails()
     if not allowed:
         logger.warning("require_feedback_reviewer: FEEDBACK_REVIEWER_EMAILS is empty")
         raise HTTPException(

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, EmailStr, field_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user
+from app.api.deps import get_current_user, get_reviewer_emails
 from app.config import settings
 from app.core.auth import (
     create_access_token,
@@ -638,11 +638,11 @@ async def get_current_user_info(
         response_data["name"] = user.name
 
     # Determine if this user can view token usage in the UI.
-    # Mirrors the FEEDBACK_REVIEWER_EMAILS allowlist used by require_feedback_reviewer.
-    allowed_raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
-    allowed_emails = {e.strip().lower() for e in allowed_raw.split(",") if e.strip()}
+    # Uses the shared helper that mirrors the FEEDBACK_REVIEWER_EMAILS allowlist
+    # used by require_feedback_reviewer in deps.py.
+    reviewer_emails = get_reviewer_emails()
     response_data["canViewTokenUsage"] = bool(
-        user.email and user.email.strip().lower() in allowed_emails
+        user.email and user.email.strip().lower() in reviewer_emails
     )
 
     # If this was a user restoration (guest or regular), issue new JWT token

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -637,6 +637,14 @@ async def get_current_user_info(
     if hasattr(user, "name") and user.name:
         response_data["name"] = user.name
 
+    # Determine if this user can view token usage in the UI.
+    # Mirrors the FEEDBACK_REVIEWER_EMAILS allowlist used by require_feedback_reviewer.
+    allowed_raw = getattr(settings, "FEEDBACK_REVIEWER_EMAILS", "") or ""
+    allowed_emails = {e.strip().lower() for e in allowed_raw.split(",") if e.strip()}
+    response_data["canViewTokenUsage"] = bool(
+        user.email and user.email.strip().lower() in allowed_emails
+    )
+
     # If this was a user restoration (guest or regular), issue new JWT token
     is_restoration = current_user.get("_restore_guest") or current_user.get("_restore_user")
     # Use type from database (already set in response_data above)

--- a/backend/tests/test_can_view_token_usage.py
+++ b/backend/tests/test_can_view_token_usage.py
@@ -1,0 +1,148 @@
+"""
+Unit tests for the canViewTokenUsage field on GET /api/auth/me.
+
+These tests exercise the logic that determines whether a given user's email
+is in the FEEDBACK_REVIEWER_EMAILS allowlist. They mock the DB user lookup
+and settings to avoid requiring a live database.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.v1.auth import get_current_user_info
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(email: str, name: str | None = None) -> MagicMock:
+    """Return a minimal mock user object."""
+    user = MagicMock()
+    user.id = "00000000-0000-0000-0000-000000000001"
+    user.email = email
+    user.type = "regular"
+    user.name = name
+    return user
+
+
+def _make_request() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_can_view_token_usage_is_true_for_reviewer():
+    """User in FEEDBACK_REVIEWER_EMAILS gets canViewTokenUsage=True."""
+    user = _make_user("reviewer@example.com")
+    reviewer_emails = "reviewer@example.com,other@example.com"
+
+    with (
+        patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
+        patch("app.api.v1.auth.settings") as mock_settings,
+    ):
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
+        current_user = {"id": str(user.id), "type": "regular"}
+
+        result = await get_current_user_info(
+            http_request=_make_request(),
+            current_user=current_user,
+            db=AsyncMock(),
+        )
+
+    # result may be a JSONResponse or dict depending on restoration flag
+    data = result if isinstance(result, dict) else result.body
+    if not isinstance(result, dict):
+        import json
+
+        data = json.loads(data)
+
+    assert data["canViewTokenUsage"] is True
+
+
+@pytest.mark.asyncio
+async def test_can_view_token_usage_is_false_for_non_reviewer():
+    """User NOT in FEEDBACK_REVIEWER_EMAILS gets canViewTokenUsage=False."""
+    user = _make_user("regular@example.com")
+    reviewer_emails = "reviewer@example.com"
+
+    with (
+        patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
+        patch("app.api.v1.auth.settings") as mock_settings,
+    ):
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
+        current_user = {"id": str(user.id), "type": "regular"}
+
+        result = await get_current_user_info(
+            http_request=_make_request(),
+            current_user=current_user,
+            db=AsyncMock(),
+        )
+
+    data = result if isinstance(result, dict) else result.body
+    if not isinstance(result, dict):
+        import json
+
+        data = json.loads(data)
+
+    assert data["canViewTokenUsage"] is False
+
+
+@pytest.mark.asyncio
+async def test_can_view_token_usage_is_false_when_list_empty():
+    """When FEEDBACK_REVIEWER_EMAILS is empty, all users get canViewTokenUsage=False."""
+    user = _make_user("anyone@example.com")
+
+    with (
+        patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
+        patch("app.api.v1.auth.settings") as mock_settings,
+    ):
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = ""
+        current_user = {"id": str(user.id), "type": "regular"}
+
+        result = await get_current_user_info(
+            http_request=_make_request(),
+            current_user=current_user,
+            db=AsyncMock(),
+        )
+
+    data = result if isinstance(result, dict) else result.body
+    if not isinstance(result, dict):
+        import json
+
+        data = json.loads(data)
+
+    assert data["canViewTokenUsage"] is False
+
+
+@pytest.mark.asyncio
+async def test_can_view_token_usage_is_case_insensitive():
+    """Email comparison is case-insensitive."""
+    user = _make_user("Reviewer@Example.COM")
+    reviewer_emails = "reviewer@example.com"
+
+    with (
+        patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
+        patch("app.api.v1.auth.settings") as mock_settings,
+    ):
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
+        current_user = {"id": str(user.id), "type": "regular"}
+
+        result = await get_current_user_info(
+            http_request=_make_request(),
+            current_user=current_user,
+            db=AsyncMock(),
+        )
+
+    data = result if isinstance(result, dict) else result.body
+    if not isinstance(result, dict):
+        import json
+
+        data = json.loads(data)
+
+    assert data["canViewTokenUsage"] is True

--- a/backend/tests/test_can_view_token_usage.py
+++ b/backend/tests/test_can_view_token_usage.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the canViewTokenUsage field on GET /api/auth/me.
+Unit tests for the canViewTokenUsage field on GET /api/auth/me
+and the shared get_reviewer_emails() helper in deps.py.
 
 These tests exercise the logic that determines whether a given user's email
 is in the FEEDBACK_REVIEWER_EMAILS allowlist. They mock the DB user lookup
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.api.deps import get_reviewer_emails
 from app.api.v1.auth import get_current_user_info
 
 # ---------------------------------------------------------------------------
@@ -32,7 +34,36 @@ def _make_request() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Tests for get_reviewer_emails() helper
+# ---------------------------------------------------------------------------
+
+
+def test_get_reviewer_emails_parses_comma_separated():
+    with patch("app.api.deps.settings") as mock_settings:
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = "a@example.com, B@example.com , c@example.com"
+        result = get_reviewer_emails()
+    assert result == {"a@example.com", "b@example.com", "c@example.com"}
+
+
+def test_get_reviewer_emails_returns_empty_set_when_blank():
+    with patch("app.api.deps.settings") as mock_settings:
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = ""
+        result = get_reviewer_emails()
+    assert result == set()
+
+
+def test_get_reviewer_emails_handles_none():
+    with patch("app.api.deps.settings") as mock_settings:
+        mock_settings.FEEDBACK_REVIEWER_EMAILS = None
+        result = get_reviewer_emails()
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for canViewTokenUsage field on /api/auth/me
+#
+# NOTE: patch target is app.api.deps.settings because get_reviewer_emails()
+# now reads settings from that module (not from auth.py).
 # ---------------------------------------------------------------------------
 
 
@@ -44,7 +75,7 @@ async def test_can_view_token_usage_is_true_for_reviewer():
 
     with (
         patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
-        patch("app.api.v1.auth.settings") as mock_settings,
+        patch("app.api.deps.settings") as mock_settings,
     ):
         mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
         current_user = {"id": str(user.id), "type": "regular"}
@@ -73,7 +104,7 @@ async def test_can_view_token_usage_is_false_for_non_reviewer():
 
     with (
         patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
-        patch("app.api.v1.auth.settings") as mock_settings,
+        patch("app.api.deps.settings") as mock_settings,
     ):
         mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
         current_user = {"id": str(user.id), "type": "regular"}
@@ -100,7 +131,7 @@ async def test_can_view_token_usage_is_false_when_list_empty():
 
     with (
         patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
-        patch("app.api.v1.auth.settings") as mock_settings,
+        patch("app.api.deps.settings") as mock_settings,
     ):
         mock_settings.FEEDBACK_REVIEWER_EMAILS = ""
         current_user = {"id": str(user.id), "type": "regular"}
@@ -128,7 +159,7 @@ async def test_can_view_token_usage_is_case_insensitive():
 
     with (
         patch("app.api.v1.auth.get_user_by_id", new=AsyncMock(return_value=user)),
-        patch("app.api.v1.auth.settings") as mock_settings,
+        patch("app.api.deps.settings") as mock_settings,
     ):
         mock_settings.FEEDBACK_REVIEWER_EMAILS = reviewer_emails
         current_user = {"id": str(user.id), "type": "regular"}

--- a/frontend/app/(chat)/layout.tsx
+++ b/frontend/app/(chat)/layout.tsx
@@ -9,6 +9,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { authProvider } from "@/lib/auth/config";
 import { getCurrentUser } from "@/lib/auth-service";
 import type { User } from "@/lib/auth-service-client";
+import { TokenUsageVisibilityProvider } from "@/contexts/token-usage-visibility";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -53,10 +54,17 @@ async function SidebarWrapper({ children }: { children: React.ReactNode }) {
   // The sidebar will show "Login to your account" for guest users
   const currentUser: User | null = user;
 
+  // Derive canViewTokenUsage from the server-resolved user.
+  // For MSAL/data360 providers where user is null at server time, we default to false
+  // (token usage stays hidden until the user is fully resolved via /api/auth/me on the client).
+  const canViewTokenUsage = currentUser?.canViewTokenUsage ?? false;
+
   return (
     <SidebarProvider defaultOpen={!isCollapsed}>
-      <AppSidebar user={currentUser ?? undefined} />
-      <SidebarInset>{children}</SidebarInset>
+      <TokenUsageVisibilityProvider canViewTokenUsage={canViewTokenUsage}>
+        <AppSidebar user={currentUser ?? undefined} />
+        <SidebarInset>{children}</SidebarInset>
+      </TokenUsageVisibilityProvider>
     </SidebarProvider>
   );
 }

--- a/frontend/components/message-actions.tsx
+++ b/frontend/components/message-actions.tsx
@@ -11,6 +11,7 @@ import { Action, Actions } from "./elements/actions";
 import { CopyIcon, FeedbackIcon, PencilEditIcon, ThumbDownIcon, ThumbUpIcon } from "./icons";
 import { MessageFeedback } from "./message-feedback";
 import { MessageTokenUsage } from "./message-token-usage";
+import { useCanViewTokenUsage } from "@/contexts/token-usage-visibility";
 
 export function PureMessageActions({
   chatId,
@@ -31,6 +32,7 @@ export function PureMessageActions({
   const { mutate } = useSWRConfig();
   const [_, copyToClipboard] = useCopyToClipboard();
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+  const canViewTokenUsage = useCanViewTokenUsage();
 
   if (isLoading) {
     return null;
@@ -277,7 +279,7 @@ export function PureMessageActions({
           </div>
         </Action>
 
-        {usageData && (
+        {canViewTokenUsage && usageData && (
           <MessageTokenUsage usage={usageData} />
         )}
       </Actions>

--- a/frontend/components/multimodal-input.tsx
+++ b/frontend/components/multimodal-input.tsx
@@ -28,6 +28,7 @@ import { appConfig, getBasePath } from "@/lib/config";
 import type { Attachment, ChatMessage } from "@/lib/types";
 import type { AppUsage } from "@/lib/usage";
 import { cn } from "@/lib/utils";
+import { useCanViewTokenUsage } from "@/contexts/token-usage-visibility";
 import { Context } from "./elements/context";
 import {
   PromptInput,
@@ -302,11 +303,13 @@ const PureMultimodalInput = forwardRef<
     [],
   );
 
+  const canViewTokenUsage = useCanViewTokenUsage();
+
   const contextProps = useMemo(
     () => ({
-      usage,
+      usage: canViewTokenUsage ? usage : undefined,
     }),
-    [usage],
+    [usage, canViewTokenUsage],
   );
 
   const handleFileChange = useCallback(

--- a/frontend/components/multimodal-input.tsx
+++ b/frontend/components/multimodal-input.tsx
@@ -14,7 +14,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -305,12 +304,6 @@ const PureMultimodalInput = forwardRef<
 
   const canViewTokenUsage = useCanViewTokenUsage();
 
-  const contextProps = useMemo(
-    () => ({
-      usage: canViewTokenUsage ? usage : undefined,
-    }),
-    [usage, canViewTokenUsage],
-  );
 
   const handleFileChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -512,7 +505,7 @@ const PureMultimodalInput = forwardRef<
             rows={1}
             value={input}
           />{" "}
-          <Context {...contextProps} />
+          {canViewTokenUsage && <Context usage={usage} />}
         </div>
         <PromptInputToolbar className="!border-top-0 border-t-0! p-0 shadow-none dark:border-0 dark:border-transparent!">
           <PromptInputTools className="gap-0 sm:gap-0.5">

--- a/frontend/contexts/token-usage-visibility.tsx
+++ b/frontend/contexts/token-usage-visibility.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { getAuthTokenFromDocument } from "@/lib/auth/cookies";
 
 /**
  * Context that carries the resolved canViewTokenUsage flag for the current user.
@@ -26,15 +33,28 @@ export function TokenUsageVisibilityProvider({
       return;
     }
     let cancelled = false;
-    fetch("/api/auth/me", { credentials: "include", cache: "no-store" })
+    const authToken = getAuthTokenFromDocument();
+    const headers = new Headers();
+    if (authToken) {
+      headers.set("Authorization", `Bearer ${authToken}`);
+    }
+    fetch("/api/auth/me", {
+      credentials: "include",
+      cache: "no-store",
+      headers,
+    })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (!cancelled && data?.canViewTokenUsage) {
           setCanView(true);
         }
       })
-      .catch(() => {
+      .catch((error) => {
         // Network error or unauthenticated — keep false.
+        console.error(
+          "Error fetching token usage visibility:",
+          error instanceof Error ? error.message : String(error),
+        );
       });
     return () => {
       cancelled = true;

--- a/frontend/contexts/token-usage-visibility.tsx
+++ b/frontend/contexts/token-usage-visibility.tsx
@@ -1,23 +1,48 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 
 /**
  * Context that carries the resolved canViewTokenUsage flag for the current user.
- * Defaults to false so that token usage is hidden until the user is resolved and
- * confirmed to be in the FEEDBACK_REVIEWER_EMAILS allowlist.
+ * Defaults to false so that token usage is hidden until confirmed.
  */
 const TokenUsageVisibilityContext = createContext<boolean>(false);
 
 export function TokenUsageVisibilityProvider({
-  canViewTokenUsage,
+  canViewTokenUsage: initialCanView,
   children,
 }: {
   canViewTokenUsage: boolean;
   children: ReactNode;
 }) {
+  const [canView, setCanView] = useState(initialCanView);
+
+  // For MSAL/data360 providers the server cannot resolve the user, so
+  // initialCanView is always false. We self-fetch /api/auth/me on the client
+  // after hydration to get the real canViewTokenUsage value.
+  useEffect(() => {
+    if (initialCanView) {
+      // Already resolved server-side (guest/user auth); nothing to do.
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/auth/me", { credentials: "include", cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.canViewTokenUsage) {
+          setCanView(true);
+        }
+      })
+      .catch(() => {
+        // Network error or unauthenticated — keep false.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [initialCanView]);
+
   return (
-    <TokenUsageVisibilityContext.Provider value={canViewTokenUsage}>
+    <TokenUsageVisibilityContext.Provider value={canView}>
       {children}
     </TokenUsageVisibilityContext.Provider>
   );

--- a/frontend/contexts/token-usage-visibility.tsx
+++ b/frontend/contexts/token-usage-visibility.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * Context that carries the resolved canViewTokenUsage flag for the current user.
+ * Defaults to false so that token usage is hidden until the user is resolved and
+ * confirmed to be in the FEEDBACK_REVIEWER_EMAILS allowlist.
+ */
+const TokenUsageVisibilityContext = createContext<boolean>(false);
+
+export function TokenUsageVisibilityProvider({
+  canViewTokenUsage,
+  children,
+}: {
+  canViewTokenUsage: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <TokenUsageVisibilityContext.Provider value={canViewTokenUsage}>
+      {children}
+    </TokenUsageVisibilityContext.Provider>
+  );
+}
+
+/** Returns true only when the current user is in the FEEDBACK_REVIEWER_EMAILS allowlist. */
+export function useCanViewTokenUsage(): boolean {
+  return useContext(TokenUsageVisibilityContext);
+}

--- a/frontend/lib/auth-service-client.ts
+++ b/frontend/lib/auth-service-client.ts
@@ -25,6 +25,8 @@ export type User = {
   type: UserType;
   /** Display name (e.g. from MSAL/Azure AD). Present when backend returns it. */
   name?: string | null;
+  /** Whether this user can view token usage in the UI. Derived from FEEDBACK_REVIEWER_EMAILS on the backend. */
+  canViewTokenUsage?: boolean;
 };
 
 /**


### PR DESCRIPTION
Closes #115

### Description
This PR implements the hiding of token usage information in the UI for non-reviewer users, ensuring data collection continues unaffected on the backend.

- Added `canViewTokenUsage` boolean field to `GET /api/auth/me` response. It is set to `true` only when the user's email is present in the existing `FEEDBACK_REVIEWER_EMAILS` environment variable.
- Extended the frontend `User` type with an optional `canViewTokenUsage` field.
- Implemented `TokenUsageVisibilityContext` and wrapped the chat layout to conditionally gate visibility.
- Gated the `<MessageTokenUsage>` dropdown in `message-actions.tsx`.
- Gated the context window usage arc in `multimodal-input.tsx`.

### Testing
- Log in as a user listed in `FEEDBACK_REVIEWER_EMAILS` -> Token usage is visible.
- Log in as a guest or unlisted user -> Token usage is hidden.

logged in reviewer
<img width="1348" height="786" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/09e95fdb-1727-4d16-bb30-385f45db9658" />


logged in non-reviewer
<img width="1348" height="786" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/318cfd1d-8f2e-4026-a20f-adef7703823b" />


guest
<img width="1348" height="786" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/7345381b-b051-4687-8884-1fae0bbbd0b3" />
