### PR TITLE
feat: integrate data360-mcp aggregation tools

### DIFF
--- a/backend/app/ai/mcp_tools/partitions.py
+++ b/backend/app/ai/mcp_tools/partitions.py
@@ -12,6 +12,9 @@ DATA_TOOL_NAMES: frozenset[str] = frozenset(
         "data360_list_indicators",
         "data360_get_data_api_url",
         "data360_expand_country_group",
+        "data360_summarize_data",
+        "data360_rank_countries",
+        "data360_compare_countries",
     }
 )
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -165,9 +165,9 @@ AVAILABLE TOOLS
 
 4. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
    Fetch actual observation values. Use ONLY for single points or small country sets.
-   - For trend summaries (any size), use tool 9 instead.
-   - For ranking a large country group, use tool 10 instead.
-   - For comparing 2–8 specific countries, use tool 11 instead.
+   - For trend summaries (any size), use `data360_summarize_data` instead.
+   - For ranking a large country group, use `data360_rank_countries` instead.
+   - For comparing 2–8 specific countries, use `data360_compare_countries` instead.
    - Always use disaggregation_filters={"REF_AREA": "ISO1,ISO2,..."} for countries.
    - Paginate if has_more=True.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -164,8 +164,10 @@ AVAILABLE TOOLS
    Use `required_country` to filter by coverage. Increase limit for broader recall.
 
 4. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
-   Fetch actual observation values. Use ONLY for single points or small datasets.
-   - For trends, ranking, or comparison of 20+ countries, use tools 9, 10, or 11 instead.
+   Fetch actual observation values. Use ONLY for single points or small country sets.
+   - For trend summaries (any size), use tool 9 instead.
+   - For ranking a large country group, use tool 10 instead.
+   - For comparing 2–8 specific countries, use tool 11 instead.
    - Always use disaggregation_filters={"REF_AREA": "ISO1,ISO2,..."} for countries.
    - Paginate if has_more=True.
 

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -22,6 +22,9 @@ Available tools (injected at runtime by tool_setup.py):
     - data360_expand_country_group — expand region/group to country codes
     - data360_list_indicators      — list all indicator IDs for a database
     - data360_get_data_api_url     — generate an API URL (no fetch)
+    - data360_summarize_data       — get trends and summary statistics
+    - data360_rank_countries       — rank countries for a specific year
+    - data360_compare_countries    — compare multiple countries on an indicator
   MCP — visualization (narrator_node / writer only):
     - data360_get_viz_spec         — generate Vega-Lite chart spec + URL
     - data360_get_multi_indicator_viz_spec — multi-indicator chart
@@ -161,7 +164,8 @@ AVAILABLE TOOLS
    Use `required_country` to filter by coverage. Increase limit for broader recall.
 
 4. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
-   Fetch actual observation values.
+   Fetch actual observation values. Use ONLY for single points or small datasets.
+   - For trends, ranking, or comparison of 20+ countries, use tools 9, 10, or 11 instead.
    - Always use disaggregation_filters={"REF_AREA": "ISO1,ISO2,..."} for countries.
    - Paginate if has_more=True.
 
@@ -177,6 +181,15 @@ AVAILABLE TOOLS
 7. data360_list_indicators — for advanced catalog lookups when broader indicator discovery is needed.
 
 8. data360_get_data_api_url(database_id, indicator_id, ...) — shareable URL.
+
+9. data360_summarize_data(database_id, indicator_id, country_code?, start_year?, end_year?, group_by?)
+   Use for TREND analysis or summary statistics over time/dimensions. Automatically paginates.
+
+10. data360_rank_countries(database_id, indicator_id, country_group?, country_codes?, year?, top_n?)
+    Use for RANKING questions ("Top N"). Automatically expands country_group and paginates.
+
+11. data360_compare_countries(database_id, indicator_id, country_codes, year?, include_time_series?)
+    Use for COMPARISON between 2-8 countries. Handles time series alignment and convergence automatically.
 
 ═══════════════════════════════════════════════════════════════════════════════
 DATA RETRIEVAL RULES

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -15,7 +15,7 @@ engine = create_async_engine(
     future=True,
     pool_pre_ping=True,
     pool_recycle=300,
-    connect_args={"ssl": True},
+    connect_args={"ssl": settings.ENVIRONMENT != "development"},
 )
 
 AsyncSessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/frontend/components/elements/tool.tsx
+++ b/frontend/components/elements/tool.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/collapsible";
 import { getToolDisplayName } from "@/lib/tool-display";
 import { cn } from "@/lib/utils";
-import { CodeBlock } from "./code-block";
+
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
 
@@ -121,7 +121,7 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
   >
     <p className="text-muted-foreground text-xs">Parameters</p>
     <div className="min-w-0 rounded-md bg-muted/40 p-3 overflow-x-auto">
-      <pre className="font-mono text-xs text-foreground whitespace-pre-wrap break-all">
+      <pre className="font-mono text-xs text-foreground whitespace-pre-wrap break-words">
         {JSON.stringify(input, null, 2)}
       </pre>
     </div>

--- a/frontend/components/elements/tool.tsx
+++ b/frontend/components/elements/tool.tsx
@@ -120,8 +120,10 @@ export const ToolInput = ({ className, input, ...props }: ToolInputProps) => (
     {...props}
   >
     <p className="text-muted-foreground text-xs">Parameters</p>
-    <div className="min-w-0 rounded-md bg-muted/40">
-      <CodeBlock code={JSON.stringify(input, null, 2)} language="json" />
+    <div className="min-w-0 rounded-md bg-muted/40 p-3 overflow-x-auto">
+      <pre className="font-mono text-xs text-foreground whitespace-pre-wrap break-all">
+        {JSON.stringify(input, null, 2)}
+      </pre>
     </div>
   </div>
 );

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -706,7 +706,10 @@ function renderMessagePart(
       if (typeof output === "string") {
         outputNode = <div className="whitespace-pre-wrap">{output}</div>;
       } else {
-        const jsonOutput = JSON.stringify(output, null, 2);
+        let jsonOutput = JSON.stringify(output, null, 2);
+        if (jsonOutput.length > 5000) {
+          jsonOutput = jsonOutput.slice(0, 5000) + "\n\n... (truncated for display. Full output processed by agent)";
+        }
         outputNode = <CodeBlock code={jsonOutput} language="json" />;
       }
     }

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -78,6 +78,10 @@ import { Weather } from "./weather";
 
 const CHART_URL_REGEXES = buildChartUrlRegexes();
 
+// Maximum characters of generic JSON tool output to render in the UI.
+// Prevents react-syntax-highlighter from blocking the main thread on large payloads.
+const MAX_GENERIC_OUTPUT_CHARS = 5000;
+
 // Helper function to render a single message part
 // This is extracted to be reusable for nested parts in data-thinking
 function renderMessagePart(
@@ -707,8 +711,12 @@ function renderMessagePart(
         outputNode = <div className="whitespace-pre-wrap">{output}</div>;
       } else {
         let jsonOutput = JSON.stringify(output, null, 2);
-        if (jsonOutput.length > 5000) {
-          jsonOutput = jsonOutput.slice(0, 5000) + "\n\n... (truncated for display. Full output processed by agent)";
+        if (jsonOutput.length > MAX_GENERIC_OUTPUT_CHARS) {
+          // Snap to the last newline within the limit so we don't split mid-token.
+          const cutAt = jsonOutput.lastIndexOf("\n", MAX_GENERIC_OUTPUT_CHARS);
+          jsonOutput =
+            jsonOutput.slice(0, cutAt > 0 ? cutAt : MAX_GENERIC_OUTPUT_CHARS) +
+            "\n\n... (truncated for display. Full output processed by agent)";
         }
         outputNode = <CodeBlock code={jsonOutput} language="json" />;
       }

--- a/frontend/lib/tool-display.ts
+++ b/frontend/lib/tool-display.ts
@@ -28,6 +28,9 @@ const TOOL_DISPLAY_LABELS: Record<string, string> = {
   "tool-data360_get_disaggregation": "Get disaggregation",
   "tool-data360_get_supported_chart_types": "Chart types",
   "tool-data360_analyze_development_topic": "Analyze topic",
+  "tool-data360_summarize_data": "Summarize data",
+  "tool-data360_rank_countries": "Rank countries",
+  "tool-data360_compare_countries": "Compare countries",
   "tool-ai4data_ai4data_mcpget_wdi_data": "WDI data",
   "tool-ai4data_ai4data_mcpsearch_relevant_indicators":
     "Search relevant indicators",


### PR DESCRIPTION
## Summary

Integrates the server-side data aggregation tools introduced in [worldbank/data360-mcp#75](https://github.com/worldbank/data360-mcp/pull/75) into the chatbot.

## Changes

**Agent tool configuration**
- Adds `data360_summarize_data`, `data360_rank_countries`, and `data360_compare_countries` to the LLM agent's tool partition (`DATA_TOOL_NAMES`).
- Updates system prompts to guide the agent on when to use these tools for trend analysis, country ranking, and multi-country comparisons over large country groups.
- Maps human-readable display names for each tool so they render cleanly in the chat interface.

**UI rendering**
- Replaces heavy `<CodeBlock>` (Prism syntax highlighter) with a lightweight `<pre>` tag for streaming tool inputs, preventing main-thread blocking when the agent generates long parameter strings (e.g. 48-country `REF_AREA` lists).
- Truncates generic JSON tool outputs to 5,000 characters in the generic fallback renderer to avoid browser hangs on large raw responses.

## Related

- data360-mcp upstream PR: https://github.com/worldbank/data360-mcp/pull/75