### PR TITLE
feat: map raw codes, add source mapping, upgrade @pcn-js dependencies, and fix tooltip bug

### DIFF
--- a/frontend/components/data360/compare-countries.tsx
+++ b/frontend/components/data360/compare-countries.tsx
@@ -133,7 +133,7 @@ function SnapshotTable({
                     {entry.claim_id ? (
                       <ClaimMark
                         id={entry.claim_id}
-                        policy={{ type: "rounded", decimals: 2 }}
+                        policy={{ type: "auto" }}
                       >
                         {formatNum(entry.value)}
                       </ClaimMark>
@@ -292,7 +292,7 @@ function TimeSeriesSection({
                               {claimId && value !== null ? (
                                 <ClaimMark
                                   id={claimId}
-                                  policy={{ type: "rounded", decimals: 2 }}
+                                  policy={{ type: "auto" }}
                                 >
                                   {formatNum(value)}
                                 </ClaimMark>

--- a/frontend/components/data360/get-data.tsx
+++ b/frontend/components/data360/get-data.tsx
@@ -329,7 +329,7 @@ export function GetData({
                   {point.REF_AREA && point.REF_AREA !== "_T" && (
                     <span>
                       <span className="font-medium">Area:</span>{" "}
-                      {point.REF_AREA}
+                      {point.REF_AREA_NAME || point.REF_AREA}
                     </span>
                   )}
                   {point.TIME_PERIOD && (
@@ -363,7 +363,7 @@ export function GetData({
                 </span>
                 {point.UNIT_MEASURE && (
                   <span className="text-muted-foreground text-sm">
-                    {point.UNIT_MEASURE}
+                    {point.UNIT_MEASURE_NAME || point.UNIT_MEASURE}
                   </span>
                 )}
               </div>
@@ -550,7 +550,7 @@ export function GetData({
                     </td>
                     <td className="px-3 py-2">
                       {point.REF_AREA && point.REF_AREA !== "_T"
-                        ? point.REF_AREA
+                        ? point.REF_AREA_NAME || point.REF_AREA
                         : "-"}
                     </td>
                     <td className="px-3 py-2">
@@ -575,7 +575,7 @@ export function GetData({
                       </ClaimMark>
                     </td>
                     <td className="px-3 py-2 text-muted-foreground text-[10px]">
-                      {point.UNIT_MEASURE || "-"}
+                      {point.UNIT_MEASURE_NAME || point.UNIT_MEASURE || "-"}
                     </td>
                     <td className="px-3 py-2">
                       <span

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -58,9 +58,11 @@ function RankingHeader({ output }: { output: CompactRankingOutput }) {
 function RankingTable({
   rankings,
   unit,
+  year,
 }: {
   rankings: CompactRankedCountry[];
   unit: string | null;
+  year: string | null;
 }) {
   if (rankings.length === 0) {
     return (
@@ -97,6 +99,9 @@ function RankingTable({
               </th>
               <th className="border-border border-b px-3 py-2 w-28 sr-only">
                 Bar
+              </th>
+              <th className="border-border border-b px-3 py-2 text-right font-medium">
+                Year
               </th>
             </tr>
           </thead>
@@ -148,6 +153,9 @@ function RankingTable({
                         style={{ width: `${barPct}%` }}
                       />
                     </div>
+                  </td>
+                  <td className="px-3 py-2 text-right text-muted-foreground font-mono">
+                    {year ?? "\u2014"}
                   </td>
                 </tr>
               );
@@ -203,7 +211,7 @@ export function RankCountries({ output }: { output: CompactRankingOutput }) {
   return (
     <div className="flex w-full flex-col gap-3 overflow-hidden rounded-sm bg-background px-4 pb-4">
       <RankingHeader output={output} />
-      <RankingTable rankings={output.rankings} unit={output.unit} />
+      <RankingTable rankings={output.rankings} unit={output.unit} year={output.year} />
       <ExcludedFooter
         count={output.excluded_count}
         sample={output.excluded_sample}

--- a/frontend/components/data360/rank-countries.tsx
+++ b/frontend/components/data360/rank-countries.tsx
@@ -138,7 +138,7 @@ function RankingTable({
                     {entry.claim_id ? (
                       <ClaimMark
                         id={entry.claim_id}
-                        policy={{ type: "rounded", decimals: 2 }}
+                        policy={{ type: "auto" }}
                       >
                         {formatNum(entry.value, 2, 4)}
                       </ClaimMark>

--- a/frontend/components/data360/search-indicators.tsx
+++ b/frontend/components/data360/search-indicators.tsx
@@ -31,6 +31,20 @@ type InputQueryGroup = {
   country?: string | null;
 };
 
+function resolveCountry(
+  countryStr: string | null | undefined,
+  countryNames?: Record<string, string> | null,
+): string | undefined {
+  if (!countryStr) return undefined;
+  if (!countryNames) return countryStr;
+
+  const parts = countryStr.split(";").map((part) => {
+    const trimmed = part.trim();
+    return countryNames[trimmed] || trimmed;
+  });
+  return parts.join("; ");
+}
+
 /**
  * For `by_query` layout: prefer the original human-readable country names from
  * `input.query_groups` (e.g. "Japan") over the resolved alpha-3 codes in the
@@ -42,6 +56,7 @@ type InputQueryGroup = {
 function subtitleFromByQuery(
   results: Array<{ query: string; country_code?: string | null }>,
   inputQueryGroups: InputQueryGroup[] | null,
+  countryNames?: Record<string, string> | null,
 ): string | undefined {
   if (!results.length) return undefined;
 
@@ -55,7 +70,8 @@ function subtitleFromByQuery(
       .map((g) => {
         const qs = g.queries ?? (g.query ? [g.query] : []);
         const queryList = qs.join(", ");
-        return g.country ? `${g.country}: ${queryList}` : queryList;
+        const resolvedCountry = resolveCountry(g.country, countryNames);
+        return resolvedCountry ? `${resolvedCountry}: ${queryList}` : queryList;
       });
     return parts.join(" · ") || undefined;
   }
@@ -69,7 +85,8 @@ function subtitleFromByQuery(
   }
   const parts: string[] = [];
   for (const [code, queries] of grouped) {
-    parts.push(code ? `${code}: ${queries.join(", ")}` : queries.join(", "));
+    const resolvedCountry = resolveCountry(code, countryNames);
+    parts.push(resolvedCountry ? `${resolvedCountry}: ${queries.join(", ")}` : queries.join(", "));
   }
   return parts.join(" · ") || undefined;
 }
@@ -78,6 +95,8 @@ function buildSubtitle(
   parsed: Data360SearchToolResult | Data360MultiQuerySearchToolResult,
   input?: Record<string, unknown> | null,
 ): string | undefined {
+  const countryNames = parsed.country_names;
+
   // by_query layout — use input.query_groups for human-readable country names
   if (
     "result_layout" in parsed &&
@@ -91,6 +110,7 @@ function buildSubtitle(
     return subtitleFromByQuery(
       parsed.results as Array<{ query: string; country_code?: string | null }>,
       inputGroups,
+      countryNames,
     );
   }
 
@@ -99,20 +119,22 @@ function buildSubtitle(
   if ("queries" in parsed && Array.isArray(parsed.queries) && parsed.queries.length > 0) {
     const queryPart = parsed.queries.join(" · ");
     // Prefer input country string (human-readable) over the resolved code in output
-    const country =
+    const rawCountry =
       typeof input?.required_country === "string"
         ? input.required_country
         : parsed.required_country;
+    const country = resolveCountry(rawCountry, countryNames);
     return country ? `${queryPart} — ${country}` : queryPart;
   }
 
   // single-query — use input.query and input.required_country directly
   const query =
     typeof input?.query === "string" ? input.query : null;
-  const country =
+  const rawCountry =
     typeof input?.required_country === "string"
       ? input.required_country
       : parsed.required_country;
+  const country = resolveCountry(rawCountry, countryNames);
   if (query && country) return `${query} — ${country}`;
   if (query) return query;
   if (country) return country;
@@ -150,6 +172,7 @@ export function SearchIndicators({ output, input }: SearchIndicatorsProps) {
         const safeGroups = data.results.map((g) => ({
           ...g,
           indicators: g.indicators ?? [],
+          country_name: g.country_code && data.country_names ? (data.country_names[g.country_code] ?? g.country_code) : g.country_code ?? undefined,
         }));
         return (
           <div className="bg-white rounded-xl overflow-hidden shadow-sm border border-gray-100">

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -59,9 +59,18 @@ function AmbiguousDimensionsWarning({ dimensions }: { dimensions: string[] }) {
 }
 
 function GroupKeyPills({ group }: { group: Record<string, string> }) {
+  const displayEntries = Object.entries(group)
+    .filter(([dim]) => dim !== "ref_area_name")
+    .map(([dim, val]) => {
+      if (dim === "ref_area" && group.ref_area_name) {
+        return [dim, group.ref_area_name];
+      }
+      return [dim, val];
+    });
+
   return (
     <div className="flex flex-wrap gap-1">
-      {Object.entries(group).map(([dim, val]) => (
+      {displayEntries.map(([dim, val]) => (
         <span
           key={dim}
           className="inline-flex items-center gap-0.5 rounded bg-muted px-1.5 py-0.5 text-[10px]"
@@ -207,19 +216,19 @@ function GroupCard({
           <div className="font-semibold text-foreground">
             {group.latest.value !== null ? (
               latestClaimId ? (
-                <ClaimMark
-                  id={latestClaimId}
-                  policy={{ type: "rounded", decimals: 2 }}
-                >
-                  <span>
+                <>
+                  <ClaimMark
+                    id={latestClaimId}
+                    policy={{ type: "rounded", decimals: 2 }}
+                  >
                     {formatNum(group.latest.value)}
-                    {unit && (
-                      <span className="ml-1 font-normal text-muted-foreground text-[10px]">
-                        {unit}
-                      </span>
-                    )}
-                  </span>
-                </ClaimMark>
+                  </ClaimMark>
+                  {unit && (
+                    <span className="ml-1 font-normal text-muted-foreground text-[10px]">
+                      {unit}
+                    </span>
+                  )}
+                </>
               ) : (
                 <>
                   {formatNum(group.latest.value)}
@@ -249,19 +258,19 @@ function GroupCard({
             <div className="font-semibold text-foreground">
               {group.earliest.value !== null ? (
                 earliestClaimId ? (
-                  <ClaimMark
-                    id={earliestClaimId}
-                    policy={{ type: "rounded", decimals: 2 }}
-                  >
-                    <span>
+                  <>
+                    <ClaimMark
+                      id={earliestClaimId}
+                      policy={{ type: "rounded", decimals: 2 }}
+                    >
                       {formatNum(group.earliest.value)}
-                      {unit && (
-                        <span className="ml-1 font-normal text-muted-foreground text-[10px]">
-                          {unit}
-                        </span>
-                      )}
-                    </span>
-                  </ClaimMark>
+                    </ClaimMark>
+                    {unit && (
+                      <span className="ml-1 font-normal text-muted-foreground text-[10px]">
+                        {unit}
+                      </span>
+                    )}
+                  </>
                 ) : (
                   <>
                     {formatNum(group.earliest.value)}

--- a/frontend/components/data360/summarize-data.tsx
+++ b/frontend/components/data360/summarize-data.tsx
@@ -154,7 +154,7 @@ function DegenerateTimeSeriesTable({
                   {value !== null && claimId ? (
                     <ClaimMark
                       id={claimId}
-                      policy={{ type: "rounded", decimals: 2 }}
+                      policy={{ type: "auto" }}
                     >
                       {formatNum(value)}
                     </ClaimMark>
@@ -219,7 +219,7 @@ function GroupCard({
                 <>
                   <ClaimMark
                     id={latestClaimId}
-                    policy={{ type: "rounded", decimals: 2 }}
+                    policy={{ type: "auto" }}
                   >
                     {formatNum(group.latest.value)}
                   </ClaimMark>
@@ -261,7 +261,7 @@ function GroupCard({
                   <>
                     <ClaimMark
                       id={earliestClaimId}
-                      policy={{ type: "rounded", decimals: 2 }}
+                      policy={{ type: "auto" }}
                     >
                       {formatNum(group.earliest.value)}
                     </ClaimMark>

--- a/frontend/components/data360/types.ts
+++ b/frontend/components/data360/types.ts
@@ -46,6 +46,7 @@ export type GetDataDataPoint = {
   INDICATOR: string;
   INDICATOR_NAME?: string;
   REF_AREA: string;
+  REF_AREA_NAME?: string;
   SEX: string;
   AGE: string;
   URBANISATION: string;
@@ -55,6 +56,7 @@ export type GetDataDataPoint = {
   TIME_PERIOD: string;
   FREQ: string;
   UNIT_MEASURE: string;
+  UNIT_MEASURE_NAME?: string;
   UNIT_TYPE: string | null;
   claim_id: string;
 };

--- a/frontend/components/elements/response.tsx
+++ b/frontend/components/elements/response.tsx
@@ -133,7 +133,7 @@ function ClaimComponentWithLog(props: ClaimComponentProps) {
       policy: props.policy ?? "—",
     });
   }
-  return <ClaimMarkStreamdown {...props} />;
+  return <ClaimMarkStreamdown {...(props as any)} />;
 }
 
 /** Streamdown uses react-markdown + rehype-raw; custom `claim` is supported at runtime but not in Components type. */

--- a/frontend/lib/data360/sources.ts
+++ b/frontend/lib/data360/sources.ts
@@ -168,6 +168,26 @@ export function getData360SourcesFromParts(
     }
 
     if (
+      type === "tool-data360_rank_countries" ||
+      type === "tool-data360_compare_countries" ||
+      type === "tool-data360_summarize_data"
+    ) {
+      const { databaseId, indicatorId } = readGetDataToolInputIds(part);
+      const title =
+        typeof out.indicator === "string" && out.indicator.trim()
+          ? out.indicator.trim()
+          : indicatorId || databaseId || "Data360 data";
+
+      const key = `${databaseId}:${indicatorId}`;
+      if ((databaseId || indicatorId) && !seen.has(key)) {
+        seen.add(key);
+        const base = appConfig.data360IndicatorBaseUrl.replace(/\/+$/, "");
+        const href = indicatorId ? `${base}/${indicatorId}` : undefined;
+        entries.push({ title, href });
+      }
+    }
+
+    if (
       type === "tool-data360_get_viz_spec" ||
       type === "tool-data360_get_multi_indicator_viz_spec"
     ) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,13 +43,13 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.35.3",
     "@data360/mcp-ui": "0.0.7",
-    "@data360/tool-types": "0.0.4",
+    "@data360/tool-types": "0.0.5",
     "@icons-pack/react-simple-icons": "^13.7.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.200.0",
-    "@pcn-js/core": "^0.1.2",
-    "@pcn-js/data360": "^0.1.4",
-    "@pcn-js/ui": "^0.1.3",
+    "@pcn-js/core": "^0.1.3",
+    "@pcn-js/data360": "^0.1.5",
+    "@pcn-js/ui": "^0.1.4",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-select": "^2.2.6",
@@ -147,7 +147,7 @@
     "overrides": {
       "@data360/chart-payload-normalize": "0.0.2",
       "@data360/mcp-viz-core": "0.0.3",
-      "@data360/tool-types": "0.0.4"
+      "@data360/tool-types": "0.0.5"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@data360/chart-payload-normalize': 0.0.2
   '@data360/mcp-viz-core': 0.0.3
-  '@data360/tool-types': 0.0.4
+  '@data360/tool-types': 0.0.5
 
 importers:
 
@@ -48,10 +48,10 @@ importers:
         version: 6.36.4
       '@data360/mcp-ui':
         specifier: 0.0.7
-        version: 0.0.7(@data360/tool-types@0.0.4)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)
+        version: 0.0.7(@data360/tool-types@0.0.5)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)
       '@data360/tool-types':
-        specifier: 0.0.4
-        version: 0.0.4
+        specifier: 0.0.5
+        version: 0.0.5
       '@icons-pack/react-simple-icons':
         specifier: ^13.7.0
         version: 13.8.0(react@19.0.0-rc-45804af1-20241021)
@@ -62,14 +62,14 @@ importers:
         specifier: ^0.200.0
         version: 0.200.0
       '@pcn-js/core':
-        specifier: ^0.1.2
-        version: 0.1.2
-      '@pcn-js/data360':
-        specifier: ^0.1.4
-        version: 0.1.4(@pcn-js/core@0.1.2)(@pcn-js/ui@0.1.3(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
-      '@pcn-js/ui':
         specifier: ^0.1.3
-        version: 0.1.3(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
+        version: 0.1.3
+      '@pcn-js/data360':
+        specifier: ^0.1.5
+        version: 0.1.5(@pcn-js/core@0.1.3)(@pcn-js/ui@0.1.4(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
+      '@pcn-js/ui':
+        specifier: ^0.1.4
+        version: 0.1.4(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
@@ -547,7 +547,7 @@ packages:
   '@data360/mcp-ui@0.0.7':
     resolution: {integrity: sha512-1DdsYjPRuIe/MekRoGA4c8a6i/7NYsAVbHvGKxCN3mjViFMl7xt7d5ib0uHh6GlGP/3XNbNyAm/dLJJpVFxfjA==}
     peerDependencies:
-      '@data360/tool-types': 0.0.4
+      '@data360/tool-types': 0.0.5
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
       vega: '>=5.0.0'
@@ -557,8 +557,8 @@ packages:
   '@data360/mcp-viz-core@0.0.3':
     resolution: {integrity: sha512-IFi1Nnh/oum9DJPDxxTM1LSvQdjJrQu/O+aJOOuvWR30/kB3QBG/EIsDjXmZBnlw8XoCtqFaq6fBbgDA4D7iGA==}
 
-  '@data360/tool-types@0.0.4':
-    resolution: {integrity: sha512-/wZwQh5qDiu+vQQF6ScBKH+FFf0wI24XT3oeidKoDx9OugNrRcf3Axrt87hmwFu2f++CmsOKQZ4kzlTa8zDzeA==}
+  '@data360/tool-types@0.0.5':
+    resolution: {integrity: sha512-TvhfiZqpxzbG2r3wCkaCD7rv/EWNQyj1gEiSowDgQ2HrrWP+/q+Gg53rrWvfxvbeWdY6gj+6Udbr0qYG5oB3wA==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
@@ -1039,18 +1039,18 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
-  '@pcn-js/core@0.1.2':
-    resolution: {integrity: sha512-8yEZsyeloCYOKETFtR9rPCQYbdxxixp5JHJ9gHaQVJ43TxjPPhX9eC+SUfItl8xA+o80QdBj0uIoLSK+cDXZiQ==}
+  '@pcn-js/core@0.1.3':
+    resolution: {integrity: sha512-KDxAjGwbyIzokkjl0xnO27zeh5V39eKUkYxwjGEx3pIaG4GNMZJydsLSYGFfqlboSyy+3EYSSto1MCMLr5sVbg==}
 
-  '@pcn-js/data360@0.1.4':
-    resolution: {integrity: sha512-H5O45dmtzoHGpA1jhbUWMozMb+9FGD1rSpFe6HAmQlGM7T83+lOZ56wNpK+bFyqr7MywBnxJo+nni3UBjk7GoA==}
+  '@pcn-js/data360@0.1.5':
+    resolution: {integrity: sha512-ATpxFjbKUzRzaw5sy/nno77LU/bOM0nqkpKnv8nW1wxntv01sHz8S9B339GTDVHSqOL6HI/AKpUucFIXp7yfCA==}
     peerDependencies:
-      '@pcn-js/core': '>=0.1.2'
-      '@pcn-js/ui': '>=0.1.3'
+      '@pcn-js/core': '>=0.1.3'
+      '@pcn-js/ui': '>=0.1.4'
       react: '>=18.0.0'
 
-  '@pcn-js/ui@0.1.3':
-    resolution: {integrity: sha512-c2AUef2fbVc4hXW/lnzFqgmbfoz6giJmygvNGbZLNvAFqEWFZ7Cgy88G/WbuTaGeFLwcvJLt/f5YH+EEhEL8ew==}
+  '@pcn-js/ui@0.1.4':
+    resolution: {integrity: sha512-eCsiuZpnwouj/iKgjc5TH3fpufSo4m179GyXPtHk8qy/wjOauudkbwv4dc0GygrVc4qEnUlkMCfI3yavgHHAXQ==}
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
@@ -4779,11 +4779,11 @@ snapshots:
 
   '@data360/chart-payload-normalize@0.0.2': {}
 
-  '@data360/mcp-ui@0.0.7(@data360/tool-types@0.0.4)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)':
+  '@data360/mcp-ui@0.0.7(@data360/tool-types@0.0.5)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)(vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1))(vega-lite@5.23.0(vega@5.33.1))(vega@5.33.1)':
     dependencies:
       '@data360/chart-payload-normalize': 0.0.2
       '@data360/mcp-viz-core': 0.0.3
-      '@data360/tool-types': 0.0.4
+      '@data360/tool-types': 0.0.5
       html-to-image: 1.11.13
       react: 19.0.0-rc-45804af1-20241021
       react-dom: 19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021)
@@ -4793,7 +4793,7 @@ snapshots:
 
   '@data360/mcp-viz-core@0.0.3': {}
 
-  '@data360/tool-types@0.0.4':
+  '@data360/tool-types@0.0.5':
     dependencies:
       zod: 3.25.76
 
@@ -5153,20 +5153,20 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
-  '@pcn-js/core@0.1.2':
+  '@pcn-js/core@0.1.3':
     dependencies:
       cheerio: 1.2.0
       domhandler: 5.0.3
 
-  '@pcn-js/data360@0.1.4(@pcn-js/core@0.1.2)(@pcn-js/ui@0.1.3(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)':
+  '@pcn-js/data360@0.1.5(@pcn-js/core@0.1.3)(@pcn-js/ui@0.1.4(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)':
     dependencies:
-      '@pcn-js/core': 0.1.2
-      '@pcn-js/ui': 0.1.3(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
+      '@pcn-js/core': 0.1.3
+      '@pcn-js/ui': 0.1.4(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)
       react: 19.0.0-rc-45804af1-20241021
 
-  '@pcn-js/ui@0.1.3(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)':
+  '@pcn-js/ui@0.1.4(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021)':
     dependencies:
-      '@pcn-js/core': 0.1.2
+      '@pcn-js/core': 0.1.3
       react: 19.0.0-rc-45804af1-20241021
       react-dom: 19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021)
 


### PR DESCRIPTION
### Summary
This PR maps raw codes to human-readable names across search, ranking, comparison, and summarization frontend widgets. It also upgrades the package dependencies to use the newly published npm packages, maps widgets to the sources list, and resolves the tooltips rendering bug.

### Details
- **Raw Code Mapping**: Map raw codes (e.g. `REF_AREA`, `UNIT_MEASURE`, and group codes) to human-readable display names in search accordions, country lists, and comparison widgets.
- **Source Tracking**: Add sources mapping parser in `sources.ts` to extract indicator information from ranking, comparison, and summarization outputs, allowing `Used X sources` to populate correctly in chat responses.
- **Dependency Upgrades**: Bump `@pcn-js/core` to `^0.1.3`, `@pcn-js/ui` to `^0.1.4`, `@pcn-js/data360` to `^0.1.5`, and `@data360/tool-types` to `0.0.5`.
- **ClaimMark Tooltip Fix**: Move unit rendering spans outside of the `ClaimMark` component inside `summarize-data.tsx` to prevent `Displayed [object Object]` rendering in tooltips and allow correct numeric matching verification.


**SCREENSHOTS**
Indicator (with ... and expanded), Unit and Country in human readable format.
<img width="780" height="236" alt="image" src="https://github.com/user-attachments/assets/1535bcb3-8488-4514-b7dc-991967d5574b" />
Used Sources on ranking, comparison, summarize data
<img width="780" height="501" alt="image" src="https://github.com/user-attachments/assets/81339f0c-f59e-46c8-b088-0cf1b8c128de" />
Summarize data correct claim tags (auto match)
<img width="780" height="402" alt="image" src="https://github.com/user-attachments/assets/3d4af8a3-7e4c-4192-b50a-c50c2305305a" />
