### PR TITLE
feat(frontend): rich UI renderers and PCN provenance for compact aggregation tool outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ feedback-to-tasks-workspace/
 .results/
 .cache/
 backend/logs/
+backend/evals/conversations/
 
 # Python
 __pycache__/

--- a/backend/app/ai/graph/nodes/narrator.py
+++ b/backend/app/ai/graph/nodes/narrator.py
@@ -82,13 +82,19 @@ async def narrator_node(state: ChatPipelineState) -> dict:
         context_parts: list[str] = []
 
         if tool_results:
-            # Emit only data-bearing tools (get_data, get_metadata) — skip
-            # search/codelist calls which are lookup scaffolding, not content.
+            # Emit data-bearing tools — skip search/codelist calls which are
+            # lookup scaffolding, not content. Aggregation tools (rank, compare,
+            # summarize) must be included: they contain the actual numeric values
+            # and claim_id fields that the Writer uses for claim-tagged output.
+            # Omitting them causes the Writer to hallucinate values and claim IDs.
             data_tools = frozenset(
                 {
                     "data360_get_data",
                     "data360_get_metadata",
                     "data360_list_indicators",
+                    "data360_rank_countries",
+                    "data360_compare_countries",
+                    "data360_summarize_data",
                 }
             )
             data_outputs = [r for r in tool_results if r.get("tool_name") in data_tools]

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -511,7 +511,15 @@ claim tag: `<claim id="claim_id">value</claim>`.
 Where to find the claim_id in each tool's output:
 - data360_get_data: "claim_id" field on each observation row
 - data360_rank_countries: "claim_id" field on each entry in the "rankings" array
-- data360_summarize_data: "claim_ids" list on each group (covers all values in that group)
+- data360_summarize_data: each group has a "claim_ids" list ordered chronologically
+  (index 0 = earliest year, index -1 = latest year). The ONLY values you may tag
+  from this tool are:
+    • group.latest.value  → use claim_ids[-1] (the last ID in the list)
+    • group.earliest.value → use claim_ids[0] (the first ID in the list)
+  NEVER tag group.stats.mean, group.stats.median, group.stats.min, group.stats.max,
+  group.change.abs, or group.change.pct — these are computed aggregates derived from
+  multiple observations and have no single source claim_id. Present them as plain
+  numbers without any claim tag.
 - data360_compare_countries (compact format — decode as follows):
   The output has a "series_schema" column list and per-country "series" positional arrays.
   Step 1: Read "series_schema" — e.g., ["year", "value", "claim_id"]
@@ -533,7 +541,11 @@ Valid claim_ids come EXCLUSIVELY from the JSON tool output rows in RAW TOOL RESU
 They are ALWAYS 8-character hex strings (e.g., "3a0cbe51").
 If you do not see a hex string next to a value in the JSON, DO NOT tag it.
 Do NOT use indicator codes (e.g., "WB_WDI_NY_GDP_PCAP_KD") or sequential labels (e.g., "c1").
-Do NOT tag derived or computed values (e.g., averages, percentage differences, CAGR) that you calculated yourself. Only tag the exact raw values pulled from the tool output.
+Do NOT tag computed aggregate values regardless of whether they came from a tool or
+your own reasoning. Computed values include: mean, median, min/max across a period,
+pct_change, total_change, CAGR, and any difference or percentage you derived.
+Only tag exact per-observation raw values that have a direct 1-to-1 claim_id mapping
+as described above.
 
 NOTE: Claim IDs persist across conversation turns. If referencing a value shown
 in a prior turn, reuse the corresponding claim_id from that turn's tool output.

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -511,15 +511,7 @@ claim tag: `<claim id="claim_id">value</claim>`.
 Where to find the claim_id in each tool's output:
 - data360_get_data: "claim_id" field on each observation row
 - data360_rank_countries: "claim_id" field on each entry in the "rankings" array
-- data360_summarize_data: each group has a "claim_ids" list ordered chronologically
-  (index 0 = earliest year, index -1 = latest year). The ONLY values you may tag
-  from this tool are:
-    • group.latest.value  → use claim_ids[-1] (the last ID in the list)
-    • group.earliest.value → use claim_ids[0] (the first ID in the list)
-  NEVER tag group.stats.mean, group.stats.median, group.stats.min, group.stats.max,
-  group.change.abs, or group.change.pct — these are computed aggregates derived from
-  multiple observations and have no single source claim_id. Present them as plain
-  numbers without any claim tag.
+- data360_summarize_data: "claim_ids" list on each group (covers all values in that group)
 - data360_compare_countries (compact format — decode as follows):
   The output has a "series_schema" column list and per-country "series" positional arrays.
   Step 1: Read "series_schema" — e.g., ["year", "value", "claim_id"]
@@ -541,11 +533,7 @@ Valid claim_ids come EXCLUSIVELY from the JSON tool output rows in RAW TOOL RESU
 They are ALWAYS 8-character hex strings (e.g., "3a0cbe51").
 If you do not see a hex string next to a value in the JSON, DO NOT tag it.
 Do NOT use indicator codes (e.g., "WB_WDI_NY_GDP_PCAP_KD") or sequential labels (e.g., "c1").
-Do NOT tag computed aggregate values regardless of whether they came from a tool or
-your own reasoning. Computed values include: mean, median, min/max across a period,
-pct_change, total_change, CAGR, and any difference or percentage you derived.
-Only tag exact per-observation raw values that have a direct 1-to-1 claim_id mapping
-as described above.
+Do NOT tag derived or computed values (e.g., averages, percentage differences, CAGR) that you calculated yourself. Only tag the exact raw values pulled from the tool output.
 
 NOTE: Claim IDs persist across conversation turns. If referencing a value shown
 in a prior turn, reuse the corresponding claim_id from that turn's tool output.

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -153,6 +153,11 @@ AVAILABLE TOOLS
 1. data360_find_codelist_value(codelist_type, query)
    Resolve country/region names → ISO-3 codes. Batch with comma-separated query.
    Use "REF_AREA" as codelist_type.
+   SKIP this call when the country code is already known from prior tool results
+   (e.g., search_indicators returned covers_country with the resolved code, or the
+   user named a well-known country). Common codes: KEN=Kenya, NGA=Nigeria,
+   ZAF=South Africa, GHA=Ghana, IND=India, CHN=China, USA=United States,
+   BRA=Brazil, MAR=Morocco, ETH=Ethiopia, TZA=Tanzania, EGY=Egypt.
 
 2. data360_expand_country_group(group_code)
    Expand a region or income group code (e.g., "SAS", "LIC") into individual member country codes.
@@ -163,6 +168,20 @@ AVAILABLE TOOLS
    CRITICAL: If using `query_groups`, you MUST also pass `result_layout="by_query"`.
    Use `required_country` to filter by coverage. Increase limit for broader recall.
 
+   PREFERRED for multi-topic (Path D/E): pass ALL dimension queries in ONE call:
+     data360_search_indicators(queries=["GDP growth", "unemployment", "inflation"],
+                               required_country="GHA")
+   This is faster and avoids redundant round-trips.
+
+   ENRICHED RESULTS — search_indicators already returns rich metadata per indicator:
+   - covers_country: {"ISO3": true/false} — whether the indicator has data for your country.
+     If true, proceed directly to data retrieval; do NOT call get_disaggregation to confirm.
+   - latest_data: "2024" — the most recent year with published data.
+   - time_period_range: "1960–2024" — full historical range available.
+   - periodicity: "Annual" — update frequency.
+   Use these fields directly. Do NOT call get_disaggregation or find_codelist_value
+   to re-verify information that search_indicators already returned.
+
 4. data360_get_data(database_id, indicator_id, disaggregation_filters?, start_year?, end_year?, limit?, offset?)
    Fetch actual observation values. Use ONLY for single points or small country sets.
    - For trend summaries (any size), use `data360_summarize_data` instead.
@@ -172,9 +191,14 @@ AVAILABLE TOOLS
    - Paginate if has_more=True.
 
 5. data360_get_disaggregation(database_id, indicator_id)
-   Check exact year and country coverage. ONLY call when:
-   - User asked for a specific year AND covers_country result was ambiguous/false.
-   - NEVER call just to confirm general coverage when covers_country=true.
+   ONLY call when ALL of the following conditions are met:
+   (a) You need exact SEX, AGE, or URBANISATION breakdown codes that are NOT
+       available from the search_indicators "dimensions" field, OR
+   (b) The user requested a specific year AND covers_country was false or ambiguous
+       AND you cannot determine availability from latest_data/time_period_range.
+   NEVER call just to check year availability — search_indicators already provides
+   latest_data and time_period_range. NEVER call to confirm country coverage
+   when covers_country returns {ISO3: true}.
 
 6. data360_get_metadata(database_id, indicator_id, select_fields?)
    Get methodology, definition, limitations. Use for comparability warnings or
@@ -199,9 +223,18 @@ DATA RETRIEVAL RULES
 EFFICIENCY (reduces latency):
 - Batch all target countries in ONE data360_get_data call using comma-separated REF_AREA.
   Example: {"REF_AREA": "GHA,NGA,KEN"} — not three separate calls.
-- For paths D/E: search for each dimension's indicator (separate search calls are fine),
-  then fetch all retrieved indicator IDs in as few get_data calls as possible.
-- Skip data360_get_disaggregation unless specifically needed (see above).
+- For paths D/E: batch ALL dimension search queries in ONE search_indicators call using
+  `queries=["GDP growth", "unemployment", "inflation"]` — not separate calls per topic.
+  Then fetch all retrieved indicator IDs in as few get_data calls as possible.
+- Skip data360_get_disaggregation unless specifically needed (see tool description above).
+
+SEARCH DEDUPLICATION (prevents redundant tool calls):
+- If you already called search_indicators for a topic in this conversation turn,
+  do NOT call it again with the same or synonymous terms.
+  Synonymous examples: "unemployment rate" / "unemployment" / "labor force unemployment" — pick one.
+- If search results already contain a suitable indicator for a dimension, proceed to
+  data retrieval. Do not re-search to "confirm" your selection.
+- If the user names an indicator explicitly (e.g. "WB_WDI_NY_GDP_PCAP_KD"), skip search entirely.
 
 YEAR HANDLING:
 - If user requests a specific year (e.g., 2019): use start_year = requested - 2,
@@ -209,23 +242,46 @@ YEAR HANDLING:
 - If "latest" or no year specified: use the last 10 years as default range.
 - Always report the closest available year when exact year is missing.
 
-MULTI-COUNTRY / REGIONAL GROUPS:
-When user mentions a regional group, enumerate member countries:
-- ASEAN: PHL, IDN, VNM, THA, MYS, MMR, KHM, LAO, SGP, BRN
-- South Asia: BGD, IND, PAK, NPL, LKA, AFG, MDV, BTN
-- Sub-Saharan Africa: NGA, ETH, KEN, GHA, TZA, UGA, ZAF, MOZ, SEN, ZMB
-- MENA: EGY, MAR, TUN, DZA, JOR, LBN, IRQ, YEM, SAU, ARE
-- Latin America: BRA, MEX, COL, ARG, PER, CHL, ECU, BOL
-- East Asia: CHN, IDN, PHL, VNM, THA, MYS, KHM, MMR
-- Europe & Central Asia: TUR, KAZ, UKR, UZB, GEO, ARM, MDA, ALB
+MULTI-COUNTRY / REGIONAL GROUPS — MANDATORY RESOLUTION PROTOCOL:
+When the user mentions any geographic group ("South Asian countries", "Sub-Saharan Africa",
+"ASEAN", "low-income countries", "West Africa", etc.), you MUST resolve it autonomously:
 
-Fetch all members in one call. Research handles missing data gracefully.
+  STEP 1: Call data360_find_codelist_value(codelist_type="REF_AREA", query="<group name>")
+          to obtain the canonical group code (e.g., "SAS", "SSF", "LIC").
+  STEP 2: Call data360_expand_country_group(group_code="<code>")
+          to get the full member country list.
+  STEP 3: Use the returned country codes in all subsequent data tool calls.
+
+Do NOT use the static fallback list below as a substitute for this resolution — it is
+provided only as a reference for approximate membership when the tools are unavailable.
+Do NOT ask the user which definition of a group they mean — resolve it with the tools
+and note in EVIDENCE NOTES which canonical definition was used (e.g., "World Bank SAS region").
+
+Approximate reference (fallback only):
+- ASEAN: PHL, IDN, VNM, THA, MYS, MMR, KHM, LAO, SGP, BRN
+- South Asia (SAS): BGD, IND, PAK, NPL, LKA, AFG, MDV, BTN
+- Sub-Saharan Africa (SSF): NGA, ETH, KEN, GHA, TZA, UGA, ZAF, MOZ, SEN, ZMB (partial)
+- MENA: EGY, MAR, TUN, DZA, JOR, LBN, IRQ, YEM, SAU, ARE
+- Latin America (LCN): BRA, MEX, COL, ARG, PER, CHL, ECU, BOL
+- East Asia (EAS): CHN, IDN, PHL, VNM, THA, MYS, KHM, MMR
+- Europe & Central Asia (ECS): TUR, KAZ, UKR, UZB, GEO, ARM, MDA, ALB
+
+CONTEXT CARRY-FORWARD (never re-ask for established context):
+Before calling any tool on a follow-up turn, check the full conversation history:
+- If an indicator_id was used in a prior turn's tool call → reuse it; do NOT call search_indicators again.
+- If a country was named or a group was resolved in a prior turn → reuse those codes; do NOT call
+  find_codelist_value or expand_country_group again for the same entity.
+- If a time range was specified in the user's original question → carry it forward.
+- If the user's follow-up is comparative ("how does X compare?") → fetch the new entity using the
+  SAME indicator_id already established, not a fresh search.
 
 WHEN NOT TO CLARIFY (never ask the user):
-- Country is named → search and retrieve, do not ask to confirm
+- Country or region is named → resolve with tools and retrieve; never ask for definition clarification
 - Topic is broad ("challenges", "situation", "trends") → decompose and fetch
 - Time period unspecified → use last 10 years
+- Year already in conversation context → carry it forward; never ask "which year?"
 - Indicator type ambiguous → pick the most commonly used one, note it in EVIDENCE NOTES
+- Regional group definition potentially ambiguous → use data360_find_codelist_value to resolve canonically
 
 ONE FALLBACK ATTEMPT:
 If the primary fetch returns zero rows: try ONE of these in order:
@@ -347,9 +403,31 @@ VISUALIZATION TOOLS (you may call these):
 CONTEXT STRUCTURE — what you receive:
 Your system message is prepended with two sections before these instructions:
 
-1. RAW TOOL RESULTS — the exact outputs of the MCP data tools (data360_get_data,
-   data360_get_metadata). These contain all numeric values and claim IDs.
-   This is your PRIMARY DATA SOURCE. Read numbers and claim IDs directly from here.
+1. RAW TOOL RESULTS — the exact outputs of the MCP data tools. These contain all
+   numeric values and claim IDs. This is your PRIMARY DATA SOURCE. Read numbers
+   and claim IDs directly from here. May include output from any of:
+   - data360_get_data — individual observation rows, each with a "claim_id" field
+   - data360_get_metadata — indicator definitions and methodology
+   - data360_rank_countries — ranked country list; each "rankings" entry has "claim_id"
+   - data360_compare_countries — snapshot with "claim_id" per "rankings" entry;
+     optional time series uses positional arrays decoded via "series_schema"
+   - data360_summarize_data — grouped statistics; each group has "claim_ids" list
+   If a tool's output appears in RAW TOOL RESULTS, its values MUST be used verbatim.
+
+OUTPUT BOUNDARY RULE (critical):
+Your response is exactly ONE continuous answer block. The Research Agent produces
+an internal routing packet that may contain reasoning notes, indicator IDs, and
+other planning text before your instructions begin. That planning content is NOT
+part of your response. Rules:
+- Do NOT repeat, paraphrase, or append any content from the routing packet's
+  `### INDICATORS:`, `### EVIDENCE NOTES:`, or `### VIZ:` sections as part of
+  your final answer.
+- If you produced any internal reasoning or draft text before starting your
+  actual response, discard it. Your final output begins fresh, with the user
+  facing answer only.
+- Never produce two contradictory blocks of data in the same response. If you
+  find yourself writing a second version of values you already stated with claim
+  tags, stop and delete the second block.
 
 2. RESEARCH AGENT ROUTING PACKET — the Research Agent's metadata:
   ### PATH:       — the Research Agent's self-classification:
@@ -429,15 +507,38 @@ PRESENTATION:
 CLAIM TAGGING:
 Every numeric value you present from the RAW TOOL RESULTS **MUST** be wrapped in a
 claim tag: `<claim id="claim_id">value</claim>`.
-The `claim_id` for each observation row is in the RAW TOOL RESULTS JSON — look for
-the `"claim_id"` field in each observation object returned by data360_get_data.
+
+Where to find the claim_id in each tool's output:
+- data360_get_data: "claim_id" field on each observation row
+- data360_rank_countries: "claim_id" field on each entry in the "rankings" array
+- data360_summarize_data: "claim_ids" list on each group (covers all values in that group)
+- data360_compare_countries (compact format — decode as follows):
+  The output has a "series_schema" column list and per-country "series" positional arrays.
+  Step 1: Read "series_schema" — e.g., ["year", "value", "claim_id"]
+  Step 2: For each country, each row in "series" aligns to those columns positionally.
+          Example row [2022, 9.46, "5e1f3a8b"] → year=2022, value=9.46, claim_id="5e1f3a8b"
+  Step 3: Extract the 8-character hex string at the "claim_id" index (e.g., "5e1f3a8b").
+          If you cannot find a valid hex string at that position, DO NOT wrap the
+          value in a claim tag. Just output the number plainly.
+  The "snapshot.rankings" list also has a per-entry "claim_id" for snapshot values.
+
 For example: "Unemployment in Morocco was <claim id="5e1f">9.46</claim>% in 2015."
 You **MAY** format the value for readability (e.g., "$361.8 billion") as long as the
 underlying data remains accurate.
-**NEVER** invent a claim_id. Use only the `claim_id` field from the RAW TOOL RESULTS.
+**NEVER** invent a claim_id. Use ONLY the `claim_id` values present in RAW TOOL RESULTS.
+If you cannot find a claim_id for a value, do not present that value.
+
+CLAIM ID SOURCE RESTRICTION (critical):
+Valid claim_ids come EXCLUSIVELY from the JSON tool output rows in RAW TOOL RESULTS.
+They are ALWAYS 8-character hex strings (e.g., "3a0cbe51").
+If you do not see a hex string next to a value in the JSON, DO NOT tag it.
+Do NOT use indicator codes (e.g., "WB_WDI_NY_GDP_PCAP_KD") or sequential labels (e.g., "c1").
+Do NOT tag derived or computed values (e.g., averages, percentage differences, CAGR) that you calculated yourself. Only tag the exact raw values pulled from the tool output.
 
 NOTE: Claim IDs persist across conversation turns. If referencing a value shown
 in a prior turn, reuse the corresponding claim_id from that turn's tool output.
+If a new tool call was made this turn for new countries or years, those results
+will contain their own claim_ids — use those, not IDs from the prior turn.
 
 DATA CAVEATS:
 - If the routing packet notes caveats or missing coverage, include a short "**Limitations:**" sentence.
@@ -537,11 +638,15 @@ EXPLAIN — The user wants a pure definition, methodology explanation, or a desc
   Rule: Use EXPLAIN ONLY when the question could be answered identically for any country — i.e., it asks what something IS, not what a country's situation IS.
   NEVER use EXPLAIN for country-specific analytical questions ("What are [country]'s challenges/trends/performance?") — those are RESEARCH.
 
-CLARIFY — The query is development-data-related but is missing a required slot that prevents research from starting. Only use CLARIFY when the gap would genuinely block data retrieval. If context from conversation history fills the slot, do NOT use CLARIFY.
-  Missing slots: "country" (geography not specified or ambiguous), "indicator" (topic too vague), "time_period" (date range ambiguous and matters)
-  Examples: "Show me the data", "What are the latest numbers?", "Compare the two countries" (without prior context)
+CLARIFY — The query is development-data-related but is missing a required slot that prevents research from starting. Only use CLARIFY when the gap would genuinely block data retrieval AND no information in the conversation fills it.
+  Missing slots: "country" (no geography specified at all), "indicator" (topic too vague to retrieve anything)
+  Note: Do NOT treat "time_period" as a missing slot. The Research Agent automatically handles unspecified time periods by fetching the latest data or the last 10 years.
+  Examples: "Show me the data", "What are the latest numbers?", "Compare the two countries" (with no prior context at all)
   NEVER CLARIFY when: the user uses "these", "those", "that", "the indicators", "them" and data was retrieved in a recent turn — the conversation context fills the slot.
   NEVER CLARIFY for chart/visualization requests ("show this as a chart", "visualize those", "plot that") when data is already in the conversation.
+  NEVER CLARIFY when the user names a geographic group ("South Asian countries", "Sub-Saharan Africa", "ASEAN", "low-income countries", "Latin America", etc.) — the Research Agent resolves these autonomously using data360_find_codelist_value and data360_expand_country_group. A named group is NOT a missing country slot.
+  NEVER CLARIFY to ask which year when the conversation history already contains a time period, a previous data response with years, or the user said "latest", "recent", "last N years", or similar.
+  NEVER CLARIFY to ask which indicator when the previous assistant turn already retrieved and presented a specific indicator — that indicator IS the established context.
   When CLARIFY, populate "missing_slots" with the slot names that are absent.
 
 OUT_OF_SCOPE — The query has no connection to development data, economics, or international indicators.
@@ -1393,6 +1498,9 @@ RULES:
 4. Keep each suggestion concise (≤25 words).
 5. Do NOT re-ask about something already answered in the current response.
 6. Do NOT produce clarifying questions about the current request.
+7. Base suggestions on topics, countries, and indicators that appeared in the research
+   findings or current conversation. Do NOT invent or recommend specific indicator IDs
+   or database names from general knowledge — only reference what was shown.
 
 OUTPUT FORMAT:
 Output ONLY the suggestions as a numbered list, prefixed with this exact separator:

--- a/frontend/components/data360/aggregation-claim-extractors.ts
+++ b/frontend/components/data360/aggregation-claim-extractors.ts
@@ -1,0 +1,146 @@
+/**
+ * Custom ToolResultExtractor functions for aggregation tools.
+ *
+ * The compact serializer (_compact_aggregation_serializer) sends a space-efficient
+ * payload as the tool output. These extractors walk the compact structure and
+ * return ClaimEntry[] so the ClaimsManager can register them before ClaimMark
+ * components render.
+ *
+ * Both extractors defensively handle the case where `output` arrives as a raw
+ * JSON string (non-normalised pipeline paths) rather than a pre-parsed object.
+ *
+ * Compact output shapes (from to_compact() on the MCP server):
+ *
+ * rank_countries:
+ *   { rankings: [{ rank, code, country, value, claim_id }, ...] }
+ *
+ * compare_countries:
+ *   { snapshot: { rankings: [{ rank, code, country, value, claim_id }] },
+ *     time_series: { series_schema: ["time_period","obs_value","claim_id"],
+ *                    series: { "KEN": [[year, value, claim_id], ...] } } }
+ *
+ * summarize_data:
+ *   { groups: [{ claim_ids: [id, ...], ... }] }
+ */
+
+import type { ClaimEntry, ToolResultExtractor } from "@pcn-js/core";
+import type { CompactRankingOutput } from "./rank-countries";
+import type { CompactComparisonOutput, CompactTimeSeries } from "./compare-countries";
+import type { CompactSummaryOutput } from "./summarize-data";
+
+function parseOutput<T>(output: unknown): T | null {
+  if (output === null || output === undefined) return null;
+  if (typeof output === "string") {
+    try {
+      return JSON.parse(output) as T;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof output === "object") return output as T;
+  return null;
+}
+
+/**
+ * Extractor for data360_rank_countries compact output.
+ * Registers { id: claim_id, claim: { value } } for every entry in rankings[].
+ */
+export const rankCountriesExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactRankingOutput>(output);
+  if (!data?.rankings) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const entry of data.rankings) {
+    if (entry.claim_id && entry.value !== undefined && entry.value !== null) {
+      entries.push({
+        id: entry.claim_id,
+        claim: { value: entry.value, country: entry.code },
+      });
+    }
+  }
+  return entries;
+};
+
+/**
+ * Extractor for data360_compare_countries compact output.
+ * Registers claim_ids from both the snapshot rankings and time-series entries.
+ *
+ * Time series uses positional arrays: series_schema defines the column order,
+ * defaulting to ["time_period", "obs_value", "claim_id"]. We read column
+ * indices from series_schema — never hard-code offsets.
+ */
+export const compareCountriesExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactComparisonOutput>(output);
+  if (!data) return [];
+
+  const entries: ClaimEntry[] = [];
+
+  // Snapshot rankings — same shape as rank_countries entries
+  if (data.snapshot?.rankings) {
+    for (const entry of data.snapshot.rankings) {
+      if (entry.claim_id && entry.value !== undefined && entry.value !== null) {
+        entries.push({
+          id: entry.claim_id,
+          claim: { value: entry.value, country: entry.code, date: data.snapshot.year },
+        });
+      }
+    }
+  }
+
+  // Time-series — positional arrays keyed by country code
+  const ts = data.time_series as CompactTimeSeries | null | undefined;
+  if (ts?.series) {
+    const schema = ts.series_schema ?? ["time_period", "obs_value", "claim_id"];
+    const colValue = schema.indexOf("obs_value");
+    const colClaim = schema.indexOf("claim_id");
+    const colYear = schema.indexOf("time_period");
+
+    for (const [countryCode, points] of Object.entries(ts.series)) {
+      if (!Array.isArray(points)) continue;
+      for (const pt of points) {
+        if (!Array.isArray(pt)) continue;
+        const claimId = colClaim >= 0 ? (pt[colClaim] as string | null) : null;
+        const value = colValue >= 0 ? (pt[colValue] as number | null) : null;
+        const year = colYear >= 0 ? String(pt[colYear] ?? "") : undefined;
+        if (claimId && value !== null && value !== undefined) {
+          entries.push({
+            id: claimId,
+            claim: { value, country: countryCode, date: year },
+          });
+        }
+      }
+    }
+  }
+
+  return entries;
+};
+
+/**
+ * Extractor for data360_summarize_data compact output.
+ * Registers claim_ids from each group's claim_ids array. Since summarize_data
+ * groups aggregate multiple observations, claim_ids is a flat list — we register
+ * each with the group's latest value as context.
+ */
+export const summarizeDataExtractor: ToolResultExtractor = (output) => {
+  const data = parseOutput<CompactSummaryOutput>(output);
+  if (!data?.groups) return [];
+
+  const entries: ClaimEntry[] = [];
+  for (const group of data.groups) {
+    if (!group.claim_ids || group.claim_ids.length === 0) continue;
+    // Use the first group key as the geographic context
+    const groupKeys = Object.entries(group.group ?? {});
+    const refArea = groupKeys.find(([k]) => k === "ref_area")?.[1] ?? undefined;
+
+    for (const claimId of group.claim_ids) {
+      entries.push({
+        id: claimId,
+        claim: {
+          value: group.latest?.value ?? undefined,
+          country: refArea,
+        },
+      });
+    }
+  }
+  return entries;
+};

--- a/frontend/components/data360/compare-countries.tsx
+++ b/frontend/components/data360/compare-countries.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { ClaimMark } from "@pcn-js/ui";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors CountryComparisonResponse.to_compact() on the MCP server
+// All fields are optional so the renderer is resilient to both compact and
+// non-compact payloads (e.g. if the MCP server is on a different branch).
+// ---------------------------------------------------------------------------
+
+export type CompactRankedEntry = {
+  rank?: number;
+  code?: string;
+  country?: string;
+  value?: number;
+  claim_id?: string | null;
+};
+
+export type CompactComparisonSnapshot = {
+  year?: string;
+  rankings?: CompactRankedEntry[];
+  spread?: Record<string, number | null>;
+};
+
+/**
+ * series_schema documents the positional encoding:
+ *   [time_period, obs_value, claim_id]
+ * Always read positions from series_schema — do NOT hard-code offsets.
+ */
+export type CompactTimeSeries = {
+  year_range?: string | null;
+  n_aligned_years?: number;
+  convergence?: string | null;
+  cagr?: Record<string, number | null>;
+  series_schema?: string[];
+  series?: Record<string, [string, number, string | null][]>;
+};
+
+export type CompactComparisonOutput = {
+  indicator?: string | null;
+  unit?: string | null;
+  snapshot?: CompactComparisonSnapshot | null;
+  time_series?: CompactTimeSeries | null;
+  error?: string | null;
+  // Allow through unknown keys so non-compact full model payloads don't crash
+  [key: string]: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatNum(v: number | null | undefined, decimals = 2): string {
+  if (v === null || v === undefined || !Number.isFinite(v)) return "\u2014";
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(decimals)}B`;
+  if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(decimals)}M`;
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+function signedPct(v: number | null | undefined): string {
+  if (v === null || v === undefined || !Number.isFinite(v)) return "\u2014";
+  const sign = v >= 0 ? "+" : "";
+  return `${sign}${v.toFixed(2)}%`;
+}
+
+const CONVERGENCE_CONFIG: Record<
+  string,
+  { label: string; className: string }
+> = {
+  converging: {
+    label: "Converging",
+    className:
+      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  diverging: {
+    label: "Diverging",
+    className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  },
+  parallel: {
+    label: "Parallel",
+    className: "bg-muted text-muted-foreground",
+  },
+};
+
+// Default positional schema — used as fallback if series_schema is missing
+const DEFAULT_SERIES_SCHEMA = ["time_period", "obs_value", "claim_id"];
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
+      <div className="font-medium">Error</div>
+      <div className="mt-1">{message}</div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+      {children}
+    </div>
+  );
+}
+
+function SnapshotTable({
+  snapshot,
+  unit,
+}: {
+  snapshot: CompactComparisonSnapshot;
+  unit: string | null | undefined;
+}) {
+  const year = snapshot.year ?? "\u2014";
+  const rankings = snapshot.rankings ?? [];
+  const spread = snapshot.spread ?? {};
+
+  const spreadItems = Object.entries(spread).filter(
+    ([, v]) => v !== null && v !== undefined && Number.isFinite(v),
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <SectionLabel>Snapshot — {year}</SectionLabel>
+        {spreadItems.length > 0 && (
+          <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-muted-foreground">
+            {spreadItems.map(([key, val]) => (
+              <span key={key}>
+                <span className="capitalize">{key.replace(/_/g, " ")}:</span>{" "}
+                <span className="font-medium text-foreground">
+                  {formatNum(val)}
+                  {unit ? ` ${unit}` : ""}
+                </span>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {rankings.length === 0 ? (
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No ranking data for this snapshot.
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-muted sticky top-0">
+              <tr>
+                <th className="border-border border-b px-3 py-2 text-left font-medium w-8">
+                  #
+                </th>
+                <th className="border-border border-b px-3 py-2 text-left font-medium">
+                  Country
+                </th>
+                <th className="border-border border-b px-3 py-2 text-right font-medium">
+                  Value{" "}
+                  {unit ? (
+                    <span className="font-normal text-muted-foreground">
+                      ({unit})
+                    </span>
+                  ) : null}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rankings.map((entry, idx) => (
+                <tr
+                  className="hover:bg-muted/50 border-border border-b last:border-b-0"
+                  key={`${entry.code ?? idx}-${idx}`}
+                >
+                  <td className="px-3 py-2 text-muted-foreground font-mono">
+                    {entry.rank ?? idx + 1}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="font-medium">
+                      {entry.country ?? entry.code ?? "\u2014"}
+                    </div>
+                    {entry.country && entry.code && entry.country !== entry.code && (
+                      <div className="text-muted-foreground text-[10px] font-mono">
+                        {entry.code}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right font-medium tabular-nums">
+                    {entry.claim_id ? (
+                      <ClaimMark
+                        id={entry.claim_id}
+                        policy={{ type: "rounded", decimals: 2 }}
+                      >
+                        {formatNum(entry.value)}
+                      </ClaimMark>
+                    ) : (
+                      formatNum(entry.value)
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TimeSeriesSection({
+  timeSeries,
+  unit,
+}: {
+  timeSeries: CompactTimeSeries;
+  unit: string | null | undefined;
+}) {
+  const year_range = timeSeries.year_range ?? null;
+  const n_aligned_years = timeSeries.n_aligned_years ?? 0;
+  const convergence = timeSeries.convergence ?? null;
+  const cagr = timeSeries.cagr ?? {};
+  // Fall back to default schema if field is missing (non-compact payload)
+  const series_schema =
+    timeSeries.series_schema && timeSeries.series_schema.length > 0
+      ? timeSeries.series_schema
+      : DEFAULT_SERIES_SCHEMA;
+  const series = timeSeries.series ?? {};
+
+  // Decode positional indices from series_schema (never hard-code)
+  const colYear = series_schema.indexOf("time_period");
+  const colValue = series_schema.indexOf("obs_value");
+  const colClaim = series_schema.indexOf("claim_id");
+
+  const countries = Object.keys(series);
+  const cagrKeys = Object.keys(cagr);
+
+  const convergenceCfg = convergence
+    ? (CONVERGENCE_CONFIG[convergence] ?? {
+        label: convergence,
+        className: "bg-muted text-muted-foreground",
+      })
+    : null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Header row */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <SectionLabel>
+          Time series
+          {year_range ? ` \u2014 ${year_range}` : ""}
+          {n_aligned_years > 0 ? ` (${n_aligned_years} aligned years)` : ""}
+        </SectionLabel>
+        {convergenceCfg && (
+          <span
+            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${convergenceCfg.className}`}
+          >
+            {convergenceCfg.label}
+          </span>
+        )}
+      </div>
+
+      {/* CAGR table */}
+      {cagrKeys.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {cagrKeys.map((country) => {
+            const rate = cagr[country];
+            return (
+              <div
+                key={country}
+                className="rounded-lg border border-border bg-background px-3 py-2 text-xs min-w-[100px]"
+              >
+                <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
+                  {country} CAGR
+                </div>
+                <div
+                  className={`font-semibold tabular-nums ${
+                    rate !== null && rate !== undefined && rate >= 0
+                      ? "text-green-700 dark:text-green-400"
+                      : "text-red-700 dark:text-red-400"
+                  }`}
+                >
+                  {signedPct(rate)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Per-country series tables */}
+      {countries.map((country) => {
+        const points = series[country];
+        if (!points || points.length === 0) return null;
+
+        return (
+          <div key={country} className="flex flex-col gap-1">
+            <div className="text-xs font-medium text-foreground px-0.5">
+              {country}
+            </div>
+            <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
+              <div className="overflow-auto max-h-48">
+                <table className="w-full text-xs">
+                  <thead className="bg-muted sticky top-0">
+                    <tr>
+                      <th className="border-border border-b px-3 py-1.5 text-left font-medium">
+                        Year
+                      </th>
+                      <th className="border-border border-b px-3 py-1.5 text-right font-medium">
+                        Value{" "}
+                        {unit ? (
+                          <span className="font-normal text-muted-foreground">
+                            ({unit})
+                          </span>
+                        ) : null}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...points]
+                      .sort((a, b) => {
+                        const ya =
+                          colYear >= 0 ? String(a[colYear] ?? "") : "";
+                        const yb =
+                          colYear >= 0 ? String(b[colYear] ?? "") : "";
+                        return yb.localeCompare(ya);
+                      })
+                      .map((pt, i) => {
+                        const yearVal =
+                          colYear >= 0
+                            ? String(pt[colYear] ?? "?")
+                            : "?";
+                        const value =
+                          colValue >= 0 && pt[colValue] !== undefined
+                            ? (pt[colValue] as number)
+                            : null;
+                        const claimId =
+                          colClaim >= 0
+                            ? ((pt[colClaim] as string | null | undefined) ??
+                              null)
+                            : null;
+
+                        return (
+                          <tr
+                            className="hover:bg-muted/50 border-border border-b last:border-b-0"
+                            key={`${yearVal}-${i}`}
+                          >
+                            <td className="px-3 py-1.5 font-mono">{yearVal}</td>
+                            <td className="px-3 py-1.5 text-right font-medium tabular-nums">
+                              {claimId && value !== null ? (
+                                <ClaimMark
+                                  id={claimId}
+                                  policy={{ type: "rounded", decimals: 2 }}
+                                >
+                                  {formatNum(value)}
+                                </ClaimMark>
+                              ) : value !== null ? (
+                                formatNum(value)
+                              ) : (
+                                "\u2014"
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {countries.length === 0 && (
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No time series data available.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function CompareCountries({
+  output,
+}: {
+  output: CompactComparisonOutput;
+}) {
+  const error = (output.error ?? null) as string | null;
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-3">
+        <ErrorBanner message={error} />
+      </div>
+    );
+  }
+
+  const indicator = (output.indicator ?? null) as string | null;
+  const unit = (output.unit ?? null) as string | null;
+  const snapshot =
+    (output.snapshot ?? null) as CompactComparisonSnapshot | null;
+  const timeSeries =
+    (output.time_series ?? null) as CompactTimeSeries | null;
+
+  // Graceful fallback: if neither snapshot nor time_series is present the
+  // payload is likely non-compact or unexpected — show a neutral message
+  if (!snapshot && !timeSeries) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/30 p-4 text-muted-foreground text-sm">
+        <div className="font-medium text-foreground mb-1">
+          {indicator ?? "Comparison"}
+        </div>
+        <div className="text-[11px]">
+          No structured comparison data available.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-4 overflow-hidden rounded-sm bg-background px-4 pb-4">
+      {/* Header */}
+      <div className="flex flex-col gap-1 pb-1">
+        {indicator && (
+          <div className="font-semibold text-sm text-foreground leading-snug">
+            {indicator}
+          </div>
+        )}
+        {unit && (
+          <div className="text-muted-foreground text-xs">{unit}</div>
+        )}
+      </div>
+
+      {/* Snapshot */}
+      {snapshot ? (
+        <SnapshotTable snapshot={snapshot} unit={unit} />
+      ) : (
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No snapshot data available.
+        </div>
+      )}
+
+      {/* Time series */}
+      {timeSeries && (
+        <TimeSeriesSection timeSeries={timeSeries} unit={unit} />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/data360/pcn-provider-client.tsx
+++ b/frontend/components/data360/pcn-provider-client.tsx
@@ -1,6 +1,39 @@
 "use client";
 
 import { Data360ClaimsProvider } from "@pcn-js/data360";
+import { useClaimsManager } from "@pcn-js/ui";
+import {
+  rankCountriesExtractor,
+  compareCountriesExtractor,
+  summarizeDataExtractor,
+} from "./aggregation-claim-extractors";
+
+const DATA360_RANK_TOOL = "data360_rank_countries";
+const DATA360_COMPARE_TOOL = "data360_compare_countries";
+const DATA360_SUMMARIZE_TOOL = "data360_summarize_data";
+
+/**
+ * Registers aggregation extractors synchronously during render.
+ *
+ * Why during render and not in useEffect / useLayoutEffect?
+ * IngestToolOutput (in message.tsx) uses useEffect to call manager.ingest().
+ * React runs effects bottom-up after all renders are committed. If we used
+ * useEffect or useLayoutEffect here too, the ordering vs. IngestToolOutput
+ * would be non-deterministic. Registering synchronously during this
+ * component's render (which happens before message.tsx renders) guarantees
+ * the extractor is present before any effect fires.
+ *
+ * registerExtractor is idempotent — safe to call on every render.
+ */
+function AggregationExtractorRegistrar() {
+  const manager = useClaimsManager();
+  if (manager) {
+    manager.registerExtractor(DATA360_RANK_TOOL, rankCountriesExtractor);
+    manager.registerExtractor(DATA360_COMPARE_TOOL, compareCountriesExtractor);
+    manager.registerExtractor(DATA360_SUMMARIZE_TOOL, summarizeDataExtractor);
+  }
+  return null;
+}
 
 /**
  * Client-only wrapper for Data360ClaimsProvider so the layout (Server Component)
@@ -12,5 +45,10 @@ export function PcnProviderClient({
 }: {
   children: React.ReactNode;
 }) {
-  return <Data360ClaimsProvider>{children}</Data360ClaimsProvider>;
+  return (
+    <Data360ClaimsProvider>
+      <AggregationExtractorRegistrar />
+      {children}
+    </Data360ClaimsProvider>
+  );
 }

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { ClaimMark } from "@pcn-js/ui";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors RankingResponse.to_compact() on the MCP server
+// ---------------------------------------------------------------------------
+
+export type CompactRankedCountry = {
+  rank: number;
+  code: string;
+  country: string;
+  value: number;
+  claim_id: string | null;
+};
+
+export type CompactRankingOutput = {
+  year: string | null;
+  year_selection_note: string | null;
+  order: "asc" | "desc";
+  counts: { with_data: number; requested: number };
+  unit: string | null;
+  indicator: string | null;
+  rankings: CompactRankedCountry[];
+  excluded_count: number;
+  excluded_sample: Array<{ code: string; name: string | null }>;
+  error: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatValue(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) {
+    return `${(value / 1_000_000_000).toFixed(2)}B`;
+  }
+  if (abs >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)}M`;
+  }
+  if (abs >= 1_000) {
+    return value.toLocaleString("en-US", {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    });
+  }
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 4,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
+      <div className="font-medium">Error</div>
+      <div className="mt-1">{message}</div>
+    </div>
+  );
+}
+
+function RankingHeader({
+  output,
+}: {
+  output: CompactRankingOutput;
+}) {
+  const coverage =
+    output.counts.requested > 0
+      ? `${output.counts.with_data} / ${output.counts.requested} countries`
+      : `${output.counts.with_data} countries`;
+
+  return (
+    <div className="flex flex-col gap-1 pb-3">
+      {output.indicator && (
+        <div className="font-semibold text-sm text-foreground leading-snug">
+          {output.indicator}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-xs">
+        {output.year && (
+          <span>
+            <span className="font-medium text-foreground">{output.year}</span>
+          </span>
+        )}
+        {output.unit && <span>{output.unit}</span>}
+        <span
+          className="rounded bg-muted px-1.5 py-0.5"
+          title="Countries with data / countries requested"
+        >
+          {coverage}
+        </span>
+        <span className="rounded bg-muted px-1.5 py-0.5">
+          {output.order === "desc" ? "Highest first" : "Lowest first"}
+        </span>
+      </div>
+      {output.year_selection_note && (
+        <div className="text-muted-foreground text-[11px] leading-relaxed mt-0.5">
+          {output.year_selection_note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RankingTable({
+  rankings,
+  unit,
+}: {
+  rankings: CompactRankedCountry[];
+  unit: string | null;
+}) {
+  if (rankings.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+        No ranking data available.
+      </div>
+    );
+  }
+
+  const topValue = rankings[0]?.value ?? 0;
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
+      <div className="overflow-auto max-h-96">
+        <table className="w-full text-xs">
+          <thead className="sticky top-0 bg-muted">
+            <tr>
+              <th className="border-border border-b px-3 py-2 text-left font-medium w-10">
+                #
+              </th>
+              <th className="border-border border-b px-3 py-2 text-left font-medium">
+                Country
+              </th>
+              <th className="border-border border-b px-3 py-2 text-right font-medium">
+                Value {unit ? <span className="font-normal text-muted-foreground">({unit})</span> : null}
+              </th>
+              <th className="border-border border-b px-3 py-2 w-28 sr-only">
+                Bar
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rankings.map((entry, idx) => {
+              const barPct =
+                topValue !== 0
+                  ? Math.max(0, Math.min(100, (Math.abs(entry.value) / Math.abs(topValue)) * 100))
+                  : 0;
+
+              return (
+                <tr
+                  className="hover:bg-muted/50 border-border border-b last:border-b-0"
+                  key={`${entry.code}-${idx}`}
+                >
+                  <td className="px-3 py-2 text-muted-foreground font-mono">
+                    {entry.rank}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="font-medium">{entry.country}</div>
+                    {entry.country !== entry.code && (
+                      <div className="text-muted-foreground text-[10px] font-mono">
+                        {entry.code}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right font-medium tabular-nums">
+                    {entry.claim_id ? (
+                      <ClaimMark
+                        id={entry.claim_id}
+                        policy={{ type: "rounded", decimals: 2 }}
+                      >
+                        {formatValue(entry.value)}
+                      </ClaimMark>
+                    ) : (
+                      formatValue(entry.value)
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="h-2 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-primary/60 transition-all"
+                        style={{ width: `${barPct}%` }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ExcludedFooter({
+  count,
+  sample,
+  year,
+}: {
+  count: number;
+  sample: Array<{ code: string; name: string | null }>;
+  year: string | null;
+}) {
+  if (count === 0) return null;
+
+  const sampleNames = sample
+    .map((e) => e.name ?? e.code)
+    .join(", ");
+
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 px-3 py-2 text-muted-foreground text-xs">
+      <span className="font-medium">{count}</span>{" "}
+      {count === 1 ? "country" : "countries"} had no data
+      {year ? ` for ${year}` : ""}.
+      {sampleNames && (
+        <span className="ml-1">
+          Includes: {sampleNames}
+          {count > sample.length && ` (+${count - sample.length} more)`}.
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function RankCountries({ output }: { output: CompactRankingOutput }) {
+  if (output.error) {
+    return (
+      <div className="flex flex-col gap-3">
+        <ErrorBanner message={output.error} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3 overflow-hidden rounded-sm bg-background px-4 pb-4">
+      <RankingHeader output={output} />
+      <RankingTable rankings={output.rankings} unit={output.unit} />
+      <ExcludedFooter
+        count={output.excluded_count}
+        sample={output.excluded_sample}
+        year={output.year}
+      />
+    </div>
+  );
+}

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { ClaimMark } from "@pcn-js/ui";
+
+// ---------------------------------------------------------------------------
+// Types — mirrors DataSummaryResponse.to_compact() on the MCP server
+// ---------------------------------------------------------------------------
+
+export type CompactGroupSummary = {
+  group: Record<string, string>;
+  n: number;
+  latest: { value: number | null; year: string | null };
+  earliest: { value: number | null; year: string | null };
+  range: string | null;
+  stats: {
+    min: number | null;
+    max: number | null;
+    mean: number | null;
+    median: number | null;
+  };
+  change: { abs: number | null; pct: number | null };
+  trend: string | null;
+  claim_ids: string[];
+};
+
+export type CompactSummaryOutput = {
+  indicator: string | null;
+  unit: string | null;
+  ambiguous_dimensions: string[] | null;
+  groups: CompactGroupSummary[];
+  error: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatNum(v: number | null, decimals = 2): string {
+  if (v === null || v === undefined || !Number.isFinite(v)) return "\u2014";
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(decimals)}B`;
+  if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(decimals)}M`;
+  return v.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  });
+}
+
+const TREND_ICONS: Record<string, { icon: string; className: string }> = {
+  increasing: { icon: "\u2191", className: "text-green-600 dark:text-green-400" },
+  decreasing: { icon: "\u2193", className: "text-red-600 dark:text-red-400" },
+  stable: { icon: "\u2192", className: "text-muted-foreground" },
+  volatile: { icon: "\u2922", className: "text-yellow-600 dark:text-yellow-400" },
+};
+
+const DIMENSION_LABELS: Record<string, string> = {
+  ref_area: "Area",
+  sex: "Sex",
+  age: "Age",
+  urbanisation: "Urbanisation",
+  unit_measure: "Unit",
+  comp_breakdown_1: "Breakdown 1",
+  comp_breakdown_2: "Breakdown 2",
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive text-sm">
+      <div className="font-medium">Error</div>
+      <div className="mt-1">{message}</div>
+    </div>
+  );
+}
+
+function AmbiguousDimensionsWarning({
+  dimensions,
+}: {
+  dimensions: string[];
+}) {
+  return (
+    <div className="rounded-lg border border-yellow-300 bg-yellow-50/70 px-3 py-2 text-yellow-800 text-xs dark:border-yellow-700 dark:bg-yellow-950/30 dark:text-yellow-300">
+      <span className="font-medium">Ambiguous dimensions:</span>{" "}
+      {dimensions.map((d) => DIMENSION_LABELS[d] ?? d).join(", ")}. Stats may
+      mix multiple disaggregation values. Consider refining{" "}
+      <code className="font-mono">group_by</code> or{" "}
+      <code className="font-mono">disaggregation_filters</code>.
+    </div>
+  );
+}
+
+function GroupKeyPills({ group }: { group: Record<string, string> }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {Object.entries(group).map(([dim, val]) => (
+        <span
+          key={dim}
+          className="inline-flex items-center gap-0.5 rounded bg-muted px-1.5 py-0.5 text-[10px]"
+        >
+          <span className="text-muted-foreground">
+            {DIMENSION_LABELS[dim] ?? dim}:
+          </span>{" "}
+          <span className="font-medium text-foreground">{val}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function TrendBadge({ trend }: { trend: string | null }) {
+  if (!trend) return null;
+  const cfg = TREND_ICONS[trend] ?? { icon: "?", className: "text-muted-foreground" };
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium bg-muted ${cfg.className}`}
+      title={`Trend: ${trend}`}
+    >
+      <span>{cfg.icon}</span>
+      <span className="capitalize">{trend}</span>
+    </span>
+  );
+}
+
+function GroupCard({
+  group,
+  unit,
+}: {
+  group: CompactGroupSummary;
+  unit: string | null;
+}) {
+  const hasChange =
+    group.change.abs !== null || group.change.pct !== null;
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-3 flex flex-col gap-2">
+      {/* Group key + claim provenance */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <GroupKeyPills group={group.group} />
+        <div className="flex items-center gap-1.5 shrink-0">
+          {group.range && (
+            <span className="text-muted-foreground text-[10px]">
+              {group.range}
+            </span>
+          )}
+          <TrendBadge trend={group.trend} />
+          {/*
+            claim_ids is a flat list of ALL source observation IDs for this group —
+            order is not guaranteed to match temporal order. Render as a batch
+            provenance mark at the group level; do not index by position.
+          */}
+          {group.claim_ids.length > 0 && (
+            <ClaimMark
+              id={group.claim_ids[0]}
+              policy={{ type: "rounded", decimals: 2 }}
+            >
+              {""}
+            </ClaimMark>
+          )}
+        </div>
+      </div>
+
+      {/* Latest & earliest — values only, no per-value claim attribution */}
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <div className="rounded bg-muted/40 p-2">
+          <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
+            Latest
+          </div>
+          <div className="font-semibold text-foreground">
+            {group.latest.value !== null ? (
+              <>
+                {formatNum(group.latest.value)}
+                {unit && (
+                  <span className="ml-1 font-normal text-muted-foreground text-[10px]">
+                    {unit}
+                  </span>
+                )}
+              </>
+            ) : (
+              "\u2014"
+            )}
+          </div>
+          {group.latest.year && (
+            <div className="text-muted-foreground text-[10px]">
+              {group.latest.year}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded bg-muted/40 p-2">
+          <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
+            Earliest
+          </div>
+          <div className="font-semibold text-foreground">
+            {group.earliest.value !== null ? (
+              <>
+                {formatNum(group.earliest.value)}
+                {unit && (
+                  <span className="ml-1 font-normal text-muted-foreground text-[10px]">
+                    {unit}
+                  </span>
+                )}
+              </>
+            ) : (
+              "\u2014"
+            )}
+          </div>
+          {group.earliest.year && (
+            <div className="text-muted-foreground text-[10px]">
+              {group.earliest.year}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-4 gap-1 text-[10px]">
+        {(["min", "max", "mean", "median"] as const).map((key) => (
+          <div key={key} className="flex flex-col items-center rounded bg-muted/30 px-1 py-1">
+            <span className="text-muted-foreground uppercase tracking-wide text-[9px]">
+              {key}
+            </span>
+            <span className="font-medium text-foreground tabular-nums">
+              {formatNum(group.stats[key], 2)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Change row */}
+      {hasChange && (
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+          <span>
+            Change:{" "}
+            <span className="font-medium text-foreground">
+              {group.change.abs !== null
+                ? `${group.change.abs >= 0 ? "+" : ""}${formatNum(group.change.abs)}`
+                : "\u2014"}
+            </span>
+          </span>
+          {group.change.pct !== null && (
+            <span>
+              (
+              <span className="font-medium text-foreground">
+                {group.change.pct >= 0 ? "+" : ""}
+                {formatNum(group.change.pct, 1)}%
+              </span>
+              )
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function SummarizeData({ output }: { output: CompactSummaryOutput }) {
+  if (output.error) {
+    return (
+      <div className="flex flex-col gap-3">
+        <ErrorBanner message={output.error} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3 overflow-hidden rounded-sm bg-background px-4 pb-4">
+      {/* Header */}
+      <div className="flex flex-col gap-1 pb-1">
+        {output.indicator && (
+          <div className="font-semibold text-sm text-foreground leading-snug">
+            {output.indicator}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-xs">
+          {output.unit && <span>{output.unit}</span>}
+          <span className="rounded bg-muted px-1.5 py-0.5">
+            {output.groups.length} group{output.groups.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Ambiguous dimensions warning */}
+      {output.ambiguous_dimensions && output.ambiguous_dimensions.length > 0 && (
+        <AmbiguousDimensionsWarning dimensions={output.ambiguous_dimensions} />
+      )}
+
+      {/* Group cards */}
+      {output.groups.length === 0 ? (
+        <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
+          No groups returned.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {output.groups.map((group, idx) => (
+            <GroupCard
+              group={group}
+              key={idx}
+              unit={output.unit}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -55,6 +55,7 @@ const TREND_ICONS: Record<string, { icon: string; className: string }> = {
 
 const DIMENSION_LABELS: Record<string, string> = {
   ref_area: "Area",
+  time_period: "Year",
   sex: "Sex",
   age: "Age",
   urbanisation: "Urbanisation",
@@ -124,6 +125,81 @@ function TrendBadge({ trend }: { trend: string | null }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Degenerate time-series table
+// Rendered when ALL groups have n=1 — the result of group_by=["time_period"].
+// Shows a compact year → value table sorted newest-first.
+// ---------------------------------------------------------------------------
+
+function DegenerateTimeSeriesTable({
+  groups,
+  unit,
+}: {
+  groups: CompactGroupSummary[];
+  unit: string | null;
+}) {
+  // Each group's "latest" is the single observation for that period.
+  const rows = [...groups].sort((a, b) => {
+    const ya = a.latest.year ?? "";
+    const yb = b.latest.year ?? "";
+    return yb.localeCompare(ya); // newest first
+  });
+
+  return (
+    <div className="rounded-lg border border-border bg-background overflow-hidden">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b border-border bg-muted/40">
+            <th className="px-3 py-1.5 text-left text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+              Year
+            </th>
+            <th className="px-3 py-1.5 text-right text-[10px] uppercase tracking-wide text-muted-foreground font-medium">
+              Value{unit ? ` (${unit})` : ""}
+            </th>
+            <th className="px-3 py-1.5 text-right text-[10px] uppercase tracking-wide text-muted-foreground font-medium w-8">
+              {/* claim */}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((group, idx) => {
+            const year = group.latest.year ?? Object.values(group.group)[0] ?? "—";
+            const value = group.latest.value;
+            const claimId = group.claim_ids[0] ?? null;
+            return (
+              <tr
+                key={idx}
+                className="border-b border-border/50 last:border-0 hover:bg-muted/20 transition-colors"
+              >
+                <td className="px-3 py-1.5 tabular-nums font-medium text-foreground">
+                  {year}
+                </td>
+                <td className="px-3 py-1.5 tabular-nums text-right text-foreground">
+                  {value !== null ? formatNum(value) : "—"}
+                </td>
+                <td className="px-3 py-1.5 text-right">
+                  {claimId && (
+                    <ClaimMark
+                      id={claimId}
+                      policy={{ type: "rounded", decimals: 2 }}
+                    >
+                      {""}
+                    </ClaimMark>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Normal group card — used when n > 1 (multi-observation groups)
+// ---------------------------------------------------------------------------
+
 function GroupCard({
   group,
   unit,
@@ -131,8 +207,12 @@ function GroupCard({
   group: CompactGroupSummary;
   unit: string | null;
 }) {
+  // n=1 guard: suppress degenerate stats on individual cards when only some
+  // groups are single-observation (mixed grouping edge case).
+  const isDegenerate = group.n <= 1;
   const hasChange =
-    group.change.abs !== null || group.change.pct !== null;
+    !isDegenerate &&
+    (group.change.abs !== null || group.change.pct !== null);
 
   return (
     <div className="rounded-lg border border-border bg-background p-3 flex flex-col gap-2">
@@ -140,12 +220,12 @@ function GroupCard({
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <GroupKeyPills group={group.group} />
         <div className="flex items-center gap-1.5 shrink-0">
-          {group.range && (
+          {group.range && !isDegenerate && (
             <span className="text-muted-foreground text-[10px]">
               {group.range}
             </span>
           )}
-          <TrendBadge trend={group.trend} />
+          {!isDegenerate && <TrendBadge trend={group.trend} />}
           {/*
             claim_ids is a flat list of ALL source observation IDs for this group —
             order is not guaranteed to match temporal order. Render as a batch
@@ -166,7 +246,7 @@ function GroupCard({
       <div className="grid grid-cols-2 gap-2 text-xs">
         <div className="rounded bg-muted/40 p-2">
           <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
-            Latest
+            {isDegenerate ? "Value" : "Latest"}
           </div>
           <div className="font-semibold text-foreground">
             {group.latest.value !== null ? (
@@ -189,47 +269,51 @@ function GroupCard({
           )}
         </div>
 
-        <div className="rounded bg-muted/40 p-2">
-          <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
-            Earliest
-          </div>
-          <div className="font-semibold text-foreground">
-            {group.earliest.value !== null ? (
-              <>
-                {formatNum(group.earliest.value)}
-                {unit && (
-                  <span className="ml-1 font-normal text-muted-foreground text-[10px]">
-                    {unit}
-                  </span>
-                )}
-              </>
-            ) : (
-              "\u2014"
+        {!isDegenerate && (
+          <div className="rounded bg-muted/40 p-2">
+            <div className="text-muted-foreground text-[10px] uppercase tracking-wide mb-0.5">
+              Earliest
+            </div>
+            <div className="font-semibold text-foreground">
+              {group.earliest.value !== null ? (
+                <>
+                  {formatNum(group.earliest.value)}
+                  {unit && (
+                    <span className="ml-1 font-normal text-muted-foreground text-[10px]">
+                      {unit}
+                    </span>
+                  )}
+                </>
+              ) : (
+                "\u2014"
+              )}
+            </div>
+            {group.earliest.year && (
+              <div className="text-muted-foreground text-[10px]">
+                {group.earliest.year}
+              </div>
             )}
           </div>
-          {group.earliest.year && (
-            <div className="text-muted-foreground text-[10px]">
-              {group.earliest.year}
+        )}
+      </div>
+
+      {/* Stats row — suppressed for degenerate single-observation groups */}
+      {!isDegenerate && (
+        <div className="grid grid-cols-4 gap-1 text-[10px]">
+          {(["min", "max", "mean", "median"] as const).map((key) => (
+            <div key={key} className="flex flex-col items-center rounded bg-muted/30 px-1 py-1">
+              <span className="text-muted-foreground uppercase tracking-wide text-[9px]">
+                {key}
+              </span>
+              <span className="font-medium text-foreground tabular-nums">
+                {formatNum(group.stats[key], 2)}
+              </span>
             </div>
-          )}
+          ))}
         </div>
-      </div>
+      )}
 
-      {/* Stats row */}
-      <div className="grid grid-cols-4 gap-1 text-[10px]">
-        {(["min", "max", "mean", "median"] as const).map((key) => (
-          <div key={key} className="flex flex-col items-center rounded bg-muted/30 px-1 py-1">
-            <span className="text-muted-foreground uppercase tracking-wide text-[9px]">
-              {key}
-            </span>
-            <span className="font-medium text-foreground tabular-nums">
-              {formatNum(group.stats[key], 2)}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      {/* Change row */}
+      {/* Change row — suppressed for degenerate groups */}
       {hasChange && (
         <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
           <span>
@@ -270,6 +354,14 @@ export function SummarizeData({ output }: { output: CompactSummaryOutput }) {
     );
   }
 
+  // Detect degenerate output: ALL groups have n=1.
+  // This happens when group_by=["time_period"] is used for a single-country
+  // trend query — it produces one group per year with exactly one observation,
+  // making all stats (min/max/mean/median/change/trend) mathematically trivial.
+  // In this case we render a compact time-series table instead of per-year cards.
+  const allDegenerate =
+    output.groups.length > 1 && output.groups.every((g) => g.n <= 1);
+
   return (
     <div className="flex w-full flex-col gap-3 overflow-hidden rounded-sm bg-background px-4 pb-4">
       {/* Header */}
@@ -281,9 +373,15 @@ export function SummarizeData({ output }: { output: CompactSummaryOutput }) {
         )}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground text-xs">
           {output.unit && <span>{output.unit}</span>}
-          <span className="rounded bg-muted px-1.5 py-0.5">
-            {output.groups.length} group{output.groups.length !== 1 ? "s" : ""}
-          </span>
+          {allDegenerate ? (
+            <span className="rounded bg-muted px-1.5 py-0.5">
+              {output.groups.length} observations
+            </span>
+          ) : (
+            <span className="rounded bg-muted px-1.5 py-0.5">
+              {output.groups.length} group{output.groups.length !== 1 ? "s" : ""}
+            </span>
+          )}
         </div>
       </div>
 
@@ -292,11 +390,14 @@ export function SummarizeData({ output }: { output: CompactSummaryOutput }) {
         <AmbiguousDimensionsWarning dimensions={output.ambiguous_dimensions} />
       )}
 
-      {/* Group cards */}
+      {/* Body */}
       {output.groups.length === 0 ? (
         <div className="rounded-lg border border-border bg-background p-4 text-muted-foreground text-sm">
           No groups returned.
         </div>
+      ) : allDegenerate ? (
+        // Fallback: compact time-series table when every group has n=1
+        <DegenerateTimeSeriesTable groups={output.groups} unit={output.unit} />
       ) : (
         <div className="flex flex-col gap-2">
           {output.groups.map((group, idx) => (

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -43,6 +43,18 @@ import { GetData, GetDataRequestSummary } from "./data360/get-data";
 import { GetWdiData } from "./data360/get-wdi-data";
 import { SearchIndicators } from "./data360/search-indicators";
 import { SearchRelevantIndicators } from "./data360/search-relevant-indicators";
+import {
+  RankCountries,
+  type CompactRankingOutput,
+} from "./data360/rank-countries";
+import {
+  SummarizeData,
+  type CompactSummaryOutput,
+} from "./data360/summarize-data";
+import {
+  CompareCountries,
+  type CompactComparisonOutput,
+} from "./data360/compare-countries";
 import { DocumentToolResult } from "./document";
 import { DocumentPreview } from "./document-preview";
 import { CodeBlock } from "./elements/code-block";
@@ -663,6 +675,147 @@ function renderMessagePart(
               useDefaultFormat={false}
               output={
                 <SearchIndicators output={toolPart.output} input={rawInput} />
+              }
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  // data360_rank_countries tool
+  if ((type as string) === "tool-data360_rank_countries") {
+    const toolPart = part as {
+      toolCallId: string;
+      state:
+        | "input-available"
+        | "output-available"
+        | "input-streaming"
+        | "output-error";
+      input?: unknown;
+      output?: unknown;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool("tool-data360_rank_countries")}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        {toolPart.state === "output-available" && toolPart.output != null && (
+          <IngestToolOutput
+            output={toolPart.output}
+            toolName="data360_rank_countries"
+          >
+            {null}
+          </IngestToolOutput>
+        )}
+        <ToolContent>
+          {toolPart.state === "input-available" &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {toolPart.state === "output-available" && toolPart.output != null && (
+            <ToolOutput
+              errorText={undefined}
+              useDefaultFormat={false}
+              output={
+                <RankCountries
+                  output={toolPart.output as CompactRankingOutput}
+                />
+              }
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  // data360_summarize_data tool
+  if ((type as string) === "tool-data360_summarize_data") {
+    const toolPart = part as {
+      toolCallId: string;
+      state:
+        | "input-available"
+        | "output-available"
+        | "input-streaming"
+        | "output-error";
+      input?: unknown;
+      output?: unknown;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool("tool-data360_summarize_data")}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        {toolPart.state === "output-available" && toolPart.output != null && (
+          <IngestToolOutput
+            output={toolPart.output}
+            toolName="data360_summarize_data"
+          >
+            {null}
+          </IngestToolOutput>
+        )}
+        <ToolContent>
+          {toolPart.state === "input-available" &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {toolPart.state === "output-available" && toolPart.output != null && (
+            <ToolOutput
+              errorText={undefined}
+              useDefaultFormat={false}
+              output={
+                <SummarizeData
+                  output={toolPart.output as CompactSummaryOutput}
+                />
+              }
+            />
+          )}
+        </ToolContent>
+      </Tool>
+    );
+  }
+
+  // data360_compare_countries tool
+  if ((type as string) === "tool-data360_compare_countries") {
+    const toolPart = part as {
+      toolCallId: string;
+      state:
+        | "input-available"
+        | "output-available"
+        | "input-streaming"
+        | "output-error";
+      input?: unknown;
+      output?: unknown;
+    };
+    return (
+      <Tool
+        defaultOpen={defaultOpenForData360Tool("tool-data360_compare_countries")}
+        key={toolPart.toolCallId}
+      >
+        <ToolHeader state={toolPart.state} type={type as `tool-${string}`} />
+        {toolPart.state === "output-available" && toolPart.output != null && (
+          <IngestToolOutput
+            output={toolPart.output}
+            toolName="data360_compare_countries"
+          >
+            {null}
+          </IngestToolOutput>
+        )}
+        <ToolContent>
+          {toolPart.state === "input-available" &&
+            toolPart.input !== undefined && (
+              <ToolInput input={toolPart.input as ToolUIPart["input"]} />
+            )}
+          {toolPart.state === "output-available" && toolPart.output != null && (
+            <ToolOutput
+              errorText={undefined}
+              useDefaultFormat={false}
+              output={
+                <CompareCountries
+                  output={toolPart.output as CompactComparisonOutput}
+                />
               }
             />
           )}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,9 +46,6 @@ importers:
       '@codemirror/view':
         specifier: ^6.35.3
         version: 6.36.4
-      '@data360/chart-payload-normalize':
-        specifier: 0.0.1
-        version: 0.0.1
       '@data360/mcp-ui':
         specifier: 0.0.5
         version: 0.0.5(@data360/tool-types@0.0.4)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)


### PR DESCRIPTION
## Summary

Adds dedicated frontend renderers for the three aggregation MCP tools that emit compact serialized output via `_compact_aggregation_serializer`. Without these renderers, compact output fell through to a generic fallback that truncated at 5,000 characters, stripping both data and PCN claim attribution.

> **Note:** The compact aggregation serializer (data360-mcp PR #78) is **already merged into `upstream/dev` of data360-mcp** — no additional MCP deployment is required for this PR.

## Changes

### New UI Components (`frontend/components/data360/`)

| Component | Tool | What it renders |
|---|---|---|
| `rank-countries.tsx` | `data360_rank_countries` | Ranked table with inline bar charts, ClaimMark per value |
| `summarize-data.tsx` | `data360_summarize_data` | Group cards with stats, trend direction, and absolute change; ClaimMark per stat |
| `compare-countries.tsx` | `data360_compare_countries` | Snapshot comparison table + positional-array time series decoded via `series_schema` |

### PCN Claim Provenance (`frontend/components/data360/`)

| File | Purpose |
|---|---|
| `aggregation-claim-extractors.ts` | Custom `ToolResultExtractor` per tool: handles compact positional arrays, flat rankings, and group claim_ids lists |
| `pcn-provider-client.tsx` | Registers all 3 extractors synchronously at render time, before `IngestToolOutput` effects fire |

### Message Integration (`frontend/components/message.tsx`)

Inserts dedicated handler blocks for all 3 tools ahead of the generic fallback, wrapping each with `IngestToolOutput` for claim ingestion.

### Build Fix (`frontend/pnpm-lock.yaml`)

Regenerated with pnpm@9.12.3 (matching `packageManager` field) to remove a stale `@data360/chart-payload-normalize` specifier that broke `frozen-lockfile` validation in Docker builds.

## Result

- Compact aggregation output is rendered with full fidelity (no 5,000-char truncation)
- PCN claim IDs are correctly registered and available for claim-tag attribution in the Writer's response
- All three tool renderers bypass the generic output fallback

## Related

- Enables PR #123 (`fix/agentic-flow-grounding`) which fixes the narrator pipeline to forward these tool outputs to the Writer