### PR TITLE
fix(chat): replace [blocked] with structured content-policy UX and chat.turn telemetry

### DIFF
--- a/backend/app/ai/graph/llm_invoke.py
+++ b/backend/app/ai/graph/llm_invoke.py
@@ -19,8 +19,25 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+CONTENT_POLICY_USER_MESSAGE = (
+    "This response is incomplete because the model provider blocked this reply under its content safety rules. "
+    "Try rephrasing your question, narrowing the topic, or contacting support."
+)
+
+# Legacy sentinel persisted before BE-003; kept for reload/migration detection only.
 LLM_POLICY_BLOCKED_TEXT = "[blocked]"
+
+CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked"
+
 LLM_STEP_FAILED_TEXT = "Sorry, this step could not be completed. Please try again in a moment."
+
+
+def content_policy_blocked_part(*, node: str) -> dict:
+    """Persisted/streamed part marking a non-fatal content-policy block."""
+    return {
+        "type": CONTENT_POLICY_BLOCKED_PART_TYPE,
+        "data": {"node": node, "message": CONTENT_POLICY_USER_MESSAGE},
+    }
 
 
 def assistant_text_part(text: str) -> dict:

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -10,11 +10,11 @@ import logging
 import re
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
-from opentelemetry import trace
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_followup_system_prompt
 from app.config import ModelType
+from app.observability.otel_setup import record_content_policy_on_span
 
 from ..llm_factory import get_chat_llm
 from ..llm_invoke import LLM_STEP_FAILED_TEXT, assistant_text_part, safe_llm_ainvoke
@@ -110,15 +110,13 @@ async def followup_node(state: ChatPipelineState) -> dict:
     existing_parts: list[dict] = state.get("assistant_parts", [])
 
     if outcome == "policy":
-        span = trace.get_current_span()
-        if span.is_recording():
-            span.set_attribute("chatbot.content_policy_blocked", True)
-            span.set_attribute("chatbot.content_policy_node", "followup")
+        record_content_policy_on_span("followup")
         return {
             "followup_questions": [],
             "assistant_parts": existing_parts,
             "final_usage": None,
             "content_policy_blocked": True,
+            "content_policy_node": "followup",
         }
 
     if outcome != "ok":

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -10,18 +10,14 @@ import logging
 import re
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from opentelemetry import trace
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_followup_system_prompt
 from app.config import ModelType
 
 from ..llm_factory import get_chat_llm
-from ..llm_invoke import (
-    LLM_POLICY_BLOCKED_TEXT,
-    LLM_STEP_FAILED_TEXT,
-    assistant_text_part,
-    safe_llm_ainvoke,
-)
+from ..llm_invoke import LLM_STEP_FAILED_TEXT, assistant_text_part, safe_llm_ainvoke
 from ..memory import trim_for_node
 from ..message_utils import openai_to_langchain, plain_text_from_ai_message_content
 from ..state import ChatPipelineState
@@ -114,9 +110,13 @@ async def followup_node(state: ChatPipelineState) -> dict:
     existing_parts: list[dict] = state.get("assistant_parts", [])
 
     if outcome == "policy":
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("chatbot.content_policy_blocked", True)
+            span.set_attribute("chatbot.content_policy_node", "followup")
         return {
             "followup_questions": [],
-            "assistant_parts": existing_parts + [assistant_text_part(LLM_POLICY_BLOCKED_TEXT)],
+            "assistant_parts": existing_parts,
             "final_usage": None,
             "content_policy_blocked": True,
         }

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -65,6 +65,7 @@ from app.ai.protocols.stream import (
     ToolInputStartPart,
     ToolOutputAvailablePart,
 )
+from app.observability.otel_setup import record_content_policy_on_span, record_error_on_span
 from app.utils.error_id import USER_MESSAGE_GENERIC, new_error_id
 
 from .llm_invoke import (
@@ -217,6 +218,7 @@ class _SseBridgeState:
         "_preprocessing_run_ids",
         "_answer_run_stream_acc",
         "_prepend_sep_before_next_answer_delta",
+        "_last_langgraph_node",
     )
 
     def __init__(
@@ -257,6 +259,7 @@ class _SseBridgeState:
         # After narrator (or any visible answer), the next answer node (e.g. followup)
         # must not concatenate flush against the prior character (e.g. "estimate---").
         self._prepend_sep_before_next_answer_delta: bool = False
+        self._last_langgraph_node: str = ""
 
     def _node_progress_chunks(
         self,
@@ -436,6 +439,8 @@ class _SseBridgeState:
         metadata: dict = event.get("metadata", {})
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
+        if node:
+            self._last_langgraph_node = node
 
         if evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
             stage_bytes = self.make_stage_sse("interpreting")
@@ -829,6 +834,11 @@ class _SseBridgeState:
                 self._final_graph_state.get("summarized_message_count") or 0
             )
             out["quick_answer_card"] = self._final_graph_state.get("quick_answer_card")
+            if self._final_graph_state.get("content_policy_blocked"):
+                out["content_policy_blocked"] = True
+                out["content_policy_node"] = (
+                    self._final_graph_state.get("content_policy_node") or "followup"
+                )
             # Merge agent trace parts into db_parts for persistence
             trace_parts = self._final_graph_state.get("agent_trace_parts") or []
             if trace_parts:
@@ -902,6 +912,9 @@ async def stream_graph_to_sse(
                         root = _root_cause(graph_exc)
                         err_id = new_error_id()
                         log_pipeline_error(message_id=message_id, error_id=err_id, exc=root)
+                        if isinstance(root, ContentPolicyViolationError):
+                            record_content_policy_on_span(br._last_langgraph_node or "stream")
+                        record_error_on_span(err_id)
                         logger.warning(
                             "Graph SSE stream failed [%s]: %s",
                             err_id,

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -67,7 +67,13 @@ from app.ai.protocols.stream import (
 )
 from app.utils.error_id import USER_MESSAGE_GENERIC, new_error_id
 
-from .llm_invoke import LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT
+from .llm_invoke import (
+    CONTENT_POLICY_BLOCKED_PART_TYPE,
+    CONTENT_POLICY_USER_MESSAGE,
+    LLM_POLICY_BLOCKED_TEXT,
+    LLM_STEP_FAILED_TEXT,
+    content_policy_blocked_part,
+)
 from .message_utils import plain_text_from_ai_message_content
 
 try:
@@ -111,10 +117,7 @@ def _root_cause(exc: BaseException) -> BaseException:
 def _user_visible_stream_error(root: BaseException, error_id: str) -> str:
     ref = f" Reference: {error_id}."
     if isinstance(root, ContentPolicyViolationError):
-        return (
-            "The model provider blocked this reply under its content safety rules. "
-            "Try rephrasing your question or narrowing the topic."
-        ) + ref
+        return CONTENT_POLICY_USER_MESSAGE + ref
     return USER_MESSAGE_GENERIC + ref
 
 
@@ -741,13 +744,20 @@ class _SseBridgeState:
         if isinstance(self._final_graph_state, dict) and self._final_graph_state.get(
             "content_policy_blocked"
         ):
-            blocked_id = f"followup-blocked-{self.message_id}"
-            for part in (
-                TextStartPart(id=blocked_id),
-                TextDeltaPart(id=blocked_id, delta=LLM_POLICY_BLOCKED_TEXT),
-                TextEndPart(id=blocked_id),
+            policy_part = content_policy_blocked_part(node="followup")
+            chunks.append(
+                DataPart(
+                    type=CONTENT_POLICY_BLOCKED_PART_TYPE,
+                    data=policy_part["data"],
+                )
+                .to_sse()
+                .encode("utf-8")
+            )
+            if not any(
+                isinstance(x, dict) and x.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE
+                for x in self._db_parts
             ):
-                chunks.append(part.to_sse().encode("utf-8"))
+                self._db_parts.append(policy_part)
         # Emit data-quickAnswerCard payload for the frontend card renderer.
         # Type matches the CustomUIDataTypes key 'quickAnswerCard' with the 'data-' prefix
         # that the AI SDK uses to map DataParts to message.parts — enabling persistence.
@@ -823,13 +833,20 @@ class _SseBridgeState:
             trace_parts = self._final_graph_state.get("agent_trace_parts") or []
             if trace_parts:
                 self._db_parts.extend(trace_parts)
-            # Non-streaming follow-up may only exist on graph state — persist short markers
+            # Non-streaming follow-up failure markers may only exist on graph state.
             assistant_tail = self._final_graph_state.get("assistant_parts") or []
             for p in assistant_tail:
                 if not isinstance(p, dict) or p.get("type") != "text":
                     continue
                 tx = (p.get("text") or "").strip()
-                if tx not in (LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT):
+                if tx == LLM_POLICY_BLOCKED_TEXT:
+                    if not any(
+                        isinstance(x, dict) and x.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE
+                        for x in self._db_parts
+                    ):
+                        self._db_parts.append(content_policy_blocked_part(node="followup"))
+                    continue
+                if tx != LLM_STEP_FAILED_TEXT:
                     continue
                 if any(
                     isinstance(x, dict)

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -66,7 +66,8 @@ class ChatPipelineState(TypedDict):
     summarized_message_count: NotRequired[int]
     # Follow-up questions generated post-narrator
     followup_questions: NotRequired[list[str]]
-    # Set when followup (or another node) surfaces LLM_POLICY_BLOCKED_TEXT under policy
+    # Set when a node hits provider content-policy (e.g. followup LLM call)
     content_policy_blocked: NotRequired[bool]
+    content_policy_node: NotRequired[str]
     # Internal agent outputs for debugging/analytics
     agent_trace_parts: NotRequired[list[dict]]

--- a/backend/app/api/v1/utils/graph_stream.py
+++ b/backend/app/api/v1/utils/graph_stream.py
@@ -22,6 +22,7 @@ from app.ai.protocols.stream import (
     TextEndPart,
     TextStartPart,
 )
+from app.observability.otel_setup import record_content_policy_on_span
 from app.utils.resumable_stream import store_stream_chunk
 
 logger = logging.getLogger(__name__)
@@ -194,4 +195,7 @@ async def stream_chat_graph_sse(
             assistant_row_id=assistant_row_id,
         ):
             yield sse_bytes
+        if graph_out.get("content_policy_blocked"):
+            policy_node = str(graph_out.get("content_policy_node") or "followup")
+            record_content_policy_on_span(policy_node)
     logger.info("[graph_stream] stream_graph_to_sse done")

--- a/backend/app/observability/__init__.py
+++ b/backend/app/observability/__init__.py
@@ -6,6 +6,7 @@ from app.observability.otel_setup import (
     instrument_fastapi_app,
     instrument_httpx_outbound,
     is_tracing_enabled,
+    record_content_policy_on_span,
     record_error_on_span,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "instrument_fastapi_app",
     "instrument_httpx_outbound",
     "is_tracing_enabled",
+    "record_content_policy_on_span",
     "record_error_on_span",
 ]

--- a/backend/app/observability/otel_setup.py
+++ b/backend/app/observability/otel_setup.py
@@ -218,19 +218,44 @@ def instrument_fastapi_app(app: object) -> None:
         _logger.warning("opentelemetry-instrumentation-fastapi not available.")
 
 
-def record_error_on_span(error_id: str) -> None:
-    """Attach support reference ID to the current span when recording."""
-    if not error_id:
-        return
+def _recording_span():
+    """Return the active span if it is recording, else None."""
     try:
         from opentelemetry import trace  # noqa: PLC0415
 
         span = trace.get_current_span()
         if span is None:
-            return
+            return None
         is_recording = getattr(span, "is_recording", None)
         if callable(is_recording) and not is_recording():
-            return
-        span.set_attribute("chatbot.error_id", error_id)
+            return None
+        return span
+    except Exception:
+        return None
+
+
+def record_content_policy_on_span(node: str) -> None:
+    """Mark the current span (e.g. ``chat.turn`` or a graph node) as policy-blocked."""
+    if not node:
+        node = "unknown"
+    span = _recording_span()
+    if span is None:
+        return
+    try:
+        cast("Any", span).set_attribute("chatbot.content_policy_blocked", True)
+        cast("Any", span).set_attribute("chatbot.content_policy_node", node)
+    except Exception:
+        pass
+
+
+def record_error_on_span(error_id: str) -> None:
+    """Attach support reference ID to the current span when recording."""
+    if not error_id:
+        return
+    span = _recording_span()
+    if span is None:
+        return
+    try:
+        cast("Any", span).set_attribute("chatbot.error_id", error_id)
     except Exception:
         pass

--- a/backend/tests/test_content_policy.py
+++ b/backend/tests/test_content_policy.py
@@ -18,6 +18,7 @@ from app.ai.graph.llm_invoke import (
 )
 from app.ai.graph.nodes import followup as followup_module
 from app.ai.graph.sse_bridge import _SseBridgeState, _user_visible_stream_error
+from app.observability.otel_setup import record_content_policy_on_span
 
 
 @pytest.mark.asyncio
@@ -80,15 +81,15 @@ async def test_followup_node_policy_block_sets_state_without_blocked_text() -> N
             AsyncMock(return_value=(None, "policy")),
         ),
         patch.object(followup_module, "trim_for_node", side_effect=lambda msgs, **_: msgs),
-        patch.object(followup_module.trace, "get_current_span") as mock_span_getter,
+        patch.object(
+            followup_module,
+            "record_content_policy_on_span",
+        ) as mock_record_policy,
     ):
-        span = MagicMock()
-        span.is_recording.return_value = True
-        mock_span_getter.return_value = span
-
         result = await followup_module.followup_node(state)
 
     assert result["content_policy_blocked"] is True
+    assert result["content_policy_node"] == "followup"
     assert result["followup_questions"] == []
     assert result["assistant_parts"] == state["assistant_parts"]
     assert not any(
@@ -96,5 +97,13 @@ async def test_followup_node_policy_block_sets_state_without_blocked_text() -> N
         for p in result["assistant_parts"]
         if isinstance(p, dict)
     )
+    mock_record_policy.assert_called_once_with("followup")
+
+
+def test_record_content_policy_on_span_sets_attributes() -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("app.observability.otel_setup._recording_span", return_value=span):
+        record_content_policy_on_span("narrator")
     span.set_attribute.assert_any_call("chatbot.content_policy_blocked", True)
-    span.set_attribute.assert_any_call("chatbot.content_policy_node", "followup")
+    span.set_attribute.assert_any_call("chatbot.content_policy_node", "narrator")

--- a/backend/tests/test_content_policy.py
+++ b/backend/tests/test_content_policy.py
@@ -1,0 +1,100 @@
+"""Tests for content-policy violation handling (BE-003)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from litellm.exceptions import ContentPolicyViolationError
+except ImportError:  # pragma: no cover
+    ContentPolicyViolationError = Exception  # type: ignore[misc, assignment]
+
+from app.ai.graph.llm_invoke import (
+    CONTENT_POLICY_BLOCKED_PART_TYPE,
+    CONTENT_POLICY_USER_MESSAGE,
+    LLM_POLICY_BLOCKED_TEXT,
+    content_policy_blocked_part,
+    safe_llm_ainvoke,
+)
+from app.ai.graph.nodes import followup as followup_module
+from app.ai.graph.sse_bridge import _SseBridgeState, _user_visible_stream_error
+
+
+@pytest.mark.asyncio
+async def test_safe_llm_ainvoke_returns_policy_outcome() -> None:
+    llm = MagicMock()
+    llm.ainvoke = AsyncMock(side_effect=ContentPolicyViolationError("blocked", "azure", "gpt-4o"))
+
+    msg, outcome = await safe_llm_ainvoke(llm, [], context="followup")
+
+    assert msg is None
+    assert outcome == "policy"
+
+
+def test_content_policy_blocked_part_shape() -> None:
+    part = content_policy_blocked_part(node="followup")
+    assert part["type"] == CONTENT_POLICY_BLOCKED_PART_TYPE
+    assert part["data"]["node"] == "followup"
+    assert part["data"]["message"] == CONTENT_POLICY_USER_MESSAGE
+
+
+def test_user_visible_stream_error_uses_shared_copy() -> None:
+    msg = _user_visible_stream_error(ContentPolicyViolationError("x", "y", "z"), "err-1")
+    assert CONTENT_POLICY_USER_MESSAGE in msg
+    assert LLM_POLICY_BLOCKED_TEXT not in msg
+    assert "Reference: err-1" in msg
+
+
+def test_finalize_chunks_emits_data_part_not_blocked_text() -> None:
+    bridge = _SseBridgeState(
+        message_id="msg-1",
+        thinking_db_id="think-1",
+        input_state={"model_type": "chat-model"},
+    )
+    bridge._final_graph_state = {"content_policy_blocked": True}
+
+    chunks = bridge.finalize_chunks()
+    joined = b"".join(chunks).decode("utf-8")
+
+    assert LLM_POLICY_BLOCKED_TEXT not in joined
+    assert CONTENT_POLICY_BLOCKED_PART_TYPE in joined
+    assert CONTENT_POLICY_USER_MESSAGE in joined
+    assert any(p.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE for p in bridge._db_parts)
+
+
+@pytest.mark.asyncio
+async def test_followup_node_policy_block_sets_state_without_blocked_text() -> None:
+    state = {
+        "model_type": "chat-model",
+        "detected_language": "",
+        "openai_messages": [{"role": "user", "content": "hello"}],
+        "assistant_parts": [{"type": "text", "text": "Main answer"}],
+        "research_packet": "",
+    }
+
+    with (
+        patch.object(followup_module, "get_chat_llm", return_value=MagicMock()),
+        patch.object(
+            followup_module,
+            "safe_llm_ainvoke",
+            AsyncMock(return_value=(None, "policy")),
+        ),
+        patch.object(followup_module, "trim_for_node", side_effect=lambda msgs, **_: msgs),
+        patch.object(followup_module.trace, "get_current_span") as mock_span_getter,
+    ):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_span_getter.return_value = span
+
+        result = await followup_module.followup_node(state)
+
+    assert result["content_policy_blocked"] is True
+    assert result["followup_questions"] == []
+    assert result["assistant_parts"] == state["assistant_parts"]
+    assert not any(
+        (p.get("text") or "").strip() == LLM_POLICY_BLOCKED_TEXT
+        for p in result["assistant_parts"]
+        if isinstance(p, dict)
+    )
+    span.set_attribute.assert_any_call("chatbot.content_policy_blocked", True)
+    span.set_attribute.assert_any_call("chatbot.content_policy_node", "followup")

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -14,12 +14,18 @@ A typical chat request produces this span hierarchy:
 
 Span attributes use opaque IDs only (`chatbot.message_id`, `chatbot.model_type`, `chatbot.intent`). User queries, emails, and tokens are **not** attached to spans.
 
-When a non-streaming node (today: **followup**) is blocked by the provider content filter, the node span may include:
+When the provider blocks a completion under content safety rules, these attributes are set:
 
 | Attribute | When set | Meaning |
 |-----------|----------|---------|
 | `chatbot.content_policy_blocked` | `true` | Provider rejected the completion under content safety rules |
-| `chatbot.content_policy_node` | e.g. `followup` | Graph node where the block occurred |
+| `chatbot.content_policy_node` | e.g. `followup`, `narrator` | Graph node (or `stream`) where the block occurred |
+
+**Where they appear:**
+
+- **`chat.turn`** — after a successful graph run with follow-up policy block, or when streaming fails with `ContentPolicyViolationError` (query all policy blocks on this span in App Insights).
+- **`chatbot.graph.<node>`** — on the node span when that node detected the block (e.g. follow-up via `safe_llm_ainvoke`).
+- **`chatbot.error_id`** — on fatal stream failures (including policy), for support correlation.
 
 **ASGI noise reduction:** Per-chunk `http receive` / `http send` internal spans are disabled. You still get the main server span (e.g. `POST /api/chat`) with total duration and status.
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -14,6 +14,13 @@ A typical chat request produces this span hierarchy:
 
 Span attributes use opaque IDs only (`chatbot.message_id`, `chatbot.model_type`, `chatbot.intent`). User queries, emails, and tokens are **not** attached to spans.
 
+When a non-streaming node (today: **followup**) is blocked by the provider content filter, the node span may include:
+
+| Attribute | When set | Meaning |
+|-----------|----------|---------|
+| `chatbot.content_policy_blocked` | `true` | Provider rejected the completion under content safety rules |
+| `chatbot.content_policy_node` | e.g. `followup` | Graph node where the block occurred |
+
 **ASGI noise reduction:** Per-chunk `http receive` / `http send` internal spans are disabled. You still get the main server span (e.g. `POST /api/chat`) with total duration and status.
 
 ## Deployed (Azure App Service)

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -22,6 +22,12 @@ import {
   buildChartUrlRegexes,
   splitAssistantTextIntoChartSegments,
 } from "@/lib/chart-url";
+import {
+  assistantTextWithoutLegacyPolicyMarker,
+  CONTENT_POLICY_BLOCKED_PART_TYPE,
+  getContentPolicyBlockedFromParts,
+  LEGACY_POLICY_BLOCKED_TEXT,
+} from "@/lib/content-policy";
 import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
@@ -858,7 +864,13 @@ const PurePreviewMessage = ({
     .filter((p): p is { type: "text"; text: string } => p.type === "text")
     .map((p) => p.text)
     .join("\n");
-  const followUps = parseFollowUps(assistantText);
+  const contentPolicyBlocked = getContentPolicyBlockedFromParts(message.parts);
+  const assistantTextForFollowUps = assistantTextWithoutLegacyPolicyMarker(
+    assistantText,
+  );
+  const followUps = contentPolicyBlocked
+    ? []
+    : parseFollowUps(assistantTextForFollowUps);
 
   // Extract quick-answer card from message.parts — persisted through DB so
   // it survives page refreshes and chat history navigation.
@@ -930,8 +942,21 @@ const PurePreviewMessage = ({
             const {
               firstRegularPartIndex,
               thinkingParts: savedThinkingParts,
-              regularParts,
+              regularParts: rawRegularParts,
             } = splitDataThinkingPrefixParts(parts);
+            const regularParts = rawRegularParts.filter((part) => {
+              if (part.type === CONTENT_POLICY_BLOCKED_PART_TYPE) {
+                return false;
+              }
+              if (
+                part.type === "text" &&
+                "text" in part &&
+                (part.text ?? "").trim() === LEGACY_POLICY_BLOCKED_TEXT
+              ) {
+                return false;
+              }
+              return true;
+            });
 
             // Filter out non-renderable stream events from saved thinking parts
             const filteredSavedThinkingParts = savedThinkingParts
@@ -1148,6 +1173,16 @@ const PurePreviewMessage = ({
                       </Sources>
                     );
                   })()}
+
+                {/* Content-policy block on follow-up (or legacy [blocked] marker) */}
+                {message.role === "assistant" && contentPolicyBlocked != null && (
+                  <div
+                    className="mt-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-sm"
+                    data-testid="content-policy-blocked-notice"
+                  >
+                    {contentPolicyBlocked.message}
+                  </div>
+                )}
 
                 {/* Suggested follow-ups: parse from assistant text and render as clickable chips — only after response is complete to avoid distraction during streaming */}
                 {message.role === "assistant" &&

--- a/frontend/lib/__tests__/content-policy.test.ts
+++ b/frontend/lib/__tests__/content-policy.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import {
   assistantTextWithoutLegacyPolicyMarker,
   CONTENT_POLICY_BLOCKED_PART_TYPE,
@@ -17,7 +18,7 @@ describe("getContentPolicyBlockedFromParts", () => {
         },
       },
     ]);
-    expect(result?.message).toBe("Policy blocked message.");
+    assert.equal(result?.message, "Policy blocked message.");
   });
 
   it("detects legacy [blocked] text part", () => {
@@ -25,19 +26,23 @@ describe("getContentPolicyBlockedFromParts", () => {
       { type: "text", text: "Answer" },
       { type: "text", text: LEGACY_POLICY_BLOCKED_TEXT },
     ]);
-    expect(result?.node).toBe("followup");
-    expect(result?.message).toContain("content safety rules");
+    assert.equal(result?.node, "followup");
+    assert.match(result?.message ?? "", /content safety rules/);
   });
 
   it("returns null when no policy marker", () => {
-    expect(getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }])).toBeNull();
+    assert.equal(
+      getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }]),
+      null,
+    );
   });
 });
 
 describe("assistantTextWithoutLegacyPolicyMarker", () => {
   it("removes trailing legacy marker", () => {
-    expect(
+    assert.equal(
       assistantTextWithoutLegacyPolicyMarker("Answer text\n\n[blocked]"),
-    ).toBe("Answer text");
+      "Answer text",
+    );
   });
 });

--- a/frontend/lib/__tests__/content-policy.test.ts
+++ b/frontend/lib/__tests__/content-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantTextWithoutLegacyPolicyMarker,
+  CONTENT_POLICY_BLOCKED_PART_TYPE,
+  getContentPolicyBlockedFromParts,
+  LEGACY_POLICY_BLOCKED_TEXT,
+} from "../content-policy";
+
+describe("getContentPolicyBlockedFromParts", () => {
+  it("returns data part payload when present", () => {
+    const result = getContentPolicyBlockedFromParts([
+      {
+        type: CONTENT_POLICY_BLOCKED_PART_TYPE,
+        data: {
+          node: "followup",
+          message: "Policy blocked message.",
+        },
+      },
+    ]);
+    expect(result?.message).toBe("Policy blocked message.");
+  });
+
+  it("detects legacy [blocked] text part", () => {
+    const result = getContentPolicyBlockedFromParts([
+      { type: "text", text: "Answer" },
+      { type: "text", text: LEGACY_POLICY_BLOCKED_TEXT },
+    ]);
+    expect(result?.node).toBe("followup");
+    expect(result?.message).toContain("content safety rules");
+  });
+
+  it("returns null when no policy marker", () => {
+    expect(getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }])).toBeNull();
+  });
+});
+
+describe("assistantTextWithoutLegacyPolicyMarker", () => {
+  it("removes trailing legacy marker", () => {
+    expect(
+      assistantTextWithoutLegacyPolicyMarker("Answer text\n\n[blocked]"),
+    ).toBe("Answer text");
+  });
+});

--- a/frontend/lib/content-policy.ts
+++ b/frontend/lib/content-policy.ts
@@ -1,0 +1,52 @@
+/** Shared contract with backend `llm_invoke.content_policy_blocked_part`. */
+
+export const CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked" as const;
+
+/** Legacy sentinel persisted before BE-003. */
+export const LEGACY_POLICY_BLOCKED_TEXT = "[blocked]";
+
+export type ContentPolicyBlockedData = {
+  node: string;
+  message: string;
+};
+
+export type ContentPolicyBlockedPart = {
+  type: typeof CONTENT_POLICY_BLOCKED_PART_TYPE;
+  data: ContentPolicyBlockedData;
+};
+
+type MessagePartLike = { type?: string; text?: string; data?: unknown };
+
+export function getContentPolicyBlockedFromParts(
+  parts: MessagePartLike[],
+): ContentPolicyBlockedData | null {
+  const dataPart = parts.find(
+    (p) => p.type === CONTENT_POLICY_BLOCKED_PART_TYPE,
+  );
+  if (dataPart?.data && typeof dataPart.data === "object") {
+    const data = dataPart.data as ContentPolicyBlockedData;
+    if (typeof data.message === "string" && data.message.length > 0) {
+      return data;
+    }
+  }
+
+  const hasLegacyMarker = parts.some(
+    (p) =>
+      p.type === "text" &&
+      (p.text ?? "").trim() === LEGACY_POLICY_BLOCKED_TEXT,
+  );
+  if (hasLegacyMarker) {
+    return {
+      node: "followup",
+      message:
+        "This response is incomplete because the model provider blocked this reply under its content safety rules. Try rephrasing your question, narrowing the topic, or contacting support.",
+    };
+  }
+
+  return null;
+}
+
+/** Strip legacy `[blocked]` tail from assistant text before follow-up parsing. */
+export function assistantTextWithoutLegacyPolicyMarker(text: string): string {
+  return text.replace(/\n*\[blocked\]\s*$/, "").trimEnd();
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -81,6 +81,10 @@ export type CustomUIDataTypes = {
   // Quick-answer visual card — persisted as a message part so it survives
   // page reloads and chat history navigation.
   quickAnswerCard: QuickAnswerCardData;
+  contentPolicyBlocked: {
+    node: string;
+    message: string;
+  };
 };
 
 export type ChatMessage = UIMessage<

--- a/frontend/run.sh
+++ b/frontend/run.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-cd "$(dirname "$0")" && pnpm dev --port 3001
+# cd "$(dirname "$0")" && pnpm dev --port 3001
+cd "$(dirname "$0")" && pnpm install && pnpm build:local && PORT=3001 node .next/standalone/server.js


### PR DESCRIPTION
## Summary

When Azure/content filters block an LLM step (especially follow-up suggestions), the backend previously appended the literal sentinel `"[blocked]"` to message parts. Users saw that string in the chat with no explanation, and operations had no reliable way to query policy blocks on the main turn span.

This PR:

- Replaces the sentinel with a structured `data-contentPolicyBlocked` part and a clear user-facing message.
- Keeps the main answer when only follow-up generation is blocked (non-fatal path).
- Migrates legacy `"[blocked]"` text on reload/stream finalize for backward compatibility.
- Tags **`chat.turn`** (and fatal stream failures) in OpenTelemetry with `chatbot.content_policy_blocked` and `chatbot.content_policy_node` for App Insights / Jaeger queries.

## Problem

- Follow-up LLM calls that hit `ContentPolicyViolationError` produced `LLM_POLICY_BLOCKED_TEXT` (`"[blocked]"`) in persisted/streamed parts.
- Frontend rendered `"[blocked]"` as normal assistant text and could still show follow-up chips.
- Policy blocks were hard to distinguish in telemetry except on individual graph node spans.

## Solution

### Backend

- **`llm_invoke.py`**: `CONTENT_POLICY_USER_MESSAGE`, `content_policy_blocked_part()`, `CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked"`.
- **`followup.py`**: On policy outcome, set graph state flags and record OTel on the node span; do not append `[blocked]` text.
- **`sse_bridge.py`**: Emit structured data part instead of streaming `[blocked]`; migrate legacy markers in `fill_out_dict`; fatal stream errors use the user message for `ContentPolicyViolationError` and tag `chat.turn` via `record_content_policy_on_span`.
- **`graph_stream.py`**: After graph completion, if `content_policy_blocked`, tag the active `chat.turn` span.
- **`state.py`**: `content_policy_blocked`, `content_policy_node` on graph state.
- **`otel_setup.py`**: `record_content_policy_on_span(node)` helper (shared with `record_error_on_span`).

### Frontend

- **`content-policy.ts`**: Detect `data-contentPolicyBlocked` and legacy `[blocked]` text.
- **`message.tsx`**: Inline policy notice; strip legacy marker from narrative; suppress follow-up chips when blocked.
- **`types.ts`**: `contentPolicyBlocked` in custom data types.

### Docs & tests

- **`docs/operations/telemetry.md`**: Documents `chatbot.content_policy_blocked` / `chatbot.content_policy_node` on `chat.turn` and graph node spans.
- **`backend/tests/test_content_policy.py`**, **`frontend/lib/__tests__/content-policy.test.ts`**: Unit coverage for parts, migration, OTel attributes, and UI helpers.

## Behavior

| Scenario | User experience | Telemetry |
|----------|-----------------|-----------|
| Follow-up blocked, main answer OK | Full answer + inline notice; no follow-up chips | `chat.turn` + `chatbot.graph.followup` tagged |
| Fatal policy block during stream | Error with support `error_id` and user message | `chat.turn` tagged with node/stream |
| Old messages with `[blocked]` | Migrated to structured part on reload/finalize | N/A |

## Out of scope

- Extending `safe_llm_ainvoke` policy handling to every graph node (only follow-up + stream path today).
