### PR TITLE
fix(quick-answer): fix trend card classification and missing year mismatch warning

### DIFF
--- a/backend/app/ai/graph/nodes/quick_answer.py
+++ b/backend/app/ai/graph/nodes/quick_answer.py
@@ -599,13 +599,12 @@ def _synthesize_card(tool_results: list[dict]) -> dict | None:
             # (e.g. for a "latest data" point lookup), the MCP server will default to 20 years,
             # but we should still render it as a single_fact for the absolute latest year.
             start_year = tool_args.get("start_year")
-            end_year = tool_args.get("end_year")
-            has_explicit_years = (start_year is not None and str(start_year).strip() != "") or (
-                end_year is not None and str(end_year).strip() != ""
-            )
+            # An explicit range query requires start_year to be provided (e.g. "since 2015" or "from 2010 to 2020").
+            # If start_year is omitted, even if end_year is set (e.g. "in 2023"), it is a single-year point lookup.
+            has_explicit_range = start_year is not None and str(start_year).strip() != ""
 
             if (
-                has_explicit_years
+                has_explicit_range
                 and len(countries) == 1
                 and target_row.get("TIME_PERIOD") != earliest_row.get("TIME_PERIOD")
             ):

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -578,9 +578,7 @@ If you call `data360_get_viz_spec`, present the returned URL as a markdown link 
 WHEN INFORMATION IS MISSING:
 - If the packet has a ### NO_DATA section: explain what was unavailable and suggest
   1-2 related queries the user could try. Do NOT ask a clarifying question.
-- If the RAW TOOL RESULTS contain a "not available" entry for a requested year with
-  a nearby year's value alongside it: clearly state the requested year had no data,
-  report the nearest year's value, and optionally offer to check alternatives.
+- If the user requested a specific year but the returned data omits that year or marks it as unavailable: clearly state that the requested year has no data, report the nearest available year's value, and optionally offer to check alternatives.
 - If you are asked to compare multiple countries, but the RAW TOOL RESULTS omit one or more
   of those countries (e.g., they are missing from the `rankings` array), you MUST explicitly
   state that the comparison could not be completed because data was unavailable for the
@@ -780,13 +778,18 @@ the UI is displaying the full structured data card automatically.
 Your response MUST be extremely minimal to avoid redundancy. The UI automatically renders a large, beautiful visual card with all the data.
 - Do NOT output any bridging prose or repeat the data values.
 - Do NOT state the key fact or use claim tags (the UI handles claims natively).
-- Provide ONLY a single line starting with "**Sources:**" that lists the database and indicator name.
+- If the year returned in the data does not match the year requested by the user, you MUST prepend a brief, one-sentence explanation (e.g., "Note: No data is available for 2019; showing the closest available value from 2018.").
+- Provide a single line starting with "**Sources:**" that lists the database and indicator name.
 - Do NOT add analysis paragraphs, interpretation, or commentary.
 - Do NOT add a "Limitations" section unless there is a critical caveat.
 - Do NOT call any visualization tools unless the user explicitly asked for a chart.
 
 Example of a correct quick-mode response:
   "**Sources:** World Development Indicators — Population, total"
+
+Example of a correct quick-mode response with year mismatch:
+  "Note: No data is available for 2019; showing the closest available value from 2018.
+  **Sources:** World Development Indicators — Population, total"
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 """
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -10,7 +10,8 @@ from app.config import settings
 # pool_pre_ping: check connection is alive before use (avoids ConnectionDoesNotExistError after DB restart/idle timeout)
 # pool_recycle: recycle connections after 5 min so they don't outlive server-side idle timeouts
 connect_args = {}
-if settings.ENVIRONMENT not in ("development", "local"):
+is_local_host = settings.POSTGRES_HOST in ("localhost", "127.0.0.1", "db")
+if settings.ENVIRONMENT not in ("development", "local") and not is_local_host:
     connect_args["ssl"] = True
 
 engine = create_async_engine(

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -10,8 +10,7 @@ from app.config import settings
 # pool_pre_ping: check connection is alive before use (avoids ConnectionDoesNotExistError after DB restart/idle timeout)
 # pool_recycle: recycle connections after 5 min so they don't outlive server-side idle timeouts
 connect_args = {}
-is_local_host = settings.POSTGRES_HOST in ("localhost", "127.0.0.1", "db")
-if settings.ENVIRONMENT not in ("development", "local") and not is_local_host:
+if settings.ENVIRONMENT not in ("development", "local"):
     connect_args["ssl"] = True
 
 engine = create_async_engine(

--- a/backend/tests/test_prompts_groups.py
+++ b/backend/tests/test_prompts_groups.py
@@ -1,5 +1,10 @@
-from app.ai.prompts import get_research_agent_system_prompt, get_scout_system_prompt
+from app.ai.prompts import (
+    get_research_agent_system_prompt,
+    get_scout_system_prompt,
+    get_system_prompt,
+)
 from app.ai.utils.geo_utils import REGION_TO_CODES
+from app.config import ModelType
 
 
 def test_asean_includes_tls():
@@ -30,3 +35,22 @@ def test_scout_prompt_injects_asean_codes():
 
     assert f"ASEAN: {asean_str}" in prompt
     assert "TLS" in prompt
+
+
+def test_system_prompt_mismatch_rules():
+    """Verify that get_system_prompt contains the expected year mismatch rules."""
+    # Test full mode prompt
+    full_prompt = get_system_prompt(selected_chat_model=ModelType.CHAT_MODEL, response_mode="full")
+    assert (
+        "If the user requested a specific year but the returned data omits that year" in full_prompt
+    )
+
+    # Test quick mode prompt
+    quick_prompt = get_system_prompt(
+        selected_chat_model=ModelType.CHAT_MODEL, response_mode="quick"
+    )
+    assert (
+        "If the year returned in the data does not match the year requested by the user"
+        in quick_prompt
+    )
+    assert "Example of a correct quick-mode response with year mismatch:" in quick_prompt

--- a/backend/tests/test_quick_answer_card.py
+++ b/backend/tests/test_quick_answer_card.py
@@ -1,0 +1,229 @@
+from app.ai.graph.nodes.quick_answer import _synthesize_card
+
+
+def test_synthesize_card_point_lookup():
+    # GIVEN data360_get_data output with end_year=2023 but no start_year
+    tool_results = [
+        {
+            "tool_name": "data360_get_data",
+            "tool_args": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_CD",
+                "country_code": "QAT",
+                "end_year": 2023,
+            },
+            "output": {
+                "data": [
+                    {
+                        "OBS_VALUE": "81816.97",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2023",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "26dadb75",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                    {
+                        "OBS_VALUE": "88701.46",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2022",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "488bed5f",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                ],
+                "metadata": {
+                    "name": "GDP per capita (current US$)",
+                    "database_id": "WB_WDI",
+                    "database_name": "World Development Indicators (WDI)",
+                },
+            },
+        }
+    ]
+
+    card = _synthesize_card(tool_results)
+    assert card is not None
+    assert card["card_type"] == "single_fact"
+    assert card["value"] == "81816.97"
+    assert card["year"] == "2023"
+    assert card["country_name"] == "Qatar"
+
+
+def test_synthesize_card_trend_lookup():
+    # GIVEN data360_get_data output with start_year=2022 and end_year=2023
+    tool_results = [
+        {
+            "tool_name": "data360_get_data",
+            "tool_args": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_CD",
+                "country_code": "QAT",
+                "start_year": 2022,
+                "end_year": 2023,
+            },
+            "output": {
+                "data": [
+                    {
+                        "OBS_VALUE": "81816.97",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2023",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "26dadb75",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                    {
+                        "OBS_VALUE": "88701.46",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2022",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "488bed5f",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                ],
+                "metadata": {
+                    "name": "GDP per capita (current US$)",
+                    "database_id": "WB_WDI",
+                    "database_name": "World Development Indicators (WDI)",
+                },
+            },
+        }
+    ]
+
+    card = _synthesize_card(tool_results)
+    assert card is not None
+    assert card["card_type"] == "trend"
+    assert card["latest_value"] == "81816.97"
+    assert card["earliest_value"] == "88701.46"
+    assert card["latest_year"] == "2023"
+    assert card["earliest_year"] == "2022"
+
+
+def test_synthesize_card_same_start_end_year():
+    # GIVEN data360_get_data output with start_year=2023 and end_year=2023 (single year point query)
+    tool_results = [
+        {
+            "tool_name": "data360_get_data",
+            "tool_args": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_CD",
+                "country_code": "QAT",
+                "start_year": 2023,
+                "end_year": 2023,
+            },
+            "output": {
+                "data": [
+                    {
+                        "OBS_VALUE": "81816.97",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2023",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "26dadb75",
+                        "REF_AREA_NAME": "Qatar",
+                    }
+                ],
+                "metadata": {
+                    "name": "GDP per capita (current US$)",
+                    "database_id": "WB_WDI",
+                    "database_name": "World Development Indicators (WDI)",
+                },
+            },
+        }
+    ]
+
+    card = _synthesize_card(tool_results)
+    assert card is not None
+    assert card["card_type"] == "single_fact"
+    assert card["value"] == "81816.97"
+    assert card["year"] == "2023"
+
+
+def test_synthesize_card_only_start_year():
+    # GIVEN data360_get_data output with start_year=2020 but no end_year (trend since 2020)
+    tool_results = [
+        {
+            "tool_name": "data360_get_data",
+            "tool_args": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_CD",
+                "country_code": "QAT",
+                "start_year": 2020,
+            },
+            "output": {
+                "data": [
+                    {
+                        "OBS_VALUE": "81816.97",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2023",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "26dadb75",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                    {
+                        "OBS_VALUE": "66841.36",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2020",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "a7ffe257",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                ],
+                "metadata": {
+                    "name": "GDP per capita (current US$)",
+                    "database_id": "WB_WDI",
+                    "database_name": "World Development Indicators (WDI)",
+                },
+            },
+        }
+    ]
+
+    card = _synthesize_card(tool_results)
+    assert card is not None
+    assert card["card_type"] == "trend"
+    assert card["latest_value"] == "81816.97"
+    assert card["earliest_value"] == "66841.36"
+    assert card["latest_year"] == "2023"
+    assert card["earliest_year"] == "2020"
+
+
+def test_synthesize_card_no_years():
+    # GIVEN data360_get_data output with no start_year and no end_year (latest value lookup)
+    tool_results = [
+        {
+            "tool_name": "data360_get_data",
+            "tool_args": {
+                "database_id": "WB_WDI",
+                "indicator_id": "WB_WDI_NY_GDP_PCAP_CD",
+                "country_code": "QAT",
+            },
+            "output": {
+                "data": [
+                    {
+                        "OBS_VALUE": "81816.97",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2023",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "26dadb75",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                    {
+                        "OBS_VALUE": "88701.46",
+                        "REF_AREA": "QAT",
+                        "TIME_PERIOD": "2022",
+                        "UNIT_MEASURE": "USD",
+                        "claim_id": "488bed5f",
+                        "REF_AREA_NAME": "Qatar",
+                    },
+                ],
+                "metadata": {
+                    "name": "GDP per capita (current US$)",
+                    "database_id": "WB_WDI",
+                    "database_name": "World Development Indicators (WDI)",
+                },
+            },
+        }
+    ]
+
+    card = _synthesize_card(tool_results)
+    assert card is not None
+    assert card["card_type"] == "single_fact"
+    assert card["value"] == "81816.97"
+    assert card["year"] == "2023"


### PR DESCRIPTION
## Summary
- Replaced the broad `has_explicit_years` check with `has_explicit_range` in the quick answer card synthesizer. This ensures that point lookups with only `end_year` set (e.g. "in 2023") are not incorrectly promoted to `trend` cards.
- Generalised the standard prompt missing year warning (under `WHEN INFORMATION IS MISSING` in `prompts.py`) to handle omitted years in raw tool outputs rather than looking for a literal `"not available"` placeholder.
- Updated `quick_mode_block` instructions to require a one-sentence note prepended to the sources when a year mismatch is found (explaining the closest available year is shown).
- Added comprehensive unit tests for card synthesis (`test_quick_answer_card.py`) and prompt mismatch rules (`test_prompts_groups.py`).

## Test Plan
- Run unit tests: `POSTGRES_HOST=localhost POSTGRES_PORT=5433 uv run pytest tests/test_quick_answer_card.py tests/test_prompts_groups.py`
- Manual verification: Check that point lookup queries (e.g. `what is the gdp per capita of qatar in 2023` or `What was the poverty headcount ratio for the Philippines in 2019?`) render appropriate `single_fact` cards and, if the year mismatches, include a warning explaining the fallback.