### PR TITLE
patch-fix(sse-bridge): prevent narrator response duplication on run_id mismatch

### DIFF
--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -352,7 +352,22 @@ class _SseBridgeState:
         if full_text.startswith(streamed):
             gap = full_text[len(streamed) :]
         elif not streamed:
-            gap = full_text
+            # Guard against run_id mismatches: if streaming is already underway
+            # (answer_text_started=True), an empty accumulator means the stream
+            # events were tracked under a different run_id — not that the provider
+            # skipped streaming. In that case, the narrator has already emitted the
+            # full text via on_chat_model_stream; re-emitting here would duplicate
+            # the response. Only fall back to full_text for genuine non-streaming
+            # providers (where answer_text_started is still False).
+            gap = full_text if not self.answer_text_started else ""
+            if gap == "" and self.answer_text_started:
+                logger.debug(
+                    "[sse_bridge] answer fallback skipped (run_id mismatch, streaming already active) "
+                    "message_id=%s run_id=%s full_len=%d",
+                    self.message_id,
+                    run_id,
+                    len(full_text),
+                )
         else:
             gap = ""
             logger.debug(


### PR DESCRIPTION
## Problem

When LangGraph's `on_chat_model_stream` and `on_chat_model_end` events are emitted with different `run_id`s for the same LLM invocation (reproducible with certain LiteLLM/provider chain-wrapping paths), the SSE bridge's per-run accumulator (`_answer_run_stream_acc`) returns an empty string for the end event even though streaming already occurred normally.

The original fallback treated `streamed == ''` as evidence that the provider never streamed — and re-emitted the entire narrator response as a 'gap'. This produced a **visible duplication in the chat UI**: the user saw the full response text appear once via streaming, then the same text appended immediately after.

## Fix

One-line guard in `_chunks_answer_text_fallback_from_end`: if `self.answer_text_started` is `True`, at least one token-level stream event was emitted this turn. An empty accumulator at that point is a run_id mismatch, not a non-streaming provider. Skip the fallback and log at DEBUG.

The genuine non-streaming fallback path (provider never emits `on_chat_model_stream` events, `answer_text_started=False`) is completely unchanged.

## Impact

- **Non-breaking.** Only modifies behaviour in the edge case where streaming succeeded but run_id correlation failed.
- **Followup node is unaffected.** It uses `streaming=False` + `safe_llm_ainvoke` and never fires `on_chat_model_end` through the SSE bridge.
- Adds a DEBUG log line to aid future diagnosis of run_id mismatches.

## Testing

Reproduce by asking the chatbot a question that triggers `data360_compare_countries` and verify the response appears exactly once in the UI.