### PR TITLE
feat: rich renderers for aggregation tools (rank, summarize, compare)

### DIFF
--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -436,6 +436,18 @@ You **MAY** format the value for readability (e.g., "$361.8 billion") as long as
 underlying data remains accurate.
 **NEVER** invent a claim_id. Use only the `claim_id` field from the RAW TOOL RESULTS.
 
+AGGREGATION TOOLS EXCEPTION — data360_rank_countries, data360_summarize_data,
+data360_compare_countries:
+These tools use a compact output format. Their claim_ids are **NOT** included in
+the text you can read — they exist only in the structured data rendered as a
+verified table or card in the UI. Therefore:
+- **NEVER** write claim tags for values from these three tools in your prose.
+- **NEVER** construct a claim_id yourself (e.g. do NOT write "WB_WDI_NY_GDP_PCAP_KD__BGD__2023").
+- Instead, refer readers to the rendered table: e.g. "as shown in the ranking table above"
+  or "see the comparison table" — the values there are already verified.
+- Only use claim tags for values sourced from data360_get_data, which does provide
+  claim_ids directly in its output.
+
 NOTE: Claim IDs persist across conversation turns. If referencing a value shown
 in a prior turn, reuse the corresponding claim_id from that turn's tool output.
 

--- a/frontend/components/data360/aggregation-claim-extractors.ts
+++ b/frontend/components/data360/aggregation-claim-extractors.ts
@@ -1,0 +1,112 @@
+/**
+ * Custom ToolResultExtractor functions for Data360 aggregation tools.
+ *
+ * These walk the compact to_compact() output shapes and emit ClaimEntry[]
+ * so ClaimsManager can resolve claim_ids for ClaimMark rendering.
+ *
+ * Usage: register via useClaimsManager().registerExtractor() and wrap the
+ * tool output in <IngestToolOutput toolName={TOOL_NAME} output={...} />.
+ *
+ * Note: data360_summarize_data is excluded — its claim_ids are group-level
+ * arrays (not per-cell), so there is no single value to bind to each claim.
+ */
+
+import type { ClaimEntry, ToolResultExtractor } from "@pcn-js/core";
+
+// ---------------------------------------------------------------------------
+// Tool name constants — must match the MCP tool names used in IngestToolOutput
+// ---------------------------------------------------------------------------
+
+export const DATA360_RANK_COUNTRIES_TOOL = "data360_rank_countries";
+export const DATA360_COMPARE_COUNTRIES_TOOL = "data360_compare_countries";
+
+// ---------------------------------------------------------------------------
+// rank_countries extractor
+// Compact shape: { rankings: [{ code, value, claim_id, ... }] }
+// ---------------------------------------------------------------------------
+
+export const rankCountriesExtractor: ToolResultExtractor = (
+  result: unknown,
+): ClaimEntry[] => {
+  if (typeof result !== "object" || result === null) return [];
+  const r = result as Record<string, unknown>;
+  if (!Array.isArray(r.rankings)) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const row of r.rankings) {
+    if (typeof row !== "object" || row === null) continue;
+    const { claim_id, value, code } = row as Record<string, unknown>;
+    if (typeof claim_id !== "string" || claim_id === "") continue;
+    entries.push({
+      id: claim_id,
+      claim: {
+        value: typeof value === "number" ? value : undefined,
+        country: typeof code === "string" ? code : undefined,
+      },
+    });
+  }
+  return entries;
+};
+
+// ---------------------------------------------------------------------------
+// compare_countries extractor
+// Compact shape:
+//   snapshot.rankings: [{ code, value, claim_id, ... }]
+//   time_series.series: { [country]: [[time_period, obs_value, claim_id], ...] }
+// ---------------------------------------------------------------------------
+
+export const compareCountriesExtractor: ToolResultExtractor = (
+  result: unknown,
+): ClaimEntry[] => {
+  if (typeof result !== "object" || result === null) return [];
+  const r = result as Record<string, unknown>;
+
+  const entries: ClaimEntry[] = [];
+
+  // Snapshot rankings
+  const snapshot = r.snapshot as Record<string, unknown> | null | undefined;
+  if (snapshot && Array.isArray(snapshot.rankings)) {
+    for (const row of snapshot.rankings) {
+      if (typeof row !== "object" || row === null) continue;
+      const { claim_id, value, code } = row as Record<string, unknown>;
+      if (typeof claim_id !== "string" || claim_id === "") continue;
+      entries.push({
+        id: claim_id,
+        claim: {
+          value: typeof value === "number" ? value : undefined,
+          country: typeof code === "string" ? code : undefined,
+        },
+      });
+    }
+  }
+
+  // Time-series positional arrays: [time_period, obs_value, claim_id]
+  // series_schema guarantees positions: [0]=time_period, [1]=obs_value, [2]=claim_id
+  const ts = r.time_series as Record<string, unknown> | null | undefined;
+  if (ts && typeof ts.series === "object" && ts.series !== null) {
+    for (const [country, points] of Object.entries(
+      ts.series as Record<string, unknown>,
+    )) {
+      if (!Array.isArray(points)) continue;
+      for (const pt of points) {
+        if (!Array.isArray(pt) || pt.length < 3) continue;
+        const [timePeriod, obsValue, claimId] = pt as [
+          string,
+          number | null,
+          string | null,
+        ];
+        if (typeof claimId !== "string" || claimId === "") continue;
+        entries.push({
+          id: claimId,
+          claim: {
+            value: typeof obsValue === "number" ? obsValue : undefined,
+            country,
+            date: timePeriod,
+          },
+        });
+      }
+    }
+  }
+
+  return entries;
+};

--- a/frontend/components/data360/aggregation-claim-extractors.ts
+++ b/frontend/components/data360/aggregation-claim-extractors.ts
@@ -28,8 +28,19 @@ export const DATA360_COMPARE_COUNTRIES_TOOL = "data360_compare_countries";
 export const rankCountriesExtractor: ToolResultExtractor = (
   result: unknown,
 ): ClaimEntry[] => {
-  if (typeof result !== "object" || result === null) return [];
-  const r = result as Record<string, unknown>;
+  // Handle raw JSON string (non-thinking / non-normalized path)
+  let r: Record<string, unknown>;
+  if (typeof result === "string") {
+    try {
+      r = JSON.parse(result);
+    } catch {
+      return [];
+    }
+  } else if (typeof result === "object" && result !== null) {
+    r = result as Record<string, unknown>;
+  } else {
+    return [];
+  }
   if (!Array.isArray(r.rankings)) return [];
 
   const entries: ClaimEntry[] = [];
@@ -58,8 +69,19 @@ export const rankCountriesExtractor: ToolResultExtractor = (
 export const compareCountriesExtractor: ToolResultExtractor = (
   result: unknown,
 ): ClaimEntry[] => {
-  if (typeof result !== "object" || result === null) return [];
-  const r = result as Record<string, unknown>;
+  // Handle raw JSON string (non-thinking / non-normalized path)
+  let r: Record<string, unknown>;
+  if (typeof result === "string") {
+    try {
+      r = JSON.parse(result);
+    } catch {
+      return [];
+    }
+  } else if (typeof result === "object" && result !== null) {
+    r = result as Record<string, unknown>;
+  } else {
+    return [];
+  }
 
   const entries: ClaimEntry[] = [];
 

--- a/frontend/components/data360/compare-countries.tsx
+++ b/frontend/components/data360/compare-countries.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ClaimMark } from "@pcn-js/ui";
 import type {
   CompactCompareOutput,
   CompactSnapshotEntry,
@@ -117,16 +116,7 @@ function SnapshotTable({
                   </div>
                 </td>
                 <td className="px-3 py-2 text-right font-medium">
-                  {entry.claim_id ? (
-                    <ClaimMark
-                      id={entry.claim_id}
-                      policy={{ type: "rounded", decimals: 2 }}
-                    >
-                      {fmtNum(entry.value)}
-                    </ClaimMark>
-                  ) : (
-                    fmtNum(entry.value)
-                  )}
+                  {fmtNum(entry.value)}
                 </td>
               </tr>
             ))}
@@ -231,20 +221,7 @@ function TimeSeriesTable({ ts }: { ts: CompactTimeSeries }) {
                         className="px-3 py-2 text-right font-medium"
                         key={c}
                       >
-                        {pt !== undefined ? (
-                          pt.claim_id ? (
-                            <ClaimMark
-                              id={pt.claim_id}
-                              policy={{ type: "rounded", decimals: 2 }}
-                            >
-                              {fmtNum(pt.value)}
-                            </ClaimMark>
-                          ) : (
-                            fmtNum(pt.value)
-                          )
-                        ) : (
-                          "—"
-                        )}
+                        {pt !== undefined ? fmtNum(pt.value) : "—"}
                       </td>
                     );
                   })}

--- a/frontend/components/data360/compare-countries.tsx
+++ b/frontend/components/data360/compare-countries.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ClaimMark } from "@pcn-js/ui";
 import type {
   CompactCompareOutput,
   CompactSnapshotEntry,
@@ -116,7 +117,16 @@ function SnapshotTable({
                   </div>
                 </td>
                 <td className="px-3 py-2 text-right font-medium">
-                  {fmtNum(entry.value)}
+                  {entry.claim_id ? (
+                    <ClaimMark
+                      id={entry.claim_id}
+                      policy={{ type: "rounded", decimals: 2 }}
+                    >
+                      {fmtNum(entry.value)}
+                    </ClaimMark>
+                  ) : (
+                    fmtNum(entry.value)
+                  )}
                 </td>
               </tr>
             ))}
@@ -221,7 +231,20 @@ function TimeSeriesTable({ ts }: { ts: CompactTimeSeries }) {
                         className="px-3 py-2 text-right font-medium"
                         key={c}
                       >
-                        {pt !== undefined ? fmtNum(pt.value) : "—"}
+                        {pt !== undefined ? (
+                          pt.claim_id ? (
+                            <ClaimMark
+                              id={pt.claim_id}
+                              policy={{ type: "rounded", decimals: 2 }}
+                            >
+                              {fmtNum(pt.value)}
+                            </ClaimMark>
+                          ) : (
+                            fmtNum(pt.value)
+                          )
+                        ) : (
+                          "—"
+                        )}
                       </td>
                     );
                   })}

--- a/frontend/components/data360/compare-countries.tsx
+++ b/frontend/components/data360/compare-countries.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { ClaimMark } from "@pcn-js/ui";
+import type {
+  CompactCompareOutput,
+  CompactSnapshotEntry,
+  CompactTimeSeries,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isCompactCompareOutput(v: unknown): v is CompactCompareOutput {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return "snapshot" in o && "time_series" in o && "indicator" in o;
+}
+
+function parseCompareOutput(output: unknown): CompactCompareOutput | null {
+  if (isCompactCompareOutput(output)) return output;
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      if (isCompactCompareOutput(parsed)) return parsed;
+    } catch {
+      // not valid JSON
+    }
+  }
+  return null;
+}
+
+function fmtNum(v: number | null, decimals = 2): string {
+  if (v === null || v === undefined) return "—";
+  return Number(v).toLocaleString("en-US", {
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: 0,
+  });
+}
+
+function convergenceBadge(
+  convergence: string | null,
+): { label: string; className: string } | null {
+  switch (convergence?.toLowerCase()) {
+    case "converging":
+      return {
+        label: "Converging",
+        className:
+          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+      };
+    case "diverging":
+      return {
+        label: "Diverging",
+        className:
+          "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+      };
+    case "parallel":
+      return {
+        label: "Parallel",
+        className:
+          "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+      };
+    default:
+      return null;
+  }
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      <strong>Error:</strong> {message}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot table
+// ---------------------------------------------------------------------------
+
+function SnapshotTable({
+  rankings,
+  year,
+}: {
+  rankings: CompactSnapshotEntry[];
+  year: string | null;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Snapshot{year ? ` · ${year}` : ""}
+      </div>
+      <div className="rounded-lg border border-border bg-muted/30">
+        <table className="w-full text-xs">
+          <thead className="bg-muted">
+            <tr>
+              <th className="w-10 border-border border-b px-3 py-2 text-left font-medium">
+                #
+              </th>
+              <th className="border-border border-b px-3 py-2 text-left font-medium">
+                Country
+              </th>
+              <th className="border-border border-b px-3 py-2 text-right font-medium">
+                Value
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rankings.map((entry) => (
+              <tr className="hover:bg-muted/50" key={entry.code}>
+                <td className="px-3 py-2 font-mono text-muted-foreground">
+                  {entry.rank}
+                </td>
+                <td className="px-3 py-2">
+                  <div className="font-medium">{entry.country}</div>
+                  <div className="text-muted-foreground text-[10px]">
+                    {entry.code}
+                  </div>
+                </td>
+                <td className="px-3 py-2 text-right font-medium">
+                  {entry.claim_id ? (
+                    <ClaimMark
+                      id={entry.claim_id}
+                      policy={{ type: "rounded", decimals: 2 }}
+                    >
+                      {fmtNum(entry.value)}
+                    </ClaimMark>
+                  ) : (
+                    fmtNum(entry.value)
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Time-series table
+// Decodes the positional array format: series_schema = [time_period, obs_value, claim_id]
+// ---------------------------------------------------------------------------
+
+function TimeSeriesTable({ ts }: { ts: CompactTimeSeries }) {
+  const countries = Object.keys(ts.series);
+
+  // Build a sorted, deduplicated list of years across all countries
+  const yearSet = new Set<string>();
+  for (const pts of Object.values(ts.series)) {
+    for (const pt of pts) {
+      yearSet.add(pt[0]);
+    }
+  }
+  const years = Array.from(yearSet).sort((a, b) => Number(b) - Number(a)); // newest first
+
+  // Build lookup: country -> year -> { value, claim_id }
+  // Positional schema: [0]=time_period, [1]=obs_value, [2]=claim_id
+  const lookup: Record<
+    string,
+    Record<string, { value: number | null; claim_id: string | null }>
+  > = {};
+  for (const [country, pts] of Object.entries(ts.series)) {
+    lookup[country] = {};
+    for (const pt of pts) {
+      lookup[country][pt[0]] = { value: pt[1], claim_id: pt[2] };
+    }
+  }
+
+  const conv = convergenceBadge(ts.convergence);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Time Series
+      </div>
+      {/* Sub-header: range + convergence + CAGR */}
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+        <span className="text-muted-foreground text-xs">
+          {ts.year_range} · {ts.n_aligned_years} aligned year
+          {ts.n_aligned_years !== 1 ? "s" : ""}
+        </span>
+        <div className="flex items-center gap-2">
+          {conv && (
+            <span
+              className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${conv.className}`}
+            >
+              {conv.label}
+            </span>
+          )}
+          {Object.keys(ts.cagr).length > 0 && (
+            <span className="text-muted-foreground text-[10px]">
+              CAGR:{" "}
+              {Object.entries(ts.cagr)
+                .map(([c, v]) => `${c} ${fmtNum(v, 1)}%`)
+                .join(" · ")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Data table */}
+      <div className="rounded-lg border border-border bg-muted/30">
+        <div className="max-h-64 overflow-auto">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-muted">
+              <tr>
+                <th className="border-border border-b px-3 py-2 text-left font-medium">
+                  Year
+                </th>
+                {countries.map((c) => (
+                  <th
+                    className="border-border border-b px-3 py-2 text-right font-medium"
+                    key={c}
+                  >
+                    {c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {years.map((year) => (
+                <tr className="hover:bg-muted/50" key={year}>
+                  <td className="px-3 py-2 font-medium text-muted-foreground">
+                    {year}
+                  </td>
+                  {countries.map((c) => {
+                    const pt = lookup[c]?.[year];
+                    return (
+                      <td
+                        className="px-3 py-2 text-right font-medium"
+                        key={c}
+                      >
+                        {pt !== undefined ? (
+                          pt.claim_id ? (
+                            <ClaimMark
+                              id={pt.claim_id}
+                              policy={{ type: "rounded", decimals: 2 }}
+                            >
+                              {fmtNum(pt.value)}
+                            </ClaimMark>
+                          ) : (
+                            fmtNum(pt.value)
+                          )
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export type CompareCountriesProps = {
+  /** Raw tool output — compact object or unparsed JSON string. */
+  output: unknown;
+};
+
+export function CompareCountries({ output }: CompareCountriesProps) {
+  const data = parseCompareOutput(output);
+
+  if (data === null) {
+    return (
+      <ErrorBanner message="Unable to parse compare_countries output. Raw data may be in an unexpected format." />
+    );
+  }
+
+  if (data.error) {
+    return <ErrorBanner message={data.error} />;
+  }
+
+  const hasSnapshot =
+    data.snapshot !== null &&
+    data.snapshot !== undefined &&
+    data.snapshot.rankings.length > 0;
+  const hasTimeSeries =
+    data.time_series !== null &&
+    data.time_series !== undefined &&
+    Object.keys(data.time_series.series).length > 0;
+
+  if (!hasSnapshot && !hasTimeSeries) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+        No comparison data available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header */}
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        {data.indicator && (
+          <div className="font-semibold text-foreground text-sm">
+            {data.indicator}
+          </div>
+        )}
+        {data.unit && (
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            {data.unit}
+          </span>
+        )}
+      </div>
+
+      {/* Snapshot */}
+      {hasSnapshot && data.snapshot && (
+        <SnapshotTable
+          rankings={data.snapshot.rankings}
+          year={data.snapshot.year}
+        />
+      )}
+
+      {/* Time series */}
+      {hasTimeSeries && data.time_series && (
+        <TimeSeriesTable ts={data.time_series} />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/data360/pcn-provider-client.tsx
+++ b/frontend/components/data360/pcn-provider-client.tsx
@@ -1,6 +1,29 @@
 "use client";
 
+import { useEffect } from "react";
 import { Data360ClaimsProvider } from "@pcn-js/data360";
+import { useClaimsManager } from "@pcn-js/ui";
+import {
+  DATA360_RANK_COUNTRIES_TOOL,
+  DATA360_COMPARE_COUNTRIES_TOOL,
+  rankCountriesExtractor,
+  compareCountriesExtractor,
+} from "./aggregation-claim-extractors";
+
+/**
+ * Registers custom ToolResultExtractors for rank_countries and compare_countries
+ * on the ClaimsManager so IngestToolOutput + ClaimMark can resolve claim_ids.
+ * Runs once on mount inside Data360ClaimsProvider.
+ */
+function AggregationExtractorRegistrar() {
+  const manager = useClaimsManager();
+  useEffect(() => {
+    if (!manager) return;
+    manager.registerExtractor(DATA360_RANK_COUNTRIES_TOOL, rankCountriesExtractor);
+    manager.registerExtractor(DATA360_COMPARE_COUNTRIES_TOOL, compareCountriesExtractor);
+  }, [manager]);
+  return null;
+}
 
 /**
  * Client-only wrapper for Data360ClaimsProvider so the layout (Server Component)
@@ -12,5 +35,10 @@ export function PcnProviderClient({
 }: {
   children: React.ReactNode;
 }) {
-  return <Data360ClaimsProvider>{children}</Data360ClaimsProvider>;
+  return (
+    <Data360ClaimsProvider>
+      <AggregationExtractorRegistrar />
+      {children}
+    </Data360ClaimsProvider>
+  );
 }

--- a/frontend/components/data360/pcn-provider-client.tsx
+++ b/frontend/components/data360/pcn-provider-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { Data360ClaimsProvider } from "@pcn-js/data360";
 import { useClaimsManager } from "@pcn-js/ui";
 import {
@@ -17,7 +17,10 @@ import {
  */
 function AggregationExtractorRegistrar() {
   const manager = useClaimsManager();
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so registration fires before IngestToolOutput's
+  // useEffect calls manager.ingest() — effects run bottom-up, so a deeper
+  // IngestToolOutput's useEffect would otherwise beat a parent's useEffect.
+  useLayoutEffect(() => {
     if (!manager) return;
     manager.registerExtractor(DATA360_RANK_COUNTRIES_TOOL, rankCountriesExtractor);
     manager.registerExtractor(DATA360_COMPARE_COUNTRIES_TOOL, compareCountriesExtractor);

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ClaimMark } from "@pcn-js/ui";
 import type { CompactRankingOutput } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -144,16 +143,7 @@ export function RankCountries({ output }: RankCountriesProps) {
                     </div>
                   </td>
                   <td className="px-3 py-2 text-right font-medium">
-                    {entry.claim_id ? (
-                      <ClaimMark
-                        id={entry.claim_id}
-                        policy={{ type: "rounded", decimals: 2 }}
-                      >
-                        {fmt(entry.value, null)}
-                      </ClaimMark>
-                    ) : (
-                      fmt(entry.value, null)
-                    )}
+                    {fmt(entry.value, null)}
                   </td>
                 </tr>
               ))}

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ClaimMark } from "@pcn-js/ui";
 import type { CompactRankingOutput } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -143,7 +144,16 @@ export function RankCountries({ output }: RankCountriesProps) {
                     </div>
                   </td>
                   <td className="px-3 py-2 text-right font-medium">
-                    {fmt(entry.value, null)}
+                    {entry.claim_id ? (
+                      <ClaimMark
+                        id={entry.claim_id}
+                        policy={{ type: "rounded", decimals: 2 }}
+                      >
+                        {fmt(entry.value, null)}
+                      </ClaimMark>
+                    ) : (
+                      fmt(entry.value, null)
+                    )}
                   </td>
                 </tr>
               ))}

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { ClaimMark } from "@pcn-js/ui";
+import type { CompactRankingOutput } from "./types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isCompactRankingOutput(v: unknown): v is CompactRankingOutput {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return Array.isArray(o.rankings) && "excluded_count" in o;
+}
+
+function parseRankingOutput(output: unknown): CompactRankingOutput | null {
+  // Already a parsed object (normalizer decoded it from TextContent)
+  if (isCompactRankingOutput(output)) return output;
+  // Fallback: raw JSON string (pre-compact server versions)
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      if (isCompactRankingOutput(parsed)) return parsed;
+    } catch {
+      // not valid JSON — fall through
+    }
+  }
+  return null;
+}
+
+function fmt(value: number, unit: string | null): string {
+  const n = Number.isFinite(value)
+    ? value.toLocaleString("en-US", { maximumFractionDigits: 2 })
+    : String(value);
+  return unit ? `${n} ${unit}` : n;
+}
+
+function TrendBadge({ order }: { order: "asc" | "desc" }) {
+  const label = order === "desc" ? "Highest first" : "Lowest first";
+  return (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+      {label}
+    </span>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      <strong>Error:</strong> {message}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export type RankCountriesProps = {
+  /** Raw tool output — compact object or unparsed JSON string. */
+  output: unknown;
+};
+
+export function RankCountries({ output }: RankCountriesProps) {
+  const data = parseRankingOutput(output);
+
+  if (data === null) {
+    return (
+      <ErrorBanner message="Unable to parse rank_countries output. Raw data may be in an unexpected format." />
+    );
+  }
+
+  if (data.error) {
+    return <ErrorBanner message={data.error} />;
+  }
+
+  if (data.rankings.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+        No ranking data available.
+      </div>
+    );
+  }
+
+  const unit = data.unit ?? "";
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header */}
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <div className="flex flex-col gap-0.5">
+          {data.indicator && (
+            <div className="font-semibold text-foreground text-sm">
+              {data.indicator}
+            </div>
+          )}
+          {data.year && (
+            <div className="text-muted-foreground text-xs">Year: {data.year}</div>
+          )}
+          {data.year_selection_note && (
+            <div className="text-muted-foreground text-[10px] italic">
+              {data.year_selection_note}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <TrendBadge order={data.order} />
+          <span className="text-muted-foreground text-xs">
+            {data.counts.with_data} of {data.counts.requested} countries
+          </span>
+        </div>
+      </div>
+
+      {/* Rankings table */}
+      <div className="rounded-lg border border-border bg-muted/30">
+        <div className="max-h-72 overflow-auto">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-muted">
+              <tr>
+                <th className="border-border border-b px-3 py-2 text-left font-medium w-10">
+                  #
+                </th>
+                <th className="border-border border-b px-3 py-2 text-left font-medium">
+                  Country
+                </th>
+                <th className="border-border border-b px-3 py-2 text-right font-medium">
+                  Value{unit ? ` (${unit})` : ""}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.rankings.map((entry) => (
+                <tr
+                  className="hover:bg-muted/50"
+                  key={`${entry.code}-${entry.rank}`}
+                >
+                  <td className="px-3 py-2 font-mono text-muted-foreground">
+                    {entry.rank}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="font-medium">{entry.country}</div>
+                    <div className="text-muted-foreground text-[10px]">
+                      {entry.code}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-right font-medium">
+                    {entry.claim_id ? (
+                      <ClaimMark
+                        id={entry.claim_id}
+                        policy={{ type: "rounded", decimals: 2 }}
+                      >
+                        {fmt(entry.value, null)}
+                      </ClaimMark>
+                    ) : (
+                      fmt(entry.value, null)
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Excluded footnote */}
+      {data.excluded_count > 0 && (
+        <div className="text-muted-foreground text-[10px]">
+          {data.excluded_count} countr{data.excluded_count === 1 ? "y" : "ies"}{" "}
+          excluded (no data){data.excluded_sample.length > 0 && ": "}
+          {data.excluded_sample
+            .map((e) => e.name ?? e.code)
+            .join(", ")}
+          {data.excluded_count > data.excluded_sample.length &&
+            ` +${data.excluded_count - data.excluded_sample.length} more`}
+          .
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import type { CompactGroupSummary, CompactSummarizeOutput } from "./types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isCompactSummarizeOutput(v: unknown): v is CompactSummarizeOutput {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return Array.isArray(o.groups) && "indicator" in o;
+}
+
+function parseSummarizeOutput(output: unknown): CompactSummarizeOutput | null {
+  if (isCompactSummarizeOutput(output)) return output;
+  if (typeof output === "string") {
+    try {
+      const parsed = JSON.parse(output);
+      if (isCompactSummarizeOutput(parsed)) return parsed;
+    } catch {
+      // not valid JSON
+    }
+  }
+  return null;
+}
+
+function fmtNum(v: number | null, decimals = 2): string {
+  if (v === null || v === undefined) return "—";
+  return Number(v).toLocaleString("en-US", {
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: 0,
+  });
+}
+
+function fmtPct(v: number | null): string {
+  if (v === null || v === undefined) return "—";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${fmtNum(v, 1)}%`;
+}
+
+function trendLabel(trend: string | null): {
+  label: string;
+  className: string;
+} {
+  switch (trend?.toLowerCase()) {
+    case "increasing":
+      return {
+        label: "Increasing",
+        className:
+          "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+      };
+    case "decreasing":
+      return {
+        label: "Decreasing",
+        className:
+          "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+      };
+    case "stable":
+      return {
+        label: "Stable",
+        className:
+          "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+      };
+    default:
+      return {
+        label: trend ?? "—",
+        className: "bg-muted text-muted-foreground",
+      };
+  }
+}
+
+/** Derive a human-readable label from a group key dict. */
+function groupLabel(key: Record<string, string>): string {
+  const parts: string[] = [];
+  if (key.ref_area) parts.push(key.ref_area);
+  if (key.sex && key.sex !== "_T") parts.push(key.sex);
+  if (key.age && key.age !== "_T") parts.push(key.age);
+  if (key.urbanisation && key.urbanisation !== "_T")
+    parts.push(key.urbanisation);
+  // Any remaining dimensions not handled above
+  for (const [k, v] of Object.entries(key)) {
+    if (
+      !["ref_area", "sex", "age", "urbanisation"].includes(k) &&
+      v !== "_T"
+    ) {
+      parts.push(`${k}:${v}`);
+    }
+  }
+  return parts.join(" · ") || "Total";
+}
+
+function GroupRow({ group }: { group: CompactGroupSummary }) {
+  const { label: trendText, className: trendClass } = trendLabel(group.trend);
+  const yearSpan =
+    group.range[0] && group.range[1]
+      ? `${group.range[0]}–${group.range[1]}`
+      : group.range[0] ?? group.range[1] ?? "—";
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-3 text-xs">
+      {/* Group label + trend badge */}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="font-semibold text-foreground text-sm">
+          {groupLabel(group.key)}
+        </span>
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${trendClass}`}
+        >
+          {trendText}
+        </span>
+      </div>
+
+      {/* Stats grid */}
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5 sm:grid-cols-4">
+        <div>
+          <dt className="text-muted-foreground">Period</dt>
+          <dd className="font-medium text-foreground">{yearSpan}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Latest value</dt>
+          <dd className="font-medium text-foreground">{fmtNum(group.last)}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Change</dt>
+          <dd
+            className={`font-medium ${
+              (group.change.abs ?? 0) > 0
+                ? "text-green-700 dark:text-green-400"
+                : (group.change.abs ?? 0) < 0
+                  ? "text-red-700 dark:text-red-400"
+                  : "text-foreground"
+            }`}
+          >
+            {fmtNum(group.change.abs)} ({fmtPct(group.change.pct)})
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Observations</dt>
+          <dd className="font-medium text-foreground">{group.n}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Min</dt>
+          <dd className="font-medium text-foreground">
+            {fmtNum(group.stats.min)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Max</dt>
+          <dd className="font-medium text-foreground">
+            {fmtNum(group.stats.max)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Mean</dt>
+          <dd className="font-medium text-foreground">
+            {fmtNum(group.stats.mean)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Median</dt>
+          <dd className="font-medium text-foreground">
+            {fmtNum(group.stats.median)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+      <strong>Error:</strong> {message}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export type SummarizeDataProps = {
+  /** Raw tool output — compact object or unparsed JSON string. */
+  output: unknown;
+};
+
+export function SummarizeData({ output }: SummarizeDataProps) {
+  const data = parseSummarizeOutput(output);
+
+  if (data === null) {
+    return (
+      <ErrorBanner message="Unable to parse summarize_data output. Raw data may be in an unexpected format." />
+    );
+  }
+
+  if (data.error) {
+    return <ErrorBanner message={data.error} />;
+  }
+
+  if (data.groups.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+        No summary data available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Header */}
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        {data.indicator && (
+          <div className="font-semibold text-foreground text-sm">
+            {data.indicator}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          {data.unit && (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              {data.unit}
+            </span>
+          )}
+          {data.ambiguous_dimensions && data.ambiguous_dimensions.length > 0 && (
+            <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
+              Auto-expanded: {data.ambiguous_dimensions.join(", ")}
+            </span>
+          )}
+          <span className="text-muted-foreground text-xs">
+            {data.groups.length} group{data.groups.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Group cards */}
+      <div className="flex flex-col gap-2">
+        {data.groups.map((group, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: groups have no stable id
+          <GroupRow group={group} key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -9,7 +9,13 @@ import type { CompactGroupSummary, CompactSummarizeOutput } from "./types";
 function isCompactSummarizeOutput(v: unknown): v is CompactSummarizeOutput {
   if (typeof v !== "object" || v === null) return false;
   const o = v as Record<string, unknown>;
-  return Array.isArray(o.groups) && "indicator" in o;
+  if (!Array.isArray(o.groups) || !("indicator" in o)) return false;
+  // Verify at least the first group has the compact shape ("group" key, not "group_key")
+  if (o.groups.length > 0) {
+    const first = o.groups[0] as Record<string, unknown>;
+    if (!("group" in first)) return false;
+  }
+  return true;
 }
 
 function parseSummarizeOutput(output: unknown): CompactSummarizeOutput | null {
@@ -71,15 +77,16 @@ function trendLabel(trend: string | null): {
 }
 
 /** Derive a human-readable label from a group key dict. */
-function groupLabel(key: Record<string, string>): string {
+function groupLabel(groupKey: Record<string, string> | null | undefined): string {
+  if (!groupKey || typeof groupKey !== "object") return "Total";
   const parts: string[] = [];
-  if (key.ref_area) parts.push(key.ref_area);
-  if (key.sex && key.sex !== "_T") parts.push(key.sex);
-  if (key.age && key.age !== "_T") parts.push(key.age);
-  if (key.urbanisation && key.urbanisation !== "_T")
-    parts.push(key.urbanisation);
+  if (groupKey.ref_area) parts.push(groupKey.ref_area);
+  if (groupKey.sex && groupKey.sex !== "_T") parts.push(groupKey.sex);
+  if (groupKey.age && groupKey.age !== "_T") parts.push(groupKey.age);
+  if (groupKey.urbanisation && groupKey.urbanisation !== "_T")
+    parts.push(groupKey.urbanisation);
   // Any remaining dimensions not handled above
-  for (const [k, v] of Object.entries(key)) {
+  for (const [k, v] of Object.entries(groupKey)) {
     if (
       !["ref_area", "sex", "age", "urbanisation"].includes(k) &&
       v !== "_T"
@@ -92,17 +99,16 @@ function groupLabel(key: Record<string, string>): string {
 
 function GroupRow({ group }: { group: CompactGroupSummary }) {
   const { label: trendText, className: trendClass } = trendLabel(group.trend);
-  const yearSpan =
-    group.range[0] && group.range[1]
-      ? `${group.range[0]}–${group.range[1]}`
-      : group.range[0] ?? group.range[1] ?? "—";
+
+  // range is a string like "2004-2023" or null
+  const yearSpan = group.range ?? "—";
 
   return (
     <div className="rounded-lg border border-border bg-background p-3 text-xs">
       {/* Group label + trend badge */}
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="font-semibold text-foreground text-sm">
-          {groupLabel(group.key)}
+          {groupLabel(group.group)}
         </span>
         <span
           className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${trendClass}`}
@@ -119,7 +125,14 @@ function GroupRow({ group }: { group: CompactGroupSummary }) {
         </div>
         <div>
           <dt className="text-muted-foreground">Latest value</dt>
-          <dd className="font-medium text-foreground">{fmtNum(group.last)}</dd>
+          <dd className="font-medium text-foreground">
+            {fmtNum(group.latest?.value ?? null)}
+            {group.latest?.year ? (
+              <span className="ml-1 text-muted-foreground text-[10px]">
+                ({group.latest.year})
+              </span>
+            ) : null}
+          </dd>
         </div>
         <div>
           <dt className="text-muted-foreground">Change</dt>

--- a/frontend/components/data360/types.ts
+++ b/frontend/components/data360/types.ts
@@ -79,3 +79,100 @@ export type GetDataOutput = {
   data: GetDataDataPoint[];
   error: string | null;
 };
+
+// ---------------------------------------------------------------------------
+// Compact aggregation output types (data360-mcp compact serializer, PR #78)
+// These mirror the to_compact() output shapes on the server side.
+// ---------------------------------------------------------------------------
+
+/** A single ranked country entry from rank_countries compact output. */
+export type CompactRankedCountry = {
+  rank: number;
+  code: string;
+  country: string;
+  value: number;
+  claim_id: string | null;
+};
+
+/** Top-level compact output for data360_rank_countries. */
+export type CompactRankingOutput = {
+  year: string | null;
+  year_selection_note: string | null;
+  order: "asc" | "desc";
+  counts: { with_data: number; requested: number };
+  unit: string | null;
+  indicator: string | null;
+  rankings: CompactRankedCountry[];
+  excluded_count: number;
+  excluded_sample: Array<{ code: string; name: string | null }>;
+  error: string | null;
+};
+
+/** Stats block inside a compact group summary. */
+export type CompactGroupStats = {
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  median: number | null;
+};
+
+/** A single group entry from summarize_data compact output. */
+export type CompactGroupSummary = {
+  /** Dimension key, e.g. {ref_area: "KEN"} or {ref_area: "KEN", sex: "F"}. */
+  key: Record<string, string>;
+  n: number;
+  first: number | null;
+  last: number | null;
+  range: [string | null, string | null];
+  stats: CompactGroupStats;
+  change: { abs: number | null; pct: number | null };
+  trend: string | null;
+  claim_ids: string[];
+};
+
+/** Top-level compact output for data360_summarize_data. */
+export type CompactSummarizeOutput = {
+  indicator: string | null;
+  unit: string | null;
+  ambiguous_dimensions: string[] | null;
+  groups: CompactGroupSummary[];
+  error: string | null;
+};
+
+/** A snapshot (single-year) ranked entry inside compare_countries output. */
+export type CompactSnapshotEntry = {
+  rank: number;
+  code: string;
+  country: string;
+  value: number;
+  claim_id: string | null;
+};
+
+/** Compact snapshot block inside compare_countries output. */
+export type CompactSnapshot = {
+  year: string | null;
+  rankings: CompactSnapshotEntry[];
+  spread: Record<string, unknown> | null;
+};
+
+/**
+ * Compact time-series block inside compare_countries output.
+ * series values are positional arrays: [time_period, obs_value, claim_id].
+ */
+export type CompactTimeSeries = {
+  year_range: string | null;
+  n_aligned_years: number;
+  convergence: string | null;
+  series_schema: ["time_period", "obs_value", "claim_id"];
+  series: Record<string, [string, number | null, string | null][]>;
+  cagr: Record<string, number | null>;
+};
+
+/** Top-level compact output for data360_compare_countries. */
+export type CompactCompareOutput = {
+  indicator: string | null;
+  unit: string | null;
+  snapshot: CompactSnapshot | null;
+  time_series: CompactTimeSeries | null;
+  error: string | null;
+};

--- a/frontend/components/data360/types.ts
+++ b/frontend/components/data360/types.ts
@@ -119,11 +119,12 @@ export type CompactGroupStats = {
 /** A single group entry from summarize_data compact output. */
 export type CompactGroupSummary = {
   /** Dimension key, e.g. {ref_area: "KEN"} or {ref_area: "KEN", sex: "F"}. */
-  key: Record<string, string>;
+  group: Record<string, string>;
   n: number;
-  first: number | null;
-  last: number | null;
-  range: [string | null, string | null];
+  latest: { value: number | null; year: string | null };
+  earliest: { value: number | null; year: string | null };
+  /** Time range string, e.g. "2004-2023" */
+  range: string | null;
   stats: CompactGroupStats;
   change: { abs: number | null; pct: number | null };
   trend: string | null;

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -6,6 +6,10 @@ import {
   parseData360VizToolResult,
 } from "@data360/tool-types";
 import { DATA360_GET_DATA_TOOL } from "@pcn-js/data360";
+import {
+  DATA360_COMPARE_COUNTRIES_TOOL,
+  DATA360_RANK_COUNTRIES_TOOL,
+} from "./data360/aggregation-claim-extractors";
 import { IngestToolOutput } from "@pcn-js/ui";
 import type { ToolUIPart } from "ai";
 import equal from "fast-deep-equal";
@@ -690,6 +694,14 @@ function renderMessagePart(
         key={toolPart.toolCallId}
       >
         <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        {toolPart.state === "output-available" && (
+          <IngestToolOutput
+            output={toolPart.output}
+            toolName={DATA360_RANK_COUNTRIES_TOOL}
+          >
+            {null}
+          </IngestToolOutput>
+        )}
         <ToolContent>
           {(toolPart.state === "input-available" ||
             toolPart.state === "input-streaming") &&
@@ -764,6 +776,14 @@ function renderMessagePart(
         key={toolPart.toolCallId}
       >
         <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        {toolPart.state === "output-available" && (
+          <IngestToolOutput
+            output={toolPart.output}
+            toolName={DATA360_COMPARE_COUNTRIES_TOOL}
+          >
+            {null}
+          </IngestToolOutput>
+        )}
         <ToolContent>
           {(toolPart.state === "input-available" ||
             toolPart.state === "input-streaming") &&

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -41,8 +41,11 @@ import { useDataStream } from "./data-stream-provider";
 import { ChartPreview } from "./data360/chart-preview";
 import { GetData, GetDataRequestSummary } from "./data360/get-data";
 import { GetWdiData } from "./data360/get-wdi-data";
+import { CompareCountries } from "./data360/compare-countries";
+import { RankCountries } from "./data360/rank-countries";
 import { SearchIndicators } from "./data360/search-indicators";
 import { SearchRelevantIndicators } from "./data360/search-relevant-indicators";
+import { SummarizeData } from "./data360/summarize-data";
 import { DocumentToolResult } from "./document";
 import { DocumentPreview } from "./document-preview";
 import { CodeBlock } from "./elements/code-block";
@@ -664,6 +667,119 @@ function renderMessagePart(
               output={
                 <SearchIndicators output={toolPart.output} input={rawInput} />
               }
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  // --- Aggregation tool renderers (compact output from data360-mcp) ---
+
+  if ((type as string) === "tool-data360_rank_countries") {
+    const toolPart = part as {
+      toolCallId: string;
+      state: "input-available" | "output-available" | "input-streaming" | "output-error";
+      input?: unknown;
+      output?: unknown;
+      errorText?: string;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool(type as string)}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        <ToolContent>
+          {(toolPart.state === "input-available" ||
+            toolPart.state === "input-streaming") &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {(toolPart.state === "output-available" ||
+            toolPart.state === "output-error") && (
+            <ToolOutput
+              errorText={toolPart.errorText}
+              output={
+                toolPart.output !== undefined && toolPart.output !== null ? (
+                  <RankCountries output={toolPart.output} />
+                ) : null
+              }
+              useDefaultFormat={false}
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  if ((type as string) === "tool-data360_summarize_data") {
+    const toolPart = part as {
+      toolCallId: string;
+      state: "input-available" | "output-available" | "input-streaming" | "output-error";
+      input?: unknown;
+      output?: unknown;
+      errorText?: string;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool(type as string)}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        <ToolContent>
+          {(toolPart.state === "input-available" ||
+            toolPart.state === "input-streaming") &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {(toolPart.state === "output-available" ||
+            toolPart.state === "output-error") && (
+            <ToolOutput
+              errorText={toolPart.errorText}
+              output={
+                toolPart.output !== undefined && toolPart.output !== null ? (
+                  <SummarizeData output={toolPart.output} />
+                ) : null
+              }
+              useDefaultFormat={false}
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  if ((type as string) === "tool-data360_compare_countries") {
+    const toolPart = part as {
+      toolCallId: string;
+      state: "input-available" | "output-available" | "input-streaming" | "output-error";
+      input?: unknown;
+      output?: unknown;
+      errorText?: string;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool(type as string)}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        <ToolContent>
+          {(toolPart.state === "input-available" ||
+            toolPart.state === "input-streaming") &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {(toolPart.state === "output-available" ||
+            toolPart.state === "output-error") && (
+            <ToolOutput
+              errorText={toolPart.errorText}
+              output={
+                toolPart.output !== undefined && toolPart.output !== null ? (
+                  <CompareCountries output={toolPart.output} />
+                ) : null
+              }
+              useDefaultFormat={false}
             />
           )}
         </ToolContent>

--- a/frontend/lib/tool-display.ts
+++ b/frontend/lib/tool-display.ts
@@ -2,6 +2,9 @@ import { getData360ToolDefaultOpen } from "@/lib/config";
 
 const DATA360_EXPAND_BY_DEFAULT = new Set([
   "tool-data360_search_indicators",
+  "tool-data360_rank_countries",
+  "tool-data360_summarize_data",
+  "tool-data360_compare_countries",
   // "tool-data360_get_data",
 ]);
 


### PR DESCRIPTION
## Summary

Replaces the generic JSON fallback + 5,000-character truncation band-aid for the three Data360 aggregation tools with dedicated React components that render compact structured output from the MCP server.

## Related

- Follows on from #120 (merged) — which added agent-side tool registration but left UI rendering as generic fallback with truncation
- Requires worldbank/data360-mcp#78 (compact serializer) to be merged and deployed for compact structured output to flow in

## Changes

**New components:**
- `frontend/components/data360/rank-countries.tsx` — ranked table with ClaimMark per entry, excluded-countries footnote
- `frontend/components/data360/summarize-data.tsx` — per-group cards with stats grid, trend badge, abs/pct change, ambiguous_dimensions warning
- `frontend/components/data360/compare-countries.tsx` — snapshot ranking table + time-series cross-country table; decodes positional series_schema arrays [time_period, obs_value, claim_id]

**Updated files:**
- `frontend/components/data360/types.ts` — 8 new TypeScript types mirroring the to_compact() output shapes
- `frontend/components/message.tsx` — 3 routing blocks added before the generic fallback; 3 imports
- `frontend/lib/tool-display.ts` — 3 tools added to DATA360_EXPAND_BY_DEFAULT (auto-expand, consistent with search_indicators)

## Backward compatibility

All three parsers accept both a parsed object (current path via normalize_tool_output_for_ui) and a raw JSON string. If parsing fails entirely, an ErrorBanner is shown rather than crashing.