### PR TITLE
fix(chat - docs): replace [blocked] with structured content-policy UX and chat.turn telemetry

### DIFF
--- a/backend/app/ai/graph/llm_invoke.py
+++ b/backend/app/ai/graph/llm_invoke.py
@@ -19,8 +19,25 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+CONTENT_POLICY_USER_MESSAGE = (
+    "This response is incomplete because the model provider blocked this reply under its content safety rules. "
+    "Try rephrasing your question, narrowing the topic, or contacting support."
+)
+
+# Legacy sentinel persisted before BE-003; kept for reload/migration detection only.
 LLM_POLICY_BLOCKED_TEXT = "[blocked]"
+
+CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked"
+
 LLM_STEP_FAILED_TEXT = "Sorry, this step could not be completed. Please try again in a moment."
+
+
+def content_policy_blocked_part(*, node: str) -> dict:
+    """Persisted/streamed part marking a non-fatal content-policy block."""
+    return {
+        "type": CONTENT_POLICY_BLOCKED_PART_TYPE,
+        "data": {"node": node, "message": CONTENT_POLICY_USER_MESSAGE},
+    }
 
 
 def assistant_text_part(text: str) -> dict:

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -10,11 +10,11 @@ import logging
 import re
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
-from opentelemetry import trace
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_followup_system_prompt
 from app.config import ModelType
+from app.observability.otel_setup import record_content_policy_on_span
 
 from ..llm_factory import get_chat_llm
 from ..llm_invoke import LLM_STEP_FAILED_TEXT, assistant_text_part, safe_llm_ainvoke
@@ -110,15 +110,13 @@ async def followup_node(state: ChatPipelineState) -> dict:
     existing_parts: list[dict] = state.get("assistant_parts", [])
 
     if outcome == "policy":
-        span = trace.get_current_span()
-        if span.is_recording():
-            span.set_attribute("chatbot.content_policy_blocked", True)
-            span.set_attribute("chatbot.content_policy_node", "followup")
+        record_content_policy_on_span("followup")
         return {
             "followup_questions": [],
             "assistant_parts": existing_parts,
             "final_usage": None,
             "content_policy_blocked": True,
+            "content_policy_node": "followup",
         }
 
     if outcome != "ok":

--- a/backend/app/ai/graph/nodes/followup.py
+++ b/backend/app/ai/graph/nodes/followup.py
@@ -10,18 +10,14 @@ import logging
 import re
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from opentelemetry import trace
 
 from app.ai.observability.token_usage import append_llm_usage_fallback
 from app.ai.prompts import get_followup_system_prompt
 from app.config import ModelType
 
 from ..llm_factory import get_chat_llm
-from ..llm_invoke import (
-    LLM_POLICY_BLOCKED_TEXT,
-    LLM_STEP_FAILED_TEXT,
-    assistant_text_part,
-    safe_llm_ainvoke,
-)
+from ..llm_invoke import LLM_STEP_FAILED_TEXT, assistant_text_part, safe_llm_ainvoke
 from ..memory import trim_for_node
 from ..message_utils import openai_to_langchain, plain_text_from_ai_message_content
 from ..state import ChatPipelineState
@@ -114,9 +110,13 @@ async def followup_node(state: ChatPipelineState) -> dict:
     existing_parts: list[dict] = state.get("assistant_parts", [])
 
     if outcome == "policy":
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("chatbot.content_policy_blocked", True)
+            span.set_attribute("chatbot.content_policy_node", "followup")
         return {
             "followup_questions": [],
-            "assistant_parts": existing_parts + [assistant_text_part(LLM_POLICY_BLOCKED_TEXT)],
+            "assistant_parts": existing_parts,
             "final_usage": None,
             "content_policy_blocked": True,
         }

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -65,6 +65,7 @@ from app.ai.protocols.stream import (
     ToolInputStartPart,
     ToolOutputAvailablePart,
 )
+from app.observability.otel_setup import record_content_policy_on_span, record_error_on_span
 from app.utils.error_id import USER_MESSAGE_GENERIC, new_error_id
 
 from .llm_invoke import (
@@ -217,6 +218,7 @@ class _SseBridgeState:
         "_preprocessing_run_ids",
         "_answer_run_stream_acc",
         "_prepend_sep_before_next_answer_delta",
+        "_last_langgraph_node",
     )
 
     def __init__(
@@ -257,6 +259,7 @@ class _SseBridgeState:
         # After narrator (or any visible answer), the next answer node (e.g. followup)
         # must not concatenate flush against the prior character (e.g. "estimate---").
         self._prepend_sep_before_next_answer_delta: bool = False
+        self._last_langgraph_node: str = ""
 
     def _node_progress_chunks(
         self,
@@ -436,6 +439,8 @@ class _SseBridgeState:
         metadata: dict = event.get("metadata", {})
         data: dict = event.get("data", {})
         node: str = metadata.get("langgraph_node", "")
+        if node:
+            self._last_langgraph_node = node
 
         if evt_type == "on_chain_start" and evt_name in _THINKING_NODES:
             stage_bytes = self.make_stage_sse("interpreting")
@@ -829,6 +834,11 @@ class _SseBridgeState:
                 self._final_graph_state.get("summarized_message_count") or 0
             )
             out["quick_answer_card"] = self._final_graph_state.get("quick_answer_card")
+            if self._final_graph_state.get("content_policy_blocked"):
+                out["content_policy_blocked"] = True
+                out["content_policy_node"] = (
+                    self._final_graph_state.get("content_policy_node") or "followup"
+                )
             # Merge agent trace parts into db_parts for persistence
             trace_parts = self._final_graph_state.get("agent_trace_parts") or []
             if trace_parts:
@@ -902,6 +912,9 @@ async def stream_graph_to_sse(
                         root = _root_cause(graph_exc)
                         err_id = new_error_id()
                         log_pipeline_error(message_id=message_id, error_id=err_id, exc=root)
+                        if isinstance(root, ContentPolicyViolationError):
+                            record_content_policy_on_span(br._last_langgraph_node or "stream")
+                        record_error_on_span(err_id)
                         logger.warning(
                             "Graph SSE stream failed [%s]: %s",
                             err_id,

--- a/backend/app/ai/graph/sse_bridge.py
+++ b/backend/app/ai/graph/sse_bridge.py
@@ -67,7 +67,13 @@ from app.ai.protocols.stream import (
 )
 from app.utils.error_id import USER_MESSAGE_GENERIC, new_error_id
 
-from .llm_invoke import LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT
+from .llm_invoke import (
+    CONTENT_POLICY_BLOCKED_PART_TYPE,
+    CONTENT_POLICY_USER_MESSAGE,
+    LLM_POLICY_BLOCKED_TEXT,
+    LLM_STEP_FAILED_TEXT,
+    content_policy_blocked_part,
+)
 from .message_utils import plain_text_from_ai_message_content
 
 try:
@@ -111,10 +117,7 @@ def _root_cause(exc: BaseException) -> BaseException:
 def _user_visible_stream_error(root: BaseException, error_id: str) -> str:
     ref = f" Reference: {error_id}."
     if isinstance(root, ContentPolicyViolationError):
-        return (
-            "The model provider blocked this reply under its content safety rules. "
-            "Try rephrasing your question or narrowing the topic."
-        ) + ref
+        return CONTENT_POLICY_USER_MESSAGE + ref
     return USER_MESSAGE_GENERIC + ref
 
 
@@ -741,13 +744,20 @@ class _SseBridgeState:
         if isinstance(self._final_graph_state, dict) and self._final_graph_state.get(
             "content_policy_blocked"
         ):
-            blocked_id = f"followup-blocked-{self.message_id}"
-            for part in (
-                TextStartPart(id=blocked_id),
-                TextDeltaPart(id=blocked_id, delta=LLM_POLICY_BLOCKED_TEXT),
-                TextEndPart(id=blocked_id),
+            policy_part = content_policy_blocked_part(node="followup")
+            chunks.append(
+                DataPart(
+                    type=CONTENT_POLICY_BLOCKED_PART_TYPE,
+                    data=policy_part["data"],
+                )
+                .to_sse()
+                .encode("utf-8")
+            )
+            if not any(
+                isinstance(x, dict) and x.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE
+                for x in self._db_parts
             ):
-                chunks.append(part.to_sse().encode("utf-8"))
+                self._db_parts.append(policy_part)
         # Emit data-quickAnswerCard payload for the frontend card renderer.
         # Type matches the CustomUIDataTypes key 'quickAnswerCard' with the 'data-' prefix
         # that the AI SDK uses to map DataParts to message.parts — enabling persistence.
@@ -823,13 +833,20 @@ class _SseBridgeState:
             trace_parts = self._final_graph_state.get("agent_trace_parts") or []
             if trace_parts:
                 self._db_parts.extend(trace_parts)
-            # Non-streaming follow-up may only exist on graph state — persist short markers
+            # Non-streaming follow-up failure markers may only exist on graph state.
             assistant_tail = self._final_graph_state.get("assistant_parts") or []
             for p in assistant_tail:
                 if not isinstance(p, dict) or p.get("type") != "text":
                     continue
                 tx = (p.get("text") or "").strip()
-                if tx not in (LLM_POLICY_BLOCKED_TEXT, LLM_STEP_FAILED_TEXT):
+                if tx == LLM_POLICY_BLOCKED_TEXT:
+                    if not any(
+                        isinstance(x, dict) and x.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE
+                        for x in self._db_parts
+                    ):
+                        self._db_parts.append(content_policy_blocked_part(node="followup"))
+                    continue
+                if tx != LLM_STEP_FAILED_TEXT:
                     continue
                 if any(
                     isinstance(x, dict)

--- a/backend/app/ai/graph/state.py
+++ b/backend/app/ai/graph/state.py
@@ -66,7 +66,8 @@ class ChatPipelineState(TypedDict):
     summarized_message_count: NotRequired[int]
     # Follow-up questions generated post-narrator
     followup_questions: NotRequired[list[str]]
-    # Set when followup (or another node) surfaces LLM_POLICY_BLOCKED_TEXT under policy
+    # Set when a node hits provider content-policy (e.g. followup LLM call)
     content_policy_blocked: NotRequired[bool]
+    content_policy_node: NotRequired[str]
     # Internal agent outputs for debugging/analytics
     agent_trace_parts: NotRequired[list[dict]]

--- a/backend/app/api/v1/utils/graph_stream.py
+++ b/backend/app/api/v1/utils/graph_stream.py
@@ -22,6 +22,7 @@ from app.ai.protocols.stream import (
     TextEndPart,
     TextStartPart,
 )
+from app.observability.otel_setup import record_content_policy_on_span
 from app.utils.resumable_stream import store_stream_chunk
 
 logger = logging.getLogger(__name__)
@@ -194,4 +195,7 @@ async def stream_chat_graph_sse(
             assistant_row_id=assistant_row_id,
         ):
             yield sse_bytes
+        if graph_out.get("content_policy_blocked"):
+            policy_node = str(graph_out.get("content_policy_node") or "followup")
+            record_content_policy_on_span(policy_node)
     logger.info("[graph_stream] stream_graph_to_sse done")

--- a/backend/app/observability/__init__.py
+++ b/backend/app/observability/__init__.py
@@ -6,6 +6,7 @@ from app.observability.otel_setup import (
     instrument_fastapi_app,
     instrument_httpx_outbound,
     is_tracing_enabled,
+    record_content_policy_on_span,
     record_error_on_span,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "instrument_fastapi_app",
     "instrument_httpx_outbound",
     "is_tracing_enabled",
+    "record_content_policy_on_span",
     "record_error_on_span",
 ]

--- a/backend/app/observability/otel_setup.py
+++ b/backend/app/observability/otel_setup.py
@@ -218,19 +218,44 @@ def instrument_fastapi_app(app: object) -> None:
         _logger.warning("opentelemetry-instrumentation-fastapi not available.")
 
 
-def record_error_on_span(error_id: str) -> None:
-    """Attach support reference ID to the current span when recording."""
-    if not error_id:
-        return
+def _recording_span():
+    """Return the active span if it is recording, else None."""
     try:
         from opentelemetry import trace  # noqa: PLC0415
 
         span = trace.get_current_span()
         if span is None:
-            return
+            return None
         is_recording = getattr(span, "is_recording", None)
         if callable(is_recording) and not is_recording():
-            return
-        span.set_attribute("chatbot.error_id", error_id)
+            return None
+        return span
+    except Exception:
+        return None
+
+
+def record_content_policy_on_span(node: str) -> None:
+    """Mark the current span (e.g. ``chat.turn`` or a graph node) as policy-blocked."""
+    if not node:
+        node = "unknown"
+    span = _recording_span()
+    if span is None:
+        return
+    try:
+        cast("Any", span).set_attribute("chatbot.content_policy_blocked", True)
+        cast("Any", span).set_attribute("chatbot.content_policy_node", node)
+    except Exception:
+        pass
+
+
+def record_error_on_span(error_id: str) -> None:
+    """Attach support reference ID to the current span when recording."""
+    if not error_id:
+        return
+    span = _recording_span()
+    if span is None:
+        return
+    try:
+        cast("Any", span).set_attribute("chatbot.error_id", error_id)
     except Exception:
         pass

--- a/backend/tests/test_content_policy.py
+++ b/backend/tests/test_content_policy.py
@@ -18,6 +18,7 @@ from app.ai.graph.llm_invoke import (
 )
 from app.ai.graph.nodes import followup as followup_module
 from app.ai.graph.sse_bridge import _SseBridgeState, _user_visible_stream_error
+from app.observability.otel_setup import record_content_policy_on_span
 
 
 @pytest.mark.asyncio
@@ -80,15 +81,15 @@ async def test_followup_node_policy_block_sets_state_without_blocked_text() -> N
             AsyncMock(return_value=(None, "policy")),
         ),
         patch.object(followup_module, "trim_for_node", side_effect=lambda msgs, **_: msgs),
-        patch.object(followup_module.trace, "get_current_span") as mock_span_getter,
+        patch.object(
+            followup_module,
+            "record_content_policy_on_span",
+        ) as mock_record_policy,
     ):
-        span = MagicMock()
-        span.is_recording.return_value = True
-        mock_span_getter.return_value = span
-
         result = await followup_module.followup_node(state)
 
     assert result["content_policy_blocked"] is True
+    assert result["content_policy_node"] == "followup"
     assert result["followup_questions"] == []
     assert result["assistant_parts"] == state["assistant_parts"]
     assert not any(
@@ -96,5 +97,13 @@ async def test_followup_node_policy_block_sets_state_without_blocked_text() -> N
         for p in result["assistant_parts"]
         if isinstance(p, dict)
     )
+    mock_record_policy.assert_called_once_with("followup")
+
+
+def test_record_content_policy_on_span_sets_attributes() -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+    with patch("app.observability.otel_setup._recording_span", return_value=span):
+        record_content_policy_on_span("narrator")
     span.set_attribute.assert_any_call("chatbot.content_policy_blocked", True)
-    span.set_attribute.assert_any_call("chatbot.content_policy_node", "followup")
+    span.set_attribute.assert_any_call("chatbot.content_policy_node", "narrator")

--- a/backend/tests/test_content_policy.py
+++ b/backend/tests/test_content_policy.py
@@ -1,0 +1,100 @@
+"""Tests for content-policy violation handling (BE-003)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from litellm.exceptions import ContentPolicyViolationError
+except ImportError:  # pragma: no cover
+    ContentPolicyViolationError = Exception  # type: ignore[misc, assignment]
+
+from app.ai.graph.llm_invoke import (
+    CONTENT_POLICY_BLOCKED_PART_TYPE,
+    CONTENT_POLICY_USER_MESSAGE,
+    LLM_POLICY_BLOCKED_TEXT,
+    content_policy_blocked_part,
+    safe_llm_ainvoke,
+)
+from app.ai.graph.nodes import followup as followup_module
+from app.ai.graph.sse_bridge import _SseBridgeState, _user_visible_stream_error
+
+
+@pytest.mark.asyncio
+async def test_safe_llm_ainvoke_returns_policy_outcome() -> None:
+    llm = MagicMock()
+    llm.ainvoke = AsyncMock(side_effect=ContentPolicyViolationError("blocked", "azure", "gpt-4o"))
+
+    msg, outcome = await safe_llm_ainvoke(llm, [], context="followup")
+
+    assert msg is None
+    assert outcome == "policy"
+
+
+def test_content_policy_blocked_part_shape() -> None:
+    part = content_policy_blocked_part(node="followup")
+    assert part["type"] == CONTENT_POLICY_BLOCKED_PART_TYPE
+    assert part["data"]["node"] == "followup"
+    assert part["data"]["message"] == CONTENT_POLICY_USER_MESSAGE
+
+
+def test_user_visible_stream_error_uses_shared_copy() -> None:
+    msg = _user_visible_stream_error(ContentPolicyViolationError("x", "y", "z"), "err-1")
+    assert CONTENT_POLICY_USER_MESSAGE in msg
+    assert LLM_POLICY_BLOCKED_TEXT not in msg
+    assert "Reference: err-1" in msg
+
+
+def test_finalize_chunks_emits_data_part_not_blocked_text() -> None:
+    bridge = _SseBridgeState(
+        message_id="msg-1",
+        thinking_db_id="think-1",
+        input_state={"model_type": "chat-model"},
+    )
+    bridge._final_graph_state = {"content_policy_blocked": True}
+
+    chunks = bridge.finalize_chunks()
+    joined = b"".join(chunks).decode("utf-8")
+
+    assert LLM_POLICY_BLOCKED_TEXT not in joined
+    assert CONTENT_POLICY_BLOCKED_PART_TYPE in joined
+    assert CONTENT_POLICY_USER_MESSAGE in joined
+    assert any(p.get("type") == CONTENT_POLICY_BLOCKED_PART_TYPE for p in bridge._db_parts)
+
+
+@pytest.mark.asyncio
+async def test_followup_node_policy_block_sets_state_without_blocked_text() -> None:
+    state = {
+        "model_type": "chat-model",
+        "detected_language": "",
+        "openai_messages": [{"role": "user", "content": "hello"}],
+        "assistant_parts": [{"type": "text", "text": "Main answer"}],
+        "research_packet": "",
+    }
+
+    with (
+        patch.object(followup_module, "get_chat_llm", return_value=MagicMock()),
+        patch.object(
+            followup_module,
+            "safe_llm_ainvoke",
+            AsyncMock(return_value=(None, "policy")),
+        ),
+        patch.object(followup_module, "trim_for_node", side_effect=lambda msgs, **_: msgs),
+        patch.object(followup_module.trace, "get_current_span") as mock_span_getter,
+    ):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_span_getter.return_value = span
+
+        result = await followup_module.followup_node(state)
+
+    assert result["content_policy_blocked"] is True
+    assert result["followup_questions"] == []
+    assert result["assistant_parts"] == state["assistant_parts"]
+    assert not any(
+        (p.get("text") or "").strip() == LLM_POLICY_BLOCKED_TEXT
+        for p in result["assistant_parts"]
+        if isinstance(p, dict)
+    )
+    span.set_attribute.assert_any_call("chatbot.content_policy_blocked", True)
+    span.set_attribute.assert_any_call("chatbot.content_policy_node", "followup")

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -14,12 +14,18 @@ A typical chat request produces this span hierarchy:
 
 Span attributes use opaque IDs only (`chatbot.message_id`, `chatbot.model_type`, `chatbot.intent`). User queries, emails, and tokens are **not** attached to spans.
 
-When a non-streaming node (today: **followup**) is blocked by the provider content filter, the node span may include:
+When the provider blocks a completion under content safety rules, these attributes are set:
 
 | Attribute | When set | Meaning |
 |-----------|----------|---------|
 | `chatbot.content_policy_blocked` | `true` | Provider rejected the completion under content safety rules |
-| `chatbot.content_policy_node` | e.g. `followup` | Graph node where the block occurred |
+| `chatbot.content_policy_node` | e.g. `followup`, `narrator` | Graph node (or `stream`) where the block occurred |
+
+**Where they appear:**
+
+- **`chat.turn`** — after a successful graph run with follow-up policy block, or when streaming fails with `ContentPolicyViolationError` (query all policy blocks on this span in App Insights).
+- **`chatbot.graph.<node>`** — on the node span when that node detected the block (e.g. follow-up via `safe_llm_ainvoke`).
+- **`chatbot.error_id`** — on fatal stream failures (including policy), for support correlation.
 
 **ASGI noise reduction:** Per-chunk `http receive` / `http send` internal spans are disabled. You still get the main server span (e.g. `POST /api/chat`) with total duration and status.
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -14,6 +14,13 @@ A typical chat request produces this span hierarchy:
 
 Span attributes use opaque IDs only (`chatbot.message_id`, `chatbot.model_type`, `chatbot.intent`). User queries, emails, and tokens are **not** attached to spans.
 
+When a non-streaming node (today: **followup**) is blocked by the provider content filter, the node span may include:
+
+| Attribute | When set | Meaning |
+|-----------|----------|---------|
+| `chatbot.content_policy_blocked` | `true` | Provider rejected the completion under content safety rules |
+| `chatbot.content_policy_node` | e.g. `followup` | Graph node where the block occurred |
+
 **ASGI noise reduction:** Per-chunk `http receive` / `http send` internal spans are disabled. You still get the main server span (e.g. `POST /api/chat`) with total duration and status.
 
 ## Deployed (Azure App Service)

--- a/frontend/app/about/layout.tsx
+++ b/frontend/app/about/layout.tsx
@@ -1,0 +1,18 @@
+import { Open_Sans } from "next/font/google";
+import "@/components/mcp-docs/mcp-docs-theme.css";
+
+const openSans = Open_Sans({
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "600", "700"],
+});
+
+export default function AboutLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <div className={`${openSans.className} min-h-0 flex-1 overflow-y-auto`}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/about/mcp/page.tsx
+++ b/frontend/app/about/mcp/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { McpDocsPage } from "@/components/mcp-docs/mcp-docs-page";
+import { appConfig } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: `MCP Server | ${appConfig.metadata.title}`,
+  description:
+    "Data360 MCP server — World Bank indicators, metadata, and charts for Cursor, VS Code, and custom clients.",
+};
+
+export default function AboutMcpPage() {
+  return <McpDocsPage />;
+}

--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -50,5 +50,17 @@
         "noSvgWithoutTitle": "off"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["components/mcp-docs/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useUniqueElementIds": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/frontend/components/mcp-docs/mcp-docs-code-snippet.tsx
+++ b/frontend/components/mcp-docs/mcp-docs-code-snippet.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useState } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+type McpDocsCodeSnippetProps = {
+  code: string;
+  language?: string;
+};
+
+export function McpDocsCodeSnippet({
+  code,
+  language = "json",
+}: McpDocsCodeSnippetProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="mcp-docs-code-wrap">
+      <button aria-label="Copy code" onClick={copy} type="button">
+        {copied ? <CheckIcon size={14} /> : <CopyIcon size={14} />}
+      </button>
+      <div>
+        <SyntaxHighlighter language={language} style={oneDark}>
+          {code}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/mcp-docs/mcp-docs-connect-section.tsx
+++ b/frontend/components/mcp-docs/mcp-docs-connect-section.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { McpDocsCodeSnippet } from "./mcp-docs-code-snippet";
+import {
+  CONNECT_SECTION_INTRO,
+  EXAMPLE_DATABASES,
+  LANGGRAPH_ENV,
+  MCP_ENDPOINTS,
+  MCP_JSON_CLAUDE,
+  MCP_JSON_CURSOR,
+  MCP_JSON_LOCAL,
+} from "./mcp-docs-content";
+
+const CLIENT_TABS = [
+  { id: "cursor", label: "Cursor / VS Code", code: MCP_JSON_CURSOR },
+  { id: "claude", label: "Claude Desktop", code: MCP_JSON_CLAUDE },
+  { id: "local", label: "Local server", code: MCP_JSON_LOCAL },
+] as const;
+
+export function McpDocsConnectSection() {
+  const [activeTab, setActiveTab] =
+    useState<(typeof CLIENT_TABS)[number]["id"]>("cursor");
+
+  const activeCode =
+    CLIENT_TABS.find((t) => t.id === activeTab)?.code ?? MCP_JSON_CURSOR;
+
+  return (
+    <section
+      aria-labelledby="connect-heading"
+      className="section section--in-technical"
+      id="connect"
+    >
+      <h3 className="section__title" id="connect-heading">
+        Connect your agent
+      </h3>
+
+      <p className="section__intro">
+        {CONNECT_SECTION_INTRO} <a href="#data360-chat">Data360 Chat</a>
+      </p>
+
+      <div className="connect-steps">
+        <article className="connect-step">
+          <h3 className="connect-step__title">1. Choose an endpoint</h3>
+          <p className="section__intro">
+            Use streamable HTTP at the <code>/mcp</code> path (default). For
+            SSE, set <code>MCP_TRANSPORT=sse</code> on the server and point
+            clients at <code>/sse</code> (example:{" "}
+            <code>http://localhost:8021/sse</code>). Other org-specific hosts
+            and paths are documented in the{" "}
+            <a
+              href="https://github.com/worldbank/data360-mcp"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              GitHub repository
+            </a>
+            .
+          </p>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Environment</th>
+                  <th scope="col">HTTP URL</th>
+                </tr>
+              </thead>
+              <tbody>
+                {MCP_ENDPOINTS.map((row) => (
+                  <tr key={row.url}>
+                    <td>{row.environment}</td>
+                    <td>
+                      <code>{row.url}</code>
+                      {row.note ? (
+                        <p className="panel__text">{row.note}</p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">2. Configure your MCP client</h3>
+          <p className="section__intro">
+            Add the server to your client config. Streamable HTTP (
+            <code>type: &quot;http&quot;</code>) is the recommended transport
+            for Cursor and compatible hosts.
+          </p>
+          <div
+            aria-label="MCP client configuration examples"
+            className="connect-tabs"
+            role="tablist"
+          >
+            {CLIENT_TABS.map((tab) => (
+              <button
+                aria-selected={activeTab === tab.id}
+                className={
+                  activeTab === tab.id
+                    ? "connect-tab connect-tab--active"
+                    : "connect-tab"
+                }
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                role="tab"
+                type="button"
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div role="tabpanel">
+            <McpDocsCodeSnippet code={activeCode} language="json" />
+          </div>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">
+            3. Load MCP resources in your agent
+          </h3>
+          <ol className="connect-step__list">
+            <li>
+              Subscribe to <code>data360://system-prompt</code> in your agent
+              system context (required for reliable tool use).
+            </li>
+            <li>
+              Optionally load <code>data360://search-usage</code> and{" "}
+              <code>data360://codelists</code> for discovery and code
+              resolution.
+            </li>
+            <li>
+              Tables: search → get_disaggregation (optional) → get_data. Charts:
+              search → get_disaggregation → get_viz_spec (fetches its own data).
+            </li>
+          </ol>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">
+            4. Authentication (hosted / APIM)
+          </h3>
+          <p className="section__intro">
+            World Bank–hosted endpoints may require a Bearer token or Azure AD
+            client credentials. On the server, set{" "}
+            <code>MCP_INTERNAL=true</code> and <code>MCP_AUTH_SCOPE</code> for
+            APIM; clients may pass an <code>Authorization</code> header in{" "}
+            <code>mcp.json</code> when required. See{" "}
+            <a
+              href="https://github.com/worldbank/data360-mcp/blob/main/DEVELOPMENT.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              DEVELOPMENT.md
+            </a>{" "}
+            for environment-specific setup (not covered here).
+          </p>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">5. Verify the connection</h3>
+          <p className="section__intro">
+            Use the{" "}
+            <a
+              href="https://modelcontextprotocol.io"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              MCP Inspector
+            </a>{" "}
+            or your IDE&apos;s MCP panel to list tools. From the repo:{" "}
+            <code>scripts/test_mcp_client.py</code> (
+            <a
+              href="https://github.com/worldbank/data360-mcp"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              data360-mcp on GitHub
+            </a>
+            ).
+          </p>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">6. Docker and containers</h3>
+          <p className="section__intro">
+            From a container, use <code>host.docker.internal</code> instead of{" "}
+            <code>localhost</code> to reach an MCP server on the host machine.
+          </p>
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">7. LangGraph / Python agents</h3>
+          <p className="section__intro">
+            Set environment variables before running your agent (see{" "}
+            <code>data360-mcp-agent</code> package in the repo):
+          </p>
+          <McpDocsCodeSnippet code={LANGGRAPH_ENV} language="bash" />
+        </article>
+
+        <article className="connect-step">
+          <h3 className="connect-step__title">8. Self-host locally</h3>
+          <p className="section__intro">
+            Install and run the server on your machine: see the{" "}
+            <a
+              href="https://github.com/worldbank/data360-mcp#readme"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              GitHub README
+            </a>
+            .
+          </p>
+        </article>
+
+        <div className="connect-panel">
+          <h3 className="connect-step__title">Databases (examples)</h3>
+          <p className="connect-panel__text">
+            All Data360 databases are supported; list indicators with{" "}
+            <code>data360_list_indicators</code>.
+          </p>
+          <ul className="connect-panel__list">
+            {EXAMPLE_DATABASES.map((db) => (
+              <li key={db.id}>
+                <strong>{db.id}</strong> — {db.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/mcp-docs/mcp-docs-content.ts
+++ b/frontend/components/mcp-docs/mcp-docs-content.ts
@@ -1,0 +1,284 @@
+export type NavLink = { href: string; label: string };
+
+export const MCP_DOCS_NAV: NavLink[] = [
+  { href: "#data360-chat", label: "Data360 Chat" },
+  { href: "#value", label: "What agents can do" },
+  { href: "#questions", label: "Example questions" },
+  { href: "#charts", label: "Charts" },
+  { href: "#technical", label: "Technical reference" },
+  { href: "#capabilities", label: "Capabilities" },
+  { href: "#tools", label: "Tools" },
+  { href: "#resources", label: "Resources" },
+  { href: "#connect", label: "Connect" },
+];
+
+export const VALUE_SECTION = {
+  title: "What your agent can do",
+  intro:
+    "An AI agent connected over MCP can query official World Bank series from Data360: search the catalog, pull time series, read indicator metadata, and request charts. Every value comes from Data360 APIs, not from model training.",
+} as const;
+
+export const OUTCOME_CARDS = [
+  {
+    title: "Countries",
+    description:
+      "Search indicators and confirm coverage for the countries named in the prompt.",
+  },
+  {
+    title: "Time series",
+    description:
+      "Retrieve values by country, year, and breakdowns such as sex, age, or urban/rural.",
+  },
+  {
+    title: "Metadata",
+    description:
+      "Surface source, definition, methodology, and known limitations for an indicator.",
+  },
+  {
+    title: "Charts",
+    description:
+      "Build line, bar, or other charts and return a URL the MCP client can display.",
+  },
+] as const;
+
+export const QUESTIONS_SECTION_INTRO =
+  "Sample prompts for a connected agent in Cursor, VS Code, or another MCP client. The agent resolves countries, selects indicators, and checks coverage before answering.";
+
+export const CHARTS_SECTION_INTRO =
+  "For charts, the agent calls visualization tools. The server loads the series from Data360 and returns a Vega-Lite spec and chart URL. For tables or numbers in text, it uses the data tools listed under Technical reference.";
+
+export const CHART_FLOW_LEAD =
+  "Search for the indicator, confirm available years and countries, then request the chart.";
+
+export const TECHNICAL_SECTION = {
+  title: "Technical reference",
+  intro:
+    "MCP tools, bundled resources, and connection details for developers wiring Cursor, Claude Desktop, LangGraph, or a custom client.",
+} as const;
+
+export const EXAMPLE_QUESTIONS = [
+  {
+    question:
+      "How has GDP per capita changed in Kenya over the last two decades?",
+    note: "Catalog search, Kenya coverage check, then the time series.",
+  },
+  {
+    question:
+      "Which indicators in WDI relate to female labor force participation, and do they include Bangladesh?",
+    note: "WDI search with a Bangladesh coverage filter.",
+  },
+  {
+    question:
+      "What is the official definition and source for this indicator—and what footnotes should I mention?",
+    note: "Metadata fields for definition, source, and footnotes.",
+  },
+  {
+    question:
+      "Plot a line chart comparing access to electricity in three countries since 2010.",
+    note: "Indicator lookup, disaggregation check, then chart spec.",
+  },
+] as const;
+
+export const CHART_TYPES = [
+  { title: "Line and area", description: "trends over years or periods" },
+  {
+    title: "Bar",
+    description: "discrete periods or categories when appropriate",
+  },
+  {
+    title: "Scatter / point",
+    description: "relationships when the data supports it",
+  },
+] as const;
+
+export const CAPABILITY_CARDS = [
+  {
+    title: "Indicator search",
+    description:
+      "Full-text search with metadata; optional country filter to limit results to series that actually exist.",
+  },
+  {
+    title: "Metadata",
+    description:
+      "Methodology, definitions, limitations, and statistical concepts for each indicator.",
+  },
+  {
+    title: "Time series",
+    description:
+      "Historical values with filters for country, period, sex, age, urbanization, and other dimensions.",
+  },
+  {
+    title: "Bundled resources",
+    description:
+      "System prompt, codelists, and usage notes exposed as MCP resources under data360://.",
+  },
+  {
+    title: "Composable tools",
+    description:
+      "Small, focused tools that validate coverage, codes, and filters before returning data.",
+  },
+] as const;
+
+export type ToolRow = { name: string; description: string };
+
+export const MCP_TOOLS: ToolRow[] = [
+  {
+    name: "data360_search_indicators",
+    description:
+      "Search with enriched metadata; use required_country for coverage. Returns covers_country, latest_data, dimensions.",
+  },
+  {
+    name: "data360_get_data",
+    description:
+      "Fetch data points with filters (country, time period, SEX, AGE, etc.).",
+  },
+  {
+    name: "data360_get_metadata",
+    description: "Indicator metadata; use select_fields to limit payload.",
+  },
+  {
+    name: "data360_get_disaggregation",
+    description:
+      "Available filter values (countries, years, dimensions) per indicator.",
+  },
+  {
+    name: "data360_find_codelist_value",
+    description: 'Resolve names to codes (e.g. "Kenya" → KEN, "female" → F).',
+  },
+  {
+    name: "data360_list_indicators",
+    description: "List all indicators for a database.",
+  },
+  {
+    name: "data360_get_viz_spec",
+    description:
+      "Fetch a series and return a Vega-Lite spec and chart URL. Call get_disaggregation first for valid filters. Does not consume get_data output.",
+  },
+  {
+    name: "data360_get_supported_chart_types",
+    description: "List supported chart types and data requirements.",
+  },
+  {
+    name: "data360_get_data_api_url",
+    description: "Low-level: direct Data360 data API URL helper.",
+  },
+];
+
+export const MCP_RESOURCES: ToolRow[] = [
+  {
+    name: "data360://system-prompt",
+    description: "Workflow and tool-use guidance for the system message",
+  },
+  {
+    name: "data360://databases",
+    description: "Available databases (WB_WDI, WB_SSGD, …)",
+  },
+  {
+    name: "data360://codelists",
+    description: "Codelist reference (REF_AREA, SEX, AGE, …)",
+  },
+  {
+    name: "data360://metadata-fields",
+    description: "Field mapping for smart question routing",
+  },
+  {
+    name: "data360://data-filters",
+    description: "Available filters and usage guidance",
+  },
+  {
+    name: "data360://search-usage",
+    description: "Search examples and best practices",
+  },
+];
+
+/** World Bank public (external) MCP endpoint for agents and IDEs. */
+export const PUBLIC_MCP_URL = "https://maimcpext.worldbank.org/ext/data360/mcp";
+
+export const AGENT_WORKFLOW = `Tables / numbers in text:
+1. data360_search_indicators(query, required_country="Kenya")
+2. data360_get_disaggregation(database_id, indicator_id)  — optional; years and dimensions
+3. data360_get_data(database_id, indicator_id, filters)
+
+Charts:
+1. data360_search_indicators(...)
+2. data360_get_disaggregation(...)  — recommended before get_viz_spec
+3. data360_get_viz_spec(database_id, indicator_id, country_code, start_year, end_year, ...)
+   Fetches data internally; does not take get_data output.`;
+
+export const MCP_ENDPOINTS = [
+  {
+    environment: "Public (external)",
+    url: PUBLIC_MCP_URL,
+    note: "Recommended for Cursor, Claude Desktop, and custom agents",
+  },
+  {
+    environment: "Local dev",
+    url: "http://localhost:8000/mcp",
+    note: "Port matches your server (see README)",
+  },
+] as const;
+
+export const MCP_JSON_CURSOR = `{
+  "mcpServers": {
+    "data360-mcp": {
+      "url": "${PUBLIC_MCP_URL}",
+      "type": "http"
+    }
+  }
+}`;
+
+export const MCP_JSON_CLAUDE = `{
+  "mcpServers": {
+    "data360-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "${PUBLIC_MCP_URL}"
+      ]
+    }
+  }
+}`;
+
+export const MCP_JSON_LOCAL = `{
+  "mcpServers": {
+    "data360-mcp": {
+      "url": "http://localhost:8000/mcp",
+      "type": "http"
+    }
+  }
+}`;
+
+export const LANGGRAPH_ENV = `DATA360_MCP_URL=${PUBLIC_MCP_URL}
+DATA360_MCP_TRANSPORT=streamable_http
+OPENAI_API_KEY=your-key`;
+
+export const EXAMPLE_DATABASES = [
+  { id: "WB_WDI", label: "World Development Indicators" },
+  {
+    id: "WB_SSGD",
+    label: "Social Sustainability and Global Database",
+  },
+] as const;
+
+export const FOOTER_LINKS = [
+  {
+    href: "https://github.com/worldbank/data360-mcp/blob/main/docs/overview.md",
+    label: "Documentation (markdown overview)",
+  },
+  {
+    href: "https://github.com/worldbank/data360-mcp/blob/main/DEVELOPMENT.md",
+    label: "DEVELOPMENT.md",
+  },
+  {
+    href: "https://github.com/worldbank/data360-mcp/blob/main/LICENSE",
+    label: "License",
+  },
+  {
+    href: "https://github.com/worldbank/data360-mcp/blob/main/WB-IGO-RIDER.md",
+    label: "IGO Rider",
+  },
+] as const;
+
+export const CONNECT_SECTION_INTRO =
+  "Required only for external MCP clients (Cursor, Claude Desktop, LangGraph, and similar). If you use Data360 Chat, the server is already configured—see the section above.";

--- a/frontend/components/mcp-docs/mcp-docs-page.tsx
+++ b/frontend/components/mcp-docs/mcp-docs-page.tsx
@@ -1,0 +1,361 @@
+import Link from "next/link";
+import { appConfig } from "@/lib/config";
+import { McpDocsConnectSection } from "./mcp-docs-connect-section";
+import {
+  AGENT_WORKFLOW,
+  CAPABILITY_CARDS,
+  CHART_FLOW_LEAD,
+  CHART_TYPES,
+  CHARTS_SECTION_INTRO,
+  EXAMPLE_QUESTIONS,
+  FOOTER_LINKS,
+  MCP_DOCS_NAV,
+  MCP_RESOURCES,
+  MCP_TOOLS,
+  OUTCOME_CARDS,
+  QUESTIONS_SECTION_INTRO,
+  TECHNICAL_SECTION,
+  VALUE_SECTION,
+} from "./mcp-docs-content";
+
+function DocsTable({
+  rows,
+}: {
+  rows: { name: string; description: string }[];
+}) {
+  return (
+    <div className="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.name}>
+              <td>
+                <code>{row.name}</code>
+              </td>
+              <td>{row.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DocsToc() {
+  return (
+    <aside aria-label="On this page" className="docs-toc">
+      <p className="docs-toc__label">On this page</p>
+      <nav>
+        <ul className="docs-toc__list">
+          {MCP_DOCS_NAV.map((link) => (
+            <li key={link.href}>
+              <a href={link.href}>{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}
+
+export function McpDocsPage() {
+  return (
+    <div className="mcp-docs">
+      <a className="skip-link" href="#main">
+        Skip to main content
+      </a>
+
+      <header className="site-topbar">
+        <div className="site-topbar__inner">
+          <span className="site-brand">Data360 MCP</span>
+          <ul className="site-topbar__links">
+            <li>
+              <a href="#connect">Connect</a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/worldbank/data360-mcp"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                GitHub
+              </a>
+            </li>
+            <li>
+              <Link href="/">Back to chat</Link>
+            </li>
+          </ul>
+        </div>
+      </header>
+
+      <div className="site-hero">
+        <div className="site-hero__inner">
+          <p className="hero__eyebrow">World Bank · Development Data Group</p>
+          <h1>World Bank development data over MCP</h1>
+          <p className="hero__lead">
+            Poverty, growth, gender, climate, health, and hundreds of other
+            indicators come from the{" "}
+            <a
+              href="https://data360.worldbank.org"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Data360 Platform
+            </a>
+            —the Bank&apos;s catalog for development data.
+          </p>
+          <p className="hero__sub">
+            The server uses the{" "}
+            <a
+              href="https://modelcontextprotocol.io"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Model Context Protocol (MCP)
+            </a>
+            . Point Cursor, VS Code, or a custom app at this server so an AI
+            agent can work with those indicators on your behalf.
+          </p>
+          <div className="hero__actions">
+            <a className="btn btn--primary" href="#value">
+              What agents can do
+            </a>
+            <a className="btn btn--secondary" href="#connect">
+              Connect your agent
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <main id="main">
+        <div className="docs-layout">
+          <DocsToc />
+          <div className="docs-content">
+            <section
+              aria-labelledby="data360-chat-heading"
+              className="section"
+              id="data360-chat"
+            >
+              <div className="notice">
+                <h2
+                  className="section__title section__title--compact"
+                  id="data360-chat-heading"
+                >
+                  Powers {appConfig.sidebar.appName}
+                </h2>
+                <p>
+                  {appConfig.sidebar.appName} is the World Bank&apos;s chat
+                  interface for development data. It already calls this MCP
+                  server for search, series, metadata, and charts. No extra MCP
+                  setup is required unless you want a separate client.
+                </p>
+                <p className="notice__actions">
+                  <Link className="btn btn--primary" href="/">
+                    Open {appConfig.sidebar.appName}
+                  </Link>
+                  <a className="btn btn--secondary" href="#connect">
+                    Connect an external client
+                  </a>
+                </p>
+              </div>
+            </section>
+
+            <section
+              aria-labelledby="value-heading"
+              className="section"
+              id="value"
+            >
+              <h2 className="section__title" id="value-heading">
+                {VALUE_SECTION.title}
+              </h2>
+              <p className="section__intro">{VALUE_SECTION.intro}</p>
+              <ul className="capability-grid">
+                {OUTCOME_CARDS.map((card) => (
+                  <li className="capability-item" key={card.title}>
+                    <h3>{card.title}</h3>
+                    <p>{card.description}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section
+              aria-labelledby="questions-heading"
+              className="section"
+              id="questions"
+            >
+              <h2 className="section__title" id="questions-heading">
+                Example questions
+              </h2>
+              <p className="section__intro">{QUESTIONS_SECTION_INTRO}</p>
+              <ul className="example-list">
+                {EXAMPLE_QUESTIONS.map((item) => (
+                  <li key={item.question}>
+                    {item.question}
+                    <span className="question__note">{item.note}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section
+              aria-labelledby="charts-heading"
+              className="section"
+              id="charts"
+            >
+              <h2 className="section__title" id="charts-heading">
+                Charts and visualizations
+              </h2>
+              <p className="section__intro">{CHARTS_SECTION_INTRO}</p>
+              <div className="prose-block">
+                <p className="prose-block__lead">
+                  <strong>Chart flow:</strong> {CHART_FLOW_LEAD}
+                </p>
+                <ul>
+                  {CHART_TYPES.map((t) => (
+                    <li key={t.title}>
+                      <strong>{t.title}</strong> — {t.description}
+                    </li>
+                  ))}
+                </ul>
+                <p className="prose-block__footnote">
+                  Charts use Vega-Lite. Your MCP client opens the URL the server
+                  returns.
+                </p>
+              </div>
+            </section>
+
+            <div className="docs-technical" id="technical">
+              <div className="docs-technical__header">
+                <h2
+                  className="section__title section__title--technical"
+                  id="technical-heading"
+                >
+                  {TECHNICAL_SECTION.title}
+                </h2>
+                <p className="section__technical-lede">
+                  {TECHNICAL_SECTION.intro}
+                </p>
+              </div>
+
+              <section
+                aria-labelledby="capabilities-heading"
+                className="section section--in-technical"
+                id="capabilities"
+              >
+                <h3 className="section__title" id="capabilities-heading">
+                  Server capabilities
+                </h3>
+                <p className="section__intro">
+                  Search, metadata, series retrieval, code lists, and bundled
+                  prompt resources exposed to MCP clients.
+                </p>
+                <ul className="feature-list">
+                  {CAPABILITY_CARDS.map((card) => (
+                    <li className="feature-card" key={card.title}>
+                      <h4>{card.title}</h4>
+                      <p>{card.description}</p>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section
+                aria-labelledby="tools-heading"
+                className="section section--in-technical"
+                id="tools"
+              >
+                <h3 className="section__title" id="tools-heading">
+                  MCP tools
+                </h3>
+                <p className="section__intro">
+                  Typical order: search, optional disaggregation, then get_data
+                  or get_viz_spec.
+                </p>
+                <DocsTable rows={MCP_TOOLS} />
+                <h4 className="section__title section__title--sub">
+                  Recommended agent workflow
+                </h4>
+                <pre className="workflow-box">{AGENT_WORKFLOW}</pre>
+              </section>
+
+              <section
+                aria-labelledby="resources-heading"
+                className="section section--in-technical"
+                id="resources"
+              >
+                <h3 className="section__title" id="resources-heading">
+                  MCP resources
+                </h3>
+                <p className="section__intro">
+                  Read-only URIs for prompts and reference data. Load{" "}
+                  <code>data360://system-prompt</code> in the system message for
+                  most integrations.
+                </p>
+                <DocsTable rows={MCP_RESOURCES} />
+              </section>
+
+              <McpDocsConnectSection />
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <footer className="site-footer">
+        <div className="site-footer__inner">
+          <p>
+            <strong>AI for Data - Data for AI Team</strong>
+            <br />
+            <a href="mailto:ai4data@worldbank.org">ai4data@worldbank.org</a>
+            <br />
+            Development Data Group / Office of the World Bank Group Chief
+            Statistician
+            <br />
+            World Bank Group
+          </p>
+          <p>
+            {FOOTER_LINKS.map((link, i) => (
+              <span key={link.href}>
+                {i > 0 ? " · " : null}
+                <a href={link.href} rel="noopener noreferrer" target="_blank">
+                  {link.label}
+                </a>
+              </span>
+            ))}
+          </p>
+          <p className="site-footer__meta">
+            This project is licensed under the MIT License together with the
+            World Bank IGO Rider. The Rider is procedural: it reserves World
+            Bank privileges and immunities without adding restrictions to MIT
+            permissions.
+          </p>
+          <p className="site-footer__built">
+            Built with{" "}
+            <a
+              href="https://github.com/jlowin/fastmcp"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              FastMCP
+            </a>{" "}
+            and the{" "}
+            <a
+              href="https://modelcontextprotocol.io"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Model Context Protocol
+            </a>
+            .
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/components/mcp-docs/mcp-docs-theme.css
+++ b/frontend/components/mcp-docs/mcp-docs-theme.css
@@ -1,0 +1,799 @@
+/* Data360 MCP docs — Open Sans, WB palette, modern product-docs layout */
+.mcp-docs {
+  --wb-navy-deep: #053657;
+  --wb-navy: #004370;
+  --wb-primary: #0071bc;
+  --wb-primary-hover: #00538a;
+  --wb-cream: #f5f7fa;
+  --wb-paper: #eef1f6;
+  --wb-surface: #ffffff;
+  --wb-ink: #1a1a1a;
+  --wb-ink-muted: #5a6572;
+  --wb-border: #e2e8f0;
+  --wb-border-strong: #cbd5e1;
+  --wb-text-on-dark: #ffffff;
+  --wb-text-on-dark-muted: rgba(255, 255, 255, 0.88);
+  --font-sans:
+    "Open Sans", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  --font-mono:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, monospace;
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4.5rem;
+  --radius: 10px;
+  --radius-sm: 6px;
+  --shadow-sm: 0 1px 2px rgba(5, 54, 87, 0.06);
+  --shadow-md: 0 4px 16px rgba(5, 54, 87, 0.08);
+  --max-width: 76rem;
+  --content-width: 44rem;
+  --toc-width: 12rem;
+  --font-h1: clamp(1.875rem, 3.2vw, 2.375rem);
+  --font-h2: 1.5rem;
+  --font-h3: 1.125rem;
+  --scroll-offset: 5rem;
+  color-scheme: light;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--wb-ink);
+  background: var(--wb-surface);
+  min-height: 100%;
+}
+
+.mcp-docs *,
+.mcp-docs *::before,
+.mcp-docs *::after {
+  box-sizing: border-box;
+}
+
+.mcp-docs [id] {
+  scroll-margin-top: var(--scroll-offset);
+}
+
+.mcp-docs .skip-link {
+  position: absolute;
+  left: -9999px;
+  z-index: 100;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--wb-primary);
+  color: var(--wb-text-on-dark);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mcp-docs .skip-link:focus {
+  left: 0;
+  top: 0;
+}
+
+/* Top bar */
+.mcp-docs .site-topbar {
+  background: var(--wb-navy-deep);
+  color: var(--wb-text-on-dark);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs .site-topbar__inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0.875rem var(--space-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.mcp-docs .site-brand {
+  font-weight: 700;
+  font-size: 1.0625rem;
+  color: var(--wb-text-on-dark);
+  letter-spacing: -0.02em;
+}
+
+.mcp-docs .site-topbar__links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm) var(--space-md);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.mcp-docs .site-topbar__links a {
+  color: var(--wb-text-on-dark-muted);
+  text-decoration: none;
+}
+
+.mcp-docs .site-topbar__links a:hover,
+.mcp-docs .site-topbar__links a:focus-visible {
+  color: var(--wb-text-on-dark);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Hero */
+.mcp-docs .site-hero {
+  background: linear-gradient(
+    180deg,
+    var(--wb-cream) 0%,
+    var(--wb-surface) 100%
+  );
+  border-bottom: 1px solid var(--wb-border);
+}
+
+.mcp-docs .site-hero__inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-md) var(--space-xl);
+}
+
+.mcp-docs .hero__eyebrow {
+  display: block;
+  margin: 0 0 var(--space-sm);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--wb-primary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mcp-docs .site-hero h1 {
+  margin: 0 0 var(--space-md);
+  max-width: 38rem;
+  font-size: var(--font-h1);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--wb-navy-deep);
+  letter-spacing: -0.03em;
+}
+
+.mcp-docs .hero__lead {
+  margin: 0 0 var(--space-sm);
+  max-width: var(--content-width);
+  font-size: 1.125rem;
+  line-height: 1.65;
+  color: var(--wb-ink);
+}
+
+.mcp-docs .hero__sub {
+  margin: 0;
+  max-width: var(--content-width);
+  font-size: 1rem;
+  color: var(--wb-ink-muted);
+}
+
+.mcp-docs .hero__lead a,
+.mcp-docs .hero__sub a {
+  color: var(--wb-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mcp-docs .hero__lead a:hover,
+.mcp-docs .hero__sub a:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.mcp-docs .hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+}
+
+/* Buttons */
+.mcp-docs .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 1.125rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.mcp-docs .btn:focus-visible {
+  outline: 2px solid var(--wb-primary);
+  outline-offset: 2px;
+}
+
+.mcp-docs .btn--primary {
+  background: var(--wb-primary);
+  color: var(--wb-text-on-dark);
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs .btn--primary:hover {
+  background: var(--wb-primary-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.mcp-docs .btn--secondary {
+  background: var(--wb-surface);
+  color: var(--wb-navy-deep);
+  border-color: var(--wb-border-strong);
+}
+
+.mcp-docs .btn--secondary:hover {
+  background: var(--wb-cream);
+  border-color: var(--wb-navy);
+}
+
+/* Main layout */
+.mcp-docs main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-md) var(--space-2xl);
+}
+
+.mcp-docs .docs-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-xl);
+  align-items: start;
+}
+
+@media (min-width: 1024px) {
+  .mcp-docs .docs-layout {
+    grid-template-columns: var(--toc-width) minmax(0, 1fr);
+    gap: 3.5rem;
+  }
+}
+
+.mcp-docs .docs-toc {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .mcp-docs .docs-toc {
+    display: block;
+    position: sticky;
+    top: var(--scroll-offset);
+    max-height: calc(100vh - var(--scroll-offset) - 1rem);
+    overflow-y: auto;
+  }
+}
+
+.mcp-docs .docs-toc__label {
+  margin: 0 0 var(--space-sm);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--wb-ink-muted);
+}
+
+.mcp-docs .docs-toc__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mcp-docs .docs-toc__list a {
+  display: block;
+  padding: 0.4rem 0;
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  color: var(--wb-ink-muted);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  padding-left: 0.5rem;
+  margin-left: -0.5rem;
+}
+
+.mcp-docs .docs-toc__list a:hover,
+.mcp-docs .docs-toc__list a:focus-visible {
+  color: var(--wb-navy-deep);
+  background: var(--wb-cream);
+}
+
+.mcp-docs .docs-content {
+  min-width: 0;
+}
+
+/* Sections */
+.mcp-docs .section {
+  margin-bottom: var(--space-xl);
+}
+
+.mcp-docs .section__title {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--font-h2);
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+  letter-spacing: -0.02em;
+}
+
+.mcp-docs .section__intro {
+  margin: 0 0 var(--space-md);
+  max-width: var(--content-width);
+  color: var(--wb-ink-muted);
+  font-size: 1rem;
+}
+
+.mcp-docs .section__title--sub {
+  margin-top: var(--space-lg);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+}
+
+.mcp-docs .section__title--compact {
+  margin: 0 0 var(--space-xs);
+  font-size: var(--font-h3);
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+}
+
+/* Technical block — wraps tools, resources, connect */
+.mcp-docs .docs-technical {
+  margin-top: var(--space-lg);
+  padding: var(--space-xl) var(--space-md);
+  background: var(--wb-paper);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+@media (min-width: 640px) {
+  .mcp-docs .docs-technical {
+    padding: var(--space-xl);
+  }
+}
+
+.mcp-docs .docs-technical__header {
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--wb-border-strong);
+}
+
+.mcp-docs .section__title--technical {
+  font-size: 1.625rem;
+  margin-bottom: var(--space-sm);
+}
+
+.mcp-docs .section__technical-lede {
+  margin: 0;
+  max-width: var(--content-width);
+  font-size: 1rem;
+  color: var(--wb-ink-muted);
+}
+
+.mcp-docs .section--in-technical {
+  margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-xl);
+  border-bottom: 1px solid var(--wb-border);
+}
+
+.mcp-docs .section--in-technical:last-child {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.mcp-docs .section--in-technical .section__title {
+  font-size: var(--font-h3);
+}
+
+/* Notice */
+.mcp-docs .notice {
+  padding: var(--space-md) var(--space-lg);
+  background: var(--wb-surface);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs .notice p {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--wb-ink);
+}
+
+.mcp-docs .notice p + p {
+  margin-top: var(--space-sm);
+}
+
+.mcp-docs .notice__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+/* Capability grid */
+.mcp-docs .capability-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 640px) {
+  .mcp-docs .capability-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.mcp-docs .capability-item {
+  padding: var(--space-md) var(--space-md) var(--space-md) 1.125rem;
+  background: var(--wb-surface);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs .capability-item h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+}
+
+.mcp-docs .capability-item p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--wb-ink-muted);
+  line-height: 1.55;
+}
+
+/* Example questions */
+.mcp-docs .example-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.mcp-docs .example-list li {
+  padding: var(--space-md) var(--space-md) var(--space-md) var(--space-lg);
+  background: var(--wb-cream);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--wb-ink);
+}
+
+.mcp-docs .example-list .question__note {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: 0.8125rem;
+  color: var(--wb-ink-muted);
+}
+
+/* Prose block */
+.mcp-docs .prose-block {
+  padding: var(--space-md) var(--space-lg);
+  background: var(--wb-cream);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius);
+}
+
+.mcp-docs .prose-block ul {
+  margin: var(--space-sm) 0 0;
+  padding-left: 1.25rem;
+  color: var(--wb-ink-muted);
+  font-size: 0.9375rem;
+}
+
+.mcp-docs .prose-block__lead {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--wb-ink);
+}
+
+.mcp-docs .prose-block__footnote {
+  margin: var(--space-sm) 0 0;
+  font-size: 0.8125rem;
+  color: var(--wb-ink-muted);
+}
+
+/* Feature cards (technical) */
+.mcp-docs .feature-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 640px) {
+  .mcp-docs .feature-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 960px) {
+  .mcp-docs .feature-list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.mcp-docs .feature-card {
+  padding: var(--space-md);
+  background: var(--wb-surface);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius-sm);
+}
+
+.mcp-docs .feature-card h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+}
+
+.mcp-docs .feature-card p {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--wb-ink-muted);
+  line-height: 1.55;
+}
+
+/* Tables */
+.mcp-docs .table-wrap {
+  overflow-x: auto;
+  margin: var(--space-sm) 0;
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius-sm);
+  background: var(--wb-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.mcp-docs th,
+.mcp-docs td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--wb-border);
+}
+
+.mcp-docs th {
+  background: var(--wb-cream);
+  font-weight: 600;
+  color: var(--wb-navy-deep);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mcp-docs tr:last-child td {
+  border-bottom: none;
+}
+
+.mcp-docs code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+}
+
+.mcp-docs td code {
+  font-size: 0.8125rem;
+  color: var(--wb-navy-deep);
+}
+
+/* Code */
+.mcp-docs .workflow-box {
+  margin: var(--space-sm) 0 0;
+  padding: var(--space-md);
+  background: var(--wb-navy-deep);
+  color: #e8edf2;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.mcp-docs .mcp-docs-code-wrap {
+  position: relative;
+  margin: var(--space-sm) 0;
+}
+
+.mcp-docs .mcp-docs-code-wrap > div {
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.mcp-docs .mcp-docs-code-wrap pre {
+  margin: 0;
+  padding: var(--space-md);
+  background: var(--wb-navy-deep);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: #e8edf2;
+  line-height: 1.55;
+}
+
+.mcp-docs .mcp-docs-code-wrap button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--wb-text-on-dark-muted);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.mcp-docs .mcp-docs-code-wrap button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* Connect */
+.mcp-docs .connect-steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.mcp-docs .connect-step__title {
+  margin: 0 0 var(--space-xs);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--wb-navy-deep);
+}
+
+.mcp-docs .connect-step .section__intro {
+  margin-bottom: var(--space-sm);
+  font-size: 0.9375rem;
+}
+
+.mcp-docs .connect-step__list {
+  margin: var(--space-sm) 0 0;
+  padding-left: 1.35rem;
+  color: var(--wb-ink-muted);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.mcp-docs .connect-step__list li + li {
+  margin-top: 0.35rem;
+}
+
+.mcp-docs .connect-tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  margin: var(--space-sm) 0;
+  padding: 3px;
+  background: var(--wb-surface);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius-sm);
+}
+
+.mcp-docs .connect-tab {
+  padding: 0.4rem 0.85rem;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--wb-ink-muted);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.mcp-docs .connect-tab--active {
+  color: var(--wb-navy-deep);
+  background: var(--wb-cream);
+}
+
+.mcp-docs .connect-tab:focus-visible {
+  outline: 2px solid var(--wb-primary);
+  outline-offset: 1px;
+}
+
+.mcp-docs .connect-panel {
+  margin-top: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--wb-surface);
+  border: 1px solid var(--wb-border);
+  border-radius: var(--radius-sm);
+}
+
+.mcp-docs .connect-panel__text {
+  margin: 0 0 var(--space-sm);
+  font-size: 0.9375rem;
+  color: var(--wb-ink-muted);
+}
+
+.mcp-docs .connect-panel__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.9375rem;
+}
+
+.mcp-docs .panel__text {
+  margin: 0.35rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--wb-ink-muted);
+}
+
+.mcp-docs .docs-content a:not(.btn) {
+  color: var(--wb-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.mcp-docs .docs-content a:not(.btn):hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Footer */
+.mcp-docs .site-footer {
+  padding: var(--space-xl) var(--space-md);
+  background: var(--wb-navy-deep);
+  color: var(--wb-text-on-dark-muted);
+  font-size: 0.875rem;
+}
+
+.mcp-docs .site-footer__inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.mcp-docs .site-footer a {
+  color: var(--wb-text-on-dark);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.mcp-docs .site-footer a:hover {
+  opacity: 0.92;
+}
+
+.mcp-docs .site-footer p {
+  margin: 0 0 var(--space-sm);
+  line-height: 1.65;
+}
+
+.mcp-docs .site-footer__meta {
+  margin-top: var(--space-md);
+  padding-top: var(--space-md);
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.mcp-docs .site-footer__built {
+  margin-top: var(--space-sm);
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}

--- a/frontend/components/message.tsx
+++ b/frontend/components/message.tsx
@@ -22,6 +22,12 @@ import {
   buildChartUrlRegexes,
   splitAssistantTextIntoChartSegments,
 } from "@/lib/chart-url";
+import {
+  assistantTextWithoutLegacyPolicyMarker,
+  CONTENT_POLICY_BLOCKED_PART_TYPE,
+  getContentPolicyBlockedFromParts,
+  LEGACY_POLICY_BLOCKED_TEXT,
+} from "@/lib/content-policy";
 import { getBasePath } from "@/lib/config";
 import {
   type Data360SourceEntry,
@@ -858,7 +864,13 @@ const PurePreviewMessage = ({
     .filter((p): p is { type: "text"; text: string } => p.type === "text")
     .map((p) => p.text)
     .join("\n");
-  const followUps = parseFollowUps(assistantText);
+  const contentPolicyBlocked = getContentPolicyBlockedFromParts(message.parts);
+  const assistantTextForFollowUps = assistantTextWithoutLegacyPolicyMarker(
+    assistantText,
+  );
+  const followUps = contentPolicyBlocked
+    ? []
+    : parseFollowUps(assistantTextForFollowUps);
 
   // Extract quick-answer card from message.parts — persisted through DB so
   // it survives page refreshes and chat history navigation.
@@ -930,8 +942,21 @@ const PurePreviewMessage = ({
             const {
               firstRegularPartIndex,
               thinkingParts: savedThinkingParts,
-              regularParts,
+              regularParts: rawRegularParts,
             } = splitDataThinkingPrefixParts(parts);
+            const regularParts = rawRegularParts.filter((part) => {
+              if (part.type === CONTENT_POLICY_BLOCKED_PART_TYPE) {
+                return false;
+              }
+              if (
+                part.type === "text" &&
+                "text" in part &&
+                (part.text ?? "").trim() === LEGACY_POLICY_BLOCKED_TEXT
+              ) {
+                return false;
+              }
+              return true;
+            });
 
             // Filter out non-renderable stream events from saved thinking parts
             const filteredSavedThinkingParts = savedThinkingParts
@@ -1148,6 +1173,16 @@ const PurePreviewMessage = ({
                       </Sources>
                     );
                   })()}
+
+                {/* Content-policy block on follow-up (or legacy [blocked] marker) */}
+                {message.role === "assistant" && contentPolicyBlocked != null && (
+                  <div
+                    className="mt-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-sm"
+                    data-testid="content-policy-blocked-notice"
+                  >
+                    {contentPolicyBlocked.message}
+                  </div>
+                )}
 
                 {/* Suggested follow-ups: parse from assistant text and render as clickable chips — only after response is complete to avoid distraction during streaming */}
                 {message.role === "assistant" &&

--- a/frontend/lib/__tests__/content-policy.test.ts
+++ b/frontend/lib/__tests__/content-policy.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import {
   assistantTextWithoutLegacyPolicyMarker,
   CONTENT_POLICY_BLOCKED_PART_TYPE,
@@ -17,7 +18,7 @@ describe("getContentPolicyBlockedFromParts", () => {
         },
       },
     ]);
-    expect(result?.message).toBe("Policy blocked message.");
+    assert.equal(result?.message, "Policy blocked message.");
   });
 
   it("detects legacy [blocked] text part", () => {
@@ -25,19 +26,23 @@ describe("getContentPolicyBlockedFromParts", () => {
       { type: "text", text: "Answer" },
       { type: "text", text: LEGACY_POLICY_BLOCKED_TEXT },
     ]);
-    expect(result?.node).toBe("followup");
-    expect(result?.message).toContain("content safety rules");
+    assert.equal(result?.node, "followup");
+    assert.match(result?.message ?? "", /content safety rules/);
   });
 
   it("returns null when no policy marker", () => {
-    expect(getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }])).toBeNull();
+    assert.equal(
+      getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }]),
+      null,
+    );
   });
 });
 
 describe("assistantTextWithoutLegacyPolicyMarker", () => {
   it("removes trailing legacy marker", () => {
-    expect(
+    assert.equal(
       assistantTextWithoutLegacyPolicyMarker("Answer text\n\n[blocked]"),
-    ).toBe("Answer text");
+      "Answer text",
+    );
   });
 });

--- a/frontend/lib/__tests__/content-policy.test.ts
+++ b/frontend/lib/__tests__/content-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  assistantTextWithoutLegacyPolicyMarker,
+  CONTENT_POLICY_BLOCKED_PART_TYPE,
+  getContentPolicyBlockedFromParts,
+  LEGACY_POLICY_BLOCKED_TEXT,
+} from "../content-policy";
+
+describe("getContentPolicyBlockedFromParts", () => {
+  it("returns data part payload when present", () => {
+    const result = getContentPolicyBlockedFromParts([
+      {
+        type: CONTENT_POLICY_BLOCKED_PART_TYPE,
+        data: {
+          node: "followup",
+          message: "Policy blocked message.",
+        },
+      },
+    ]);
+    expect(result?.message).toBe("Policy blocked message.");
+  });
+
+  it("detects legacy [blocked] text part", () => {
+    const result = getContentPolicyBlockedFromParts([
+      { type: "text", text: "Answer" },
+      { type: "text", text: LEGACY_POLICY_BLOCKED_TEXT },
+    ]);
+    expect(result?.node).toBe("followup");
+    expect(result?.message).toContain("content safety rules");
+  });
+
+  it("returns null when no policy marker", () => {
+    expect(getContentPolicyBlockedFromParts([{ type: "text", text: "Hello" }])).toBeNull();
+  });
+});
+
+describe("assistantTextWithoutLegacyPolicyMarker", () => {
+  it("removes trailing legacy marker", () => {
+    expect(
+      assistantTextWithoutLegacyPolicyMarker("Answer text\n\n[blocked]"),
+    ).toBe("Answer text");
+  });
+});

--- a/frontend/lib/content-policy.ts
+++ b/frontend/lib/content-policy.ts
@@ -1,0 +1,52 @@
+/** Shared contract with backend `llm_invoke.content_policy_blocked_part`. */
+
+export const CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked" as const;
+
+/** Legacy sentinel persisted before BE-003. */
+export const LEGACY_POLICY_BLOCKED_TEXT = "[blocked]";
+
+export type ContentPolicyBlockedData = {
+  node: string;
+  message: string;
+};
+
+export type ContentPolicyBlockedPart = {
+  type: typeof CONTENT_POLICY_BLOCKED_PART_TYPE;
+  data: ContentPolicyBlockedData;
+};
+
+type MessagePartLike = { type?: string; text?: string; data?: unknown };
+
+export function getContentPolicyBlockedFromParts(
+  parts: MessagePartLike[],
+): ContentPolicyBlockedData | null {
+  const dataPart = parts.find(
+    (p) => p.type === CONTENT_POLICY_BLOCKED_PART_TYPE,
+  );
+  if (dataPart?.data && typeof dataPart.data === "object") {
+    const data = dataPart.data as ContentPolicyBlockedData;
+    if (typeof data.message === "string" && data.message.length > 0) {
+      return data;
+    }
+  }
+
+  const hasLegacyMarker = parts.some(
+    (p) =>
+      p.type === "text" &&
+      (p.text ?? "").trim() === LEGACY_POLICY_BLOCKED_TEXT,
+  );
+  if (hasLegacyMarker) {
+    return {
+      node: "followup",
+      message:
+        "This response is incomplete because the model provider blocked this reply under its content safety rules. Try rephrasing your question, narrowing the topic, or contacting support.",
+    };
+  }
+
+  return null;
+}
+
+/** Strip legacy `[blocked]` tail from assistant text before follow-up parsing. */
+export function assistantTextWithoutLegacyPolicyMarker(text: string): string {
+  return text.replace(/\n*\[blocked\]\s*$/, "").trimEnd();
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -81,6 +81,10 @@ export type CustomUIDataTypes = {
   // Quick-answer visual card — persisted as a message part so it survives
   // page reloads and chat history navigation.
   quickAnswerCard: QuickAnswerCardData;
+  contentPolicyBlocked: {
+    node: string;
+    message: string;
+  };
 };
 
 export type ChatMessage = UIMessage<

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -19,7 +19,7 @@ const nextConfig: NextConfig = {
       // Redirect / and unknown paths to basePath. Exclude known app routes (chat, api, etc.)
       // so that when an external proxy strips the path prefix, /chat/:id and /api/* still work.
       const excludeAppRoutes =
-        "(?!chat/)(?!review/)(?!api/)(?!login)(?!register)(?!maintenance)(?!ping)(?!images/)(?!json/)(?!_next/)";
+        "(?!chat/)(?!review/)(?!about/)(?!api/)(?!login)(?!register)(?!maintenance)(?!ping)(?!images/)(?!json/)(?!_next/)";
       redirects.push(
         { source: "/", destination: basePath, basePath: false, permanent: false },
         {

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -245,6 +245,7 @@ export async function proxy(request: NextRequest) {
       pathMatches(pathname, "/login") ||
       pathMatches(pathname, "/register") ||
       pathMatches(pathname, "/maintenance") ||
+      pathMatches(pathname, "/about") ||
       pathMatches(pathname, "/ping");
     const shouldRedirectToBasePath =
       !isAppRoot && !isNextInternal && !isStaticAsset && !isKnownAppPath;
@@ -274,14 +275,15 @@ export async function proxy(request: NextRequest) {
   if (effectiveMaintenance && !isMaintenanceBypass(request)) {
     const isMaintenance =
       pathMatches(pathname, "/maintenance") || pathname === maintenancePath;
+    const isAboutDocs = pathMatches(pathname, "/about");
     const isNextOrApi =
       pathMatches(pathname, "/_next") ||
       pathMatches(pathname, "/api") ||
       pathname.includes(".");
-    if (!isMaintenance && !isNextOrApi) {
+    if (!isMaintenance && !isAboutDocs && !isNextOrApi) {
       return NextResponse.redirect(new URL(maintenancePath, request.url));
     }
-    if (isMaintenance) {
+    if (isMaintenance || isAboutDocs) {
       return nextWithCsp(request);
     }
   }
@@ -327,6 +329,11 @@ export async function proxy(request: NextRequest) {
       );
       return NextResponse.redirect(guestUrl);
     }
+    return nextWithCsp(request);
+  }
+
+  // Public MCP documentation (no sign-in required)
+  if (pathMatches(pathname, "/about")) {
     return nextWithCsp(request);
   }
 

--- a/frontend/run.sh
+++ b/frontend/run.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-cd "$(dirname "$0")" && pnpm dev --port 3001
+# cd "$(dirname "$0")" && pnpm dev --port 3001
+cd "$(dirname "$0")" && pnpm install && pnpm build:local && PORT=3001 node .next/standalone/server.js


### PR DESCRIPTION
## Summary

Add documentation of Data360 MCP in `about/mcp`.

When Azure/content filters block an LLM step (especially follow-up suggestions), the backend previously appended the literal sentinel `"[blocked]"` to message parts. Users saw that string in the chat with no explanation, and operations had no reliable way to query policy blocks on the main turn span.

This PR:

- Replaces the sentinel with a structured `data-contentPolicyBlocked` part and a clear user-facing message.
- Keeps the main answer when only follow-up generation is blocked (non-fatal path).
- Migrates legacy `"[blocked]"` text on reload/stream finalize for backward compatibility.
- Tags **`chat.turn`** (and fatal stream failures) in OpenTelemetry with `chatbot.content_policy_blocked` and `chatbot.content_policy_node` for App Insights / Jaeger queries.

## Problem

- Follow-up LLM calls that hit `ContentPolicyViolationError` produced `LLM_POLICY_BLOCKED_TEXT` (`"[blocked]"`) in persisted/streamed parts.
- Frontend rendered `"[blocked]"` as normal assistant text and could still show follow-up chips.
- Policy blocks were hard to distinguish in telemetry except on individual graph node spans.

## Solution

### Backend

- **`llm_invoke.py`**: `CONTENT_POLICY_USER_MESSAGE`, `content_policy_blocked_part()`, `CONTENT_POLICY_BLOCKED_PART_TYPE = "data-contentPolicyBlocked"`.
- **`followup.py`**: On policy outcome, set graph state flags and record OTel on the node span; do not append `[blocked]` text.
- **`sse_bridge.py`**: Emit structured data part instead of streaming `[blocked]`; migrate legacy markers in `fill_out_dict`; fatal stream errors use the user message for `ContentPolicyViolationError` and tag `chat.turn` via `record_content_policy_on_span`.
- **`graph_stream.py`**: After graph completion, if `content_policy_blocked`, tag the active `chat.turn` span.
- **`state.py`**: `content_policy_blocked`, `content_policy_node` on graph state.
- **`otel_setup.py`**: `record_content_policy_on_span(node)` helper (shared with `record_error_on_span`).

### Frontend

- **`content-policy.ts`**: Detect `data-contentPolicyBlocked` and legacy `[blocked]` text.
- **`message.tsx`**: Inline policy notice; strip legacy marker from narrative; suppress follow-up chips when blocked.
- **`types.ts`**: `contentPolicyBlocked` in custom data types.

### Docs & tests

- **`docs/operations/telemetry.md`**: Documents `chatbot.content_policy_blocked` / `chatbot.content_policy_node` on `chat.turn` and graph node spans.
- **`backend/tests/test_content_policy.py`**, **`frontend/lib/__tests__/content-policy.test.ts`**: Unit coverage for parts, migration, OTel attributes, and UI helpers.

## Behavior

| Scenario | User experience | Telemetry |
|----------|-----------------|-----------|
| Follow-up blocked, main answer OK | Full answer + inline notice; no follow-up chips | `chat.turn` + `chatbot.graph.followup` tagged |
| Fatal policy block during stream | Error with support `error_id` and user message | `chat.turn` tagged with node/stream |
| Old messages with `[blocked]` | Migrated to structured part on reload/finalize | N/A |

## Out of scope

- Extending `safe_llm_ainvoke` policy handling to every graph node (only follow-up + stream path today).
